### PR TITLE
Print Attributes in stdout exporter

### DIFF
--- a/Sources/Exporters/Stdout/StdoutExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutExporter.swift
@@ -32,6 +32,7 @@ public class StdoutExporter: SpanExporter {
             print("ParentSpanId: \(span.parentSpanId?.hexString ?? "no Parent")")
             print("Start: \(span.startEpochNanos)")
             print("Duration: \(span.endEpochNanos - span.startEpochNanos)")
+            print("Attributes: \(span.attributes)")
             print("------------------\n")
         }
         return .success

--- a/Sources/Exporters/Stdout/StdoutExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutExporter.swift
@@ -31,7 +31,7 @@ public class StdoutExporter: SpanExporter {
             print("TraceState: \(span.traceState)")
             print("ParentSpanId: \(span.parentSpanId?.hexString ?? "no Parent")")
             print("Start: \(span.startEpochNanos)")
-            print("Duration: \(span.endEpochNanos - span.startEpochNanos)")
+            print("Duration: \(span.endEpochNanos - span.startEpochNanos) nanoseconds")
             print("Attributes: \(span.attributes)")
             print("------------------\n")
         }


### PR DESCRIPTION
Print Span attributes in stdout exporter, so it can be more useful for debugging.