### PR TITLE
Fix traceState in SpanContext cannot be a constant

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/SpanContext.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanContext.swift
@@ -29,7 +29,7 @@ public final class SpanContext: Equatable, CustomStringConvertible {
     public private(set) var traceFlags: TraceFlags
 
     /// The traceState associated with this SpanContext
-    public let traceState: TraceState
+    public var traceState: TraceState
 
     /// The traceState associated with this SpanContext
     public let isRemote: Bool


### PR DESCRIPTION
traceState in SpanContext cannot be constant because we may want to modify it after creation