### PR TITLE
Check also parent activity to locate current scope.

### DIFF
--- a/Sources/OpenTelemetryApi/CorrelationContext/CorrelationContextManager.swift
+++ b/Sources/OpenTelemetryApi/CorrelationContext/CorrelationContextManager.swift
@@ -32,8 +32,8 @@ public protocol CorrelationContextManager: AnyObject {
     /// Enters the scope of code where the given CorrelationContext is in the current context
     /// (replacing the previous CorrelationContext) and returns an object that represents that
     /// scope. The scope is exited when the returned object is closed.
-    /// - Parameter distContext: the CorrelationContext to be set as the current context.
-    func withContext(distContext: CorrelationContext) -> Scope
+    /// - Parameter correlationContext: the CorrelationContext to be set as the current context.
+    func withContext(correlationContext: CorrelationContext) -> Scope
 
     /// Returns the BinaryFormat for this implementation.
     func getBinaryFormat() -> BinaryFormattable

--- a/Sources/OpenTelemetryApi/CorrelationContext/DefaultCorrelationContextManager.swift
+++ b/Sources/OpenTelemetryApi/CorrelationContext/DefaultCorrelationContextManager.swift
@@ -33,8 +33,8 @@ public class DefaultCorrelationContextManager: CorrelationContextManager {
         ContextUtils.getCurrentCorrelationContext() ?? EmptyCorrelationContext.instance
     }
 
-    public func withContext(distContext: CorrelationContext) -> Scope {
-        return ContextUtils.withCorrelationContext(distContext)
+    public func withContext(correlationContext: CorrelationContext) -> Scope {
+        return ContextUtils.withCorrelationContext(correlationContext)
     }
 
     public func getBinaryFormat() -> BinaryFormattable {

--- a/Sources/OpenTelemetryApi/CorrelationContext/unsafe/CorrelationContextInScope.swift
+++ b/Sources/OpenTelemetryApi/CorrelationContext/unsafe/CorrelationContextInScope.swift
@@ -30,13 +30,13 @@ class CorrelationContextInScope: Scope {
     var current = os_activity_scope_state_s()
 
     /// Constructs a new CorrelationContextInScope.
-    /// - Parameter distContext: the CorrelationContext to be added to the current context.
-    init(distContext: CorrelationContext) {
+    /// - Parameter correlationContext: the CorrelationContext to be added to the current context.
+    init(correlationContext: CorrelationContext) {
         let dso = UnsafeMutableRawPointer(mutating: #dsohandle)
-        let activity = _os_activity_create(dso, "InitSpan", OS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT)
+        let activity = _os_activity_create(dso, "InitCorrelationContext", OS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT)
         let activityId = os_activity_get_identifier(activity, nil)
         os_activity_scope_enter(activity, &current)
-        ContextUtils.setContext(activityId: activityId, forCorrelationContext: distContext)
+        ContextUtils.setContext(activityId: activityId, forCorrelationContext: correlationContext)
     }
 
     func close() {

--- a/Sources/OpenTelemetryApi/Trace/Unsafe/SpanInScope.swift
+++ b/Sources/OpenTelemetryApi/Trace/Unsafe/SpanInScope.swift
@@ -25,23 +25,25 @@ private let OS_ACTIVITY_CURRENT = unsafeBitCast(dlsym(UnsafeMutableRawPointer(bi
                                                                       _ parent: Unmanaged<AnyObject>?,
                                                                       _ flags: os_activity_flag_t) -> AnyObject!
 
-///  A scope that manages the for a Span
+///  A class that manages the scope for a Span
 class SpanInScope: Scope {
-    var current = os_activity_scope_state_s()
+    var currentActivityState = os_activity_scope_state_s()
+    var currentActivityId: os_activity_id_t
 
     /// Constructs a new SpanInScope.
     /// - Parameter span: the Span to be added to the current context
     init(span: Span) {
         let dso = UnsafeMutableRawPointer(mutating: #dsohandle)
         let activity = _os_activity_create(dso, "InitSpan", OS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT)
-        let activityId = os_activity_get_identifier(activity, nil)
-        os_activity_scope_enter(activity, &current)
-        ContextUtils.setContext(activityId: activityId, forSpan: span)
+        currentActivityId = os_activity_get_identifier(activity, nil)
+        os_activity_scope_enter(activity, &currentActivityState)
+        ContextUtils.setContext(activityId: currentActivityId, forSpan: span)
         span.context.scope = self
     }
 
     func close() {
-        os_activity_scope_leave(&current)
+        os_activity_scope_leave(&currentActivityState)
+        ContextUtils.removeContextForSpan(activityId: currentActivityId)
     }
 
     deinit {

--- a/Sources/OpenTelemetrySdk/CorrelationContext/CorrelationContextManagerSdk.swift
+++ b/Sources/OpenTelemetrySdk/CorrelationContext/CorrelationContextManagerSdk.swift
@@ -26,8 +26,8 @@ public class CorrelationContextManagerSdk: CorrelationContextManager {
         return ContextUtils.getCurrentCorrelationContext() ?? EmptyCorrelationContext.instance
     }
 
-    public func withContext(distContext: CorrelationContext) -> Scope {
-        return ContextUtils.withCorrelationContext(distContext)
+    public func withContext(correlationContext: CorrelationContext) -> Scope {
+        return ContextUtils.withCorrelationContext(correlationContext)
     }
 
     public func getBinaryFormat() -> BinaryFormattable {

--- a/Tests/OpenTelemetryApiTests/CorrelationContext/DefaultCorrelationContextManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/CorrelationContext/DefaultCorrelationContextManagerTests.swift
@@ -35,7 +35,7 @@ class TestCorrelationContext: CorrelationContext {
 
 class DefaultCorrelationContextManagerTests: XCTestCase {
     let defaultCorrelationContextManager = DefaultCorrelationContextManager.instance
-    let distContext = TestCorrelationContext()
+    let correlationContext = TestCorrelationContext()
 
     func testBuilderMethod() {
         let builder = defaultCorrelationContextManager.contextBuilder()
@@ -47,27 +47,27 @@ class DefaultCorrelationContextManagerTests: XCTestCase {
     }
 
     func testGetCurrentContext_ContextSetToNil() {
-        let distContext = defaultCorrelationContextManager.getCurrentContext()
-        XCTAssertNotNil(distContext)
-        XCTAssertEqual(distContext.getEntries().count, 0)
+        let correlationContext = defaultCorrelationContextManager.getCurrentContext()
+        XCTAssertNotNil(correlationContext)
+        XCTAssertEqual(correlationContext.getEntries().count, 0)
     }
 
     func testWithContext() {
         XCTAssertTrue(defaultCorrelationContextManager.getCurrentContext() === EmptyCorrelationContext.instance)
-        var wtm = defaultCorrelationContextManager.withContext(distContext: distContext)
-        XCTAssertTrue(defaultCorrelationContextManager.getCurrentContext() === distContext)
+        var wtm = defaultCorrelationContextManager.withContext(correlationContext: correlationContext)
+        XCTAssertTrue(defaultCorrelationContextManager.getCurrentContext() === correlationContext)
         wtm.close()
         XCTAssertTrue(defaultCorrelationContextManager.getCurrentContext() === EmptyCorrelationContext.instance)
     }
 
     func testWithContextUsingWrap() {
         let expec = expectation(description: "testWithContextUsingWrap")
-        var wtm = defaultCorrelationContextManager.withContext(distContext: distContext)
-        XCTAssertTrue(defaultCorrelationContextManager.getCurrentContext() === distContext)
+        var wtm = defaultCorrelationContextManager.withContext(correlationContext: correlationContext)
+        XCTAssertTrue(defaultCorrelationContextManager.getCurrentContext() === correlationContext)
         let semaphore = DispatchSemaphore(value: 0)
         DispatchQueue.global().async {
             semaphore.wait()
-            XCTAssertTrue(self.defaultCorrelationContextManager.getCurrentContext() === self.distContext)
+            XCTAssertTrue(self.defaultCorrelationContextManager.getCurrentContext() === self.correlationContext)
             expec.fulfill()
         }
         wtm.close()

--- a/Tests/OpenTelemetrySdkTests/DistributedContext/DistributedContextManagerSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/DistributedContext/DistributedContextManagerSdkTests.swift
@@ -18,7 +18,7 @@ import OpenTelemetryApi
 import XCTest
 
 class CorrelationContextManagerSdkTests: XCTestCase {
-    let distContext = CorrelationContextMock()
+    let correlationContext = CorrelationContextMock()
     let contextManager = CorrelationContextManagerSdk()
 
     func testGetCurrentContext_DefaultContext() {
@@ -27,20 +27,20 @@ class CorrelationContextManagerSdkTests: XCTestCase {
 
     func testWithCorrelationContext() {
         XCTAssertTrue(contextManager.getCurrentContext() === EmptyCorrelationContext.instance)
-        var wtm = contextManager.withContext(distContext: distContext)
-        XCTAssertTrue(contextManager.getCurrentContext() === distContext)
+        var wtm = contextManager.withContext(correlationContext: correlationContext)
+        XCTAssertTrue(contextManager.getCurrentContext() === correlationContext)
         wtm.close()
         XCTAssertTrue(contextManager.getCurrentContext() === EmptyCorrelationContext.instance)
     }
 
     func testWithCorrelationContextUsingWrap() {
         let expec = expectation(description: "testWithCorrelationContextUsingWrap")
-        var wtm = contextManager.withContext(distContext: distContext)
-        XCTAssertTrue(contextManager.getCurrentContext() === distContext)
+        var wtm = contextManager.withContext(correlationContext: correlationContext)
+        XCTAssertTrue(contextManager.getCurrentContext() === correlationContext)
         let semaphore = DispatchSemaphore(value: 0)
         DispatchQueue.global().async {
             semaphore.wait()
-            XCTAssertTrue(self.contextManager.getCurrentContext() === self.distContext)
+            XCTAssertTrue(self.contextManager.getCurrentContext() === self.correlationContext)
             expec.fulfill()
         }
         wtm.close()

--- a/Tests/OpenTelemetrySdkTests/DistributedContext/DistributedContextSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/DistributedContext/DistributedContextSdkTests.swift
@@ -37,36 +37,36 @@ class CorrelationContextSdkTests: XCTestCase {
     }
 
     func testGetEntries_empty() {
-        let distContext = CorrelationContextSdk.contextBuilder().build()
-        XCTAssertEqual(distContext.getEntries().count, 0)
+        let correlationContext = CorrelationContextSdk.contextBuilder().build()
+        XCTAssertEqual(correlationContext.getEntries().count, 0)
     }
 
     func testGetEntries_nonEmpty() {
-        let distContext = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1, t2])
-        XCTAssertEqual(distContext.getEntries().sorted(), [t1, t2].sorted())
+        let correlationContext = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1, t2])
+        XCTAssertEqual(correlationContext.getEntries().sorted(), [t1, t2].sorted())
     }
 
     func testGetEntries_chain() {
         let t1alt = Entry(key: k1, value: v2, entryMetadata: tmd)
         let parent = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1, t2])
-        let distContext = CorrelationContextSdk.contextBuilder().setParent(parent).put(key: t1alt.key, value: t1alt.value, metadata: t1alt.metadata).build()
-        XCTAssertEqual(distContext.getEntries().sorted(), [t1alt, t2].sorted())
+        let correlationContext = CorrelationContextSdk.contextBuilder().setParent(parent).put(key: t1alt.key, value: t1alt.value, metadata: t1alt.metadata).build()
+        XCTAssertEqual(correlationContext.getEntries().sorted(), [t1alt, t2].sorted())
     }
 
     func testPut_newKey() {
-        let distContext = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1])
-        XCTAssertEqual(contextManager.contextBuilder().setParent(distContext).put(key: k2, value: v2, metadata: tmd).build().getEntries().sorted(), [t1, t2].sorted())
+        let correlationContext = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1])
+        XCTAssertEqual(contextManager.contextBuilder().setParent(correlationContext).put(key: k2, value: v2, metadata: tmd).build().getEntries().sorted(), [t1, t2].sorted())
     }
 
     func testPut_existingKey() {
-        let distContext = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1])
-        XCTAssertEqual(contextManager.contextBuilder().setParent(distContext).put(key: k1, value: v2, metadata: tmd).build().getEntries(), [Entry(key: k1, value: v2, entryMetadata: tmd)])
+        let correlationContext = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1])
+        XCTAssertEqual(contextManager.contextBuilder().setParent(correlationContext).put(key: k1, value: v2, metadata: tmd).build().getEntries(), [Entry(key: k1, value: v2, entryMetadata: tmd)])
     }
 
     func testPetParent_setNoParent() {
         let parent = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1])
-        let distContext = contextManager.contextBuilder().setParent(parent).setNoParent().build()
-        XCTAssertEqual(distContext.getEntries().count, 0)
+        let correlationContext = contextManager.contextBuilder().setParent(parent).setNoParent().build()
+        XCTAssertEqual(correlationContext.getEntries().count, 0)
     }
 
     func testRemove_existingKey() {
@@ -84,8 +84,8 @@ class CorrelationContextSdkTests: XCTestCase {
     }
 
     func testRemove_keyFromParent() {
-        let distContext = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1, t2])
-        XCTAssertEqual(contextManager.contextBuilder().setParent(distContext).remove(key: k1).build().getEntries(), [t2])
+        let correlationContext = CorrelationContextTestUtil.listToCorrelationContext(entries: [t1, t2])
+        XCTAssertEqual(contextManager.contextBuilder().setParent(correlationContext).remove(key: k1).build().getEntries(), [t2])
     }
 
     func testEquals() {

--- a/Tests/OpenTelemetrySdkTests/DistributedContext/ScopedDistributedContextTests.swift
+++ b/Tests/OpenTelemetrySdkTests/DistributedContext/ScopedDistributedContextTests.swift
@@ -50,7 +50,7 @@ class ScopedCorrelationContextTests: XCTestCase {
         XCTAssertEqual(contextManager.getCurrentContext().getEntries().count, 0)
         let scopedEntries = contextManager.contextBuilder().put(key: key1, value: value1, metadata: metadataUnlimitedPropagation).build()
         do {
-            let scope = contextManager.withContext(distContext: scopedEntries)
+            let scope = contextManager.withContext(correlationContext: scopedEntries)
             XCTAssertTrue(contextManager.getCurrentContext() === scopedEntries)
             print(scope) // Silence unused warning
         }
@@ -60,7 +60,7 @@ class ScopedCorrelationContextTests: XCTestCase {
     func testCreateBuilderFromCurrentEntries() {
         let scopedDistContext = contextManager.contextBuilder().put(key: key1, value: value1, metadata: metadataUnlimitedPropagation).build()
         do {
-            let scope = contextManager.withContext(distContext: scopedDistContext)
+            let scope = contextManager.withContext(correlationContext: scopedDistContext)
             let newEntries = contextManager.contextBuilder().put(key: key2, value: value2, metadata: metadataUnlimitedPropagation).build()
             XCTAssertEqual(newEntries.getEntries().count, 2)
             XCTAssertEqual(newEntries.getEntries().sorted(), [Entry(key: key1, value: value1, entryMetadata: metadataUnlimitedPropagation), Entry(key: key2, value: value2, entryMetadata: metadataUnlimitedPropagation)].sorted())
@@ -73,7 +73,7 @@ class ScopedCorrelationContextTests: XCTestCase {
         XCTAssertEqual(contextManager.getCurrentContext().getEntries().count, 0)
         let scopedDistContext = contextManager.contextBuilder().put(key: key1, value: value1, metadata: metadataUnlimitedPropagation).build()
         do {
-            let scope = contextManager.withContext(distContext: scopedDistContext)
+            let scope = contextManager.withContext(correlationContext: scopedDistContext)
             XCTAssertEqual(contextManager.getCurrentContext().getEntries().count, 1)
             XCTAssertEqual(contextManager.getCurrentContext().getEntries().first, Entry(key: key1, value: value1, entryMetadata: metadataUnlimitedPropagation))
             print(scope) // Silence unused warning
@@ -84,10 +84,10 @@ class ScopedCorrelationContextTests: XCTestCase {
     func testAddToCurrentEntriesWithBuilder() {
         let scopedDistContext = contextManager.contextBuilder().put(key: key1, value: value1, metadata: metadataUnlimitedPropagation).build()
         do {
-            let scope1 = contextManager.withContext(distContext: scopedDistContext)
+            let scope1 = contextManager.withContext(correlationContext: scopedDistContext)
             let innerDistContext = contextManager.contextBuilder().put(key: key2, value: value2, metadata: metadataUnlimitedPropagation).build()
             do {
-                let scope2 = contextManager.withContext(distContext: innerDistContext)
+                let scope2 = contextManager.withContext(correlationContext: innerDistContext)
                 XCTAssertEqual(contextManager.getCurrentContext().getEntries().sorted(),
                                [Entry(key: key1, value: value1, entryMetadata: metadataUnlimitedPropagation),
                                 Entry(key: key2, value: value2, entryMetadata: metadataUnlimitedPropagation)].sorted())
@@ -106,13 +106,13 @@ class ScopedCorrelationContextTests: XCTestCase {
             .build()
 
         do {
-            let scope1 = contextManager.withContext(distContext: scopedDistContext)
+            let scope1 = contextManager.withContext(correlationContext: scopedDistContext)
 
             let innerDistContext = contextManager.contextBuilder().put(key: key3, value: value3, metadata: metadataUnlimitedPropagation)
                 .put(key: key2, value: value4, metadata: metadataUnlimitedPropagation)
                 .build()
             do {
-                let scope2 = contextManager.withContext(distContext: innerDistContext)
+                let scope2 = contextManager.withContext(correlationContext: innerDistContext)
                 XCTAssertEqual(contextManager.getCurrentContext().getEntries().sorted(),
                                [Entry(key: key1, value: value1, entryMetadata: metadataUnlimitedPropagation),
                                 Entry(key: key2, value: value4, entryMetadata: metadataUnlimitedPropagation),
@@ -129,7 +129,7 @@ class ScopedCorrelationContextTests: XCTestCase {
         XCTAssertEqual(contextManager.getCurrentContext().getEntries().count, 0)
         let scopedDistContext = contextManager.contextBuilder().put(key: key1, value: value1, metadata: metadataUnlimitedPropagation).build()
         do {
-            let scope = contextManager.withContext(distContext: scopedDistContext)
+            let scope = contextManager.withContext(correlationContext: scopedDistContext)
             let innerDistContext = contextManager.contextBuilder().setNoParent().put(key: key2, value: value2, metadata: metadataUnlimitedPropagation).build()
             XCTAssertEqual(innerDistContext.getEntries(), [Entry(key: key2, value: value2, entryMetadata: metadataUnlimitedPropagation)])
             print(scope) // Silence unused warning


### PR DESCRIPTION
It would be much better if we could traverse all the activities hierarchy but couldn't find a proper way
Clean the context when the scope ends, or it will leak memory
Some renaming of CorrelationContext variables still named with old distContext name