### PR TITLE
Keep the scope in the span context

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/DefaultSpan.swift
+++ b/Sources/OpenTelemetryApi/Trace/DefaultSpan.swift
@@ -96,9 +96,4 @@ public class DefaultSpan: Span {
     public func addLink(link: Link) {
     }
 
-    public func end() {
-    }
-
-    public func end(endOptions: EndSpanOptions) {
-    }
 }

--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -128,6 +128,16 @@ public enum SpanAttributeConstants: String {
 }
 
 extension Span {
+    public func end() {
+        context.scope?.close()
+    }
+
+    public func end(endOptions: EndSpanOptions) {
+        end()
+    }
+}
+
+extension Span {
     public func setAttribute(key: String, value: String?) {
         return setAttribute(key: key, value: AttributeValue.string(value))
     }

--- a/Sources/OpenTelemetryApi/Trace/SpanContext.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanContext.swift
@@ -40,6 +40,9 @@ public final class SpanContext: Equatable, CustomStringConvertible {
                                             traceFlags: TraceFlags(),
                                             traceState: TraceState(), isRemote: false)
 
+    /// If the Span has its own Scope, if exist should be closed on span end
+    public var scope: Scope?
+
     private init(traceId: TraceId, spanId: SpanId, traceFlags: TraceFlags, traceState: TraceState, isRemote: Bool) {
         self.traceId = traceId
         self.spanId = spanId

--- a/Sources/OpenTelemetryApi/Trace/Tracer.swift
+++ b/Sources/OpenTelemetryApi/Trace/Tracer.swift
@@ -35,5 +35,5 @@ public protocol Tracer: AnyObject {
 
     /// Associates the span with the current context.
     /// - Parameter span: Span to associate with the current context.
-    func withSpan(_ span: Span) -> Scope
+    @discardableResult func withSpan(_ span: Span) -> Scope
 }

--- a/Sources/OpenTelemetryApi/Trace/Unsafe/SpanInScope.swift
+++ b/Sources/OpenTelemetryApi/Trace/Unsafe/SpanInScope.swift
@@ -37,6 +37,7 @@ class SpanInScope: Scope {
         let activityId = os_activity_get_identifier(activity, nil)
         os_activity_scope_enter(activity, &current)
         ContextUtils.setContext(activityId: activityId, forSpan: span)
+        span.context.scope = self
     }
 
     func close() {

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -273,6 +273,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
         endEpochNanos = timestamp
         hasEnded = true
         spanProcessor.onEnd(span: self)
+        context.scope?.close()
     }
 
     public func addChild() {

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/ReadableSpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/ReadableSpanMock.swift
@@ -89,12 +89,6 @@ class ReadableSpanMock: ReadableSpan {
 
     func addEvent<E>(event: E, timestamp: Int) where E: Event {
     }
-
-    func end() {
-    }
-
-    func end(endOptions: EndSpanOptions) {
-    }
-
+    
     var description: String = "ReadableSpanMock"
 }

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
@@ -66,11 +66,5 @@ class SpanMock: Span {
     func addEvent<E>(event: E, timestamp: Int) where E: Event {
     }
 
-    func end() {
-    }
-
-    func end(endOptions: EndSpanOptions) {
-    }
-
     var description: String = "SpanMock"
 }

--- a/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
@@ -187,14 +187,13 @@ class SpanBuilderSdkTest: XCTestCase {
 
     func testNoParent() {
         let parent = tracerSdk.spanBuilder(spanName: spanName).startSpan()
-        var scope = tracerSdk.withSpan(parent)
+        tracerSdk.withSpan(parent)
         let span = tracerSdk.spanBuilder(spanName: spanName).setNoParent().startSpan()
         XCTAssertNotEqual(span.context.traceId, parent.context.traceId)
         let spanNoParent = tracerSdk.spanBuilder(spanName: spanName).setNoParent().setParent(parent).setNoParent().startSpan()
         XCTAssertNotEqual(span.context.traceId, parent.context.traceId)
         spanNoParent.end()
         span.end()
-        scope.close()
         parent.end()
     }
 
@@ -221,12 +220,11 @@ class SpanBuilderSdkTest: XCTestCase {
 
     func testParentCurrentSpan() {
         let parent = tracerSdk.spanBuilder(spanName: spanName).startSpan()
-        var scope = tracerSdk.withSpan(parent)
+        tracerSdk.withSpan(parent)
         let span = tracerSdk.spanBuilder(spanName: spanName).startSpan() as! RecordEventsReadableSpan
         XCTAssertEqual(span.context.traceId, parent.context.traceId)
         XCTAssertEqual(span.parentSpanId, parent.context.spanId)
         span.end()
-        scope.close()
         parent.end()
     }
 
@@ -247,10 +245,9 @@ class SpanBuilderSdkTest: XCTestCase {
 
     func testParentCurrentSpan_timestampConverter() {
         let parent = tracerSdk.spanBuilder(spanName: spanName).startSpan()
-        var scope = tracerSdk.withSpan(parent)
+        tracerSdk.withSpan(parent)
         let span = tracerSdk.spanBuilder(spanName: spanName).startSpan() as! RecordEventsReadableSpan
         XCTAssert(span.clock === (parent as! RecordEventsReadableSpan).clock)
-        scope.close()
         parent.end()
     }
 }

--- a/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
@@ -250,4 +250,18 @@ class SpanBuilderSdkTest: XCTestCase {
         XCTAssert(span.clock === (parent as! RecordEventsReadableSpan).clock)
         parent.end()
     }
+    
+    func testSpanRestorationInContext() {
+        XCTAssertNil(tracerSdk.currentSpan)
+        let parent = tracerSdk.spanBuilder(spanName: spanName).startSpan()
+        tracerSdk.withSpan(parent)
+        XCTAssertEqual(parent.context, tracerSdk.currentSpan?.context)
+        let span = tracerSdk.spanBuilder(spanName: spanName).startSpan() as! RecordEventsReadableSpan
+        tracerSdk.withSpan(span)
+        XCTAssertEqual(span.context, tracerSdk.currentSpan?.context)
+        span.end()
+        XCTAssertEqual(parent.context, tracerSdk.currentSpan?.context)
+        parent.end()
+        XCTAssertNil(tracerSdk.currentSpan)
+    }
 }


### PR DESCRIPTION
Keep the scope where a span was created in the span context, so we can end it when the span ends.

Make the handling as a protocol extension.