### PR TITLE
Fix Scope Testing action for external PR

### DIFF
--- a/.github/workflows/ScopeTesting.yml
+++ b/.github/workflows/ScopeTesting.yml
@@ -12,6 +12,6 @@ jobs:
     - name: Testing for macOS
       uses: undefinedlabs/scope-for-swift-action@v1
       with:
-        dsn: ${{ secrets.SCOPE_DSN }}
+        dsn: https://d6756ad6b68e4df7a3cd93693139ad35@app.scope.dev
         platform: macos
         codePath: true


### PR DESCRIPTION
GitHub Actions doesn't support accessing the repository secrets when running in an external pull request so it fails.
Its better having this value public than avoiding external PR to run the action and tests