### PR TITLE
First iteration of Metrics implementation

### DIFF
--- a/Examples/Logging Tracer/LoggingTracerProvider.swift
+++ b/Examples/Logging Tracer/LoggingTracerProvider.swift
@@ -17,7 +17,7 @@ import Foundation
 import OpenTelemetryApi
 
 class LoggingTracerProvider: TracerProvider {
-    override func get(instrumentationName: String, instrumentationVersion: String?) -> Tracer {
+    func get(instrumentationName: String, instrumentationVersion: String?) -> Tracer {
         Logger.log("TracerFactory.get(\(instrumentationName), \(instrumentationVersion ?? ""))")
         var labels = [String: String]()
         labels["instrumentationName"] = instrumentationName

--- a/Examples/Simple Exporter/main.swift
+++ b/Examples/Simple Exporter/main.swift
@@ -26,7 +26,7 @@ let instrumentationLibraryVersion = "semver:0.1.0"
 var instrumentationLibraryInfo = InstrumentationLibraryInfo(name: instrumentationLibraryName, version: instrumentationLibraryVersion)
 
 var tracer: TracerSdk
-tracer = OpenTelemetrySDK.instance.tracerFactory.get(instrumentationName: instrumentationLibraryName, instrumentationVersion: instrumentationLibraryVersion) as! TracerSdk
+tracer = OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: instrumentationLibraryName, instrumentationVersion: instrumentationLibraryVersion) as! TracerSdk
 
 func simpleSpan() {
     let span = tracer.spanBuilder(spanName: "SimpleSpan").setSpanKind(spanKind: .client).startSpan()
@@ -58,7 +58,7 @@ let stdoutExporter = StdoutExporter()
 let spanExporter = MultiSpanExporter(spanExporters: [jaegerExporter, stdoutExporter])
 
 let spanProcessor = SimpleSpanProcessor(spanExporter: spanExporter)
-OpenTelemetrySDK.instance.tracerFactory.addSpanProcessor(spanProcessor)
+OpenTelemetrySDK.instance.tracerProvider.addSpanProcessor(spanProcessor)
 
 simpleSpan()
 sleep(1)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -22,7 +22,7 @@ let package = Package(
         .executable(name: "loggingTracer", targets: ["LoggingTracer"]),
     ],
     dependencies: [
-        .package(url:  "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1") // Need custom fork because of SPM
+        .package(name:"Thrift", url:  "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1") // Need custom fork because of SPM
     ],
     targets: [
         .target(  name: "OpenTelemetryApi", dependencies: []),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -22,7 +22,7 @@ let package = Package(
         .executable(name: "loggingTracer", targets: ["LoggingTracer"]),
     ],
     dependencies: [
-        .package(name:"Thrift", url:  "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1") // Need custom fork because of SPM
+        .package(url:  "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1") // Need custom fork because of SPM
     ],
     targets: [
         .target(  name: "OpenTelemetryApi", dependencies: []),

--- a/Sources/OpenTelemetryApi/Internal/ContextUtils.swift
+++ b/Sources/OpenTelemetryApi/Internal/ContextUtils.swift
@@ -16,7 +16,7 @@
 import Foundation
 import os.activity
 
-/// Helper class to get the current Span and current distributedContext
+/// Helper class to get the current Span and current CorrelationContext
 /// Users must interact with the current Context via the public APIs in Tracer and avoid
 /// accessing this class directly.
 public struct ContextUtils {

--- a/Sources/OpenTelemetryApi/Internal/StringUtils.swift
+++ b/Sources/OpenTelemetryApi/Internal/StringUtils.swift
@@ -31,4 +31,13 @@ public struct StringUtils {
     private static func isPrintableChar(_ char: Unicode.Scalar) -> Bool {
         return char >= UnicodeScalar(" ") && char <= UnicodeScalar("~")
     }
+    
+    /// Determines whether the metric name contains a valid metric name.
+    /// - Parameter string: the String to be validated.
+    public static func isValidMetricName(_ metricName: String) -> Bool {
+        if metricName.range(of: "[aA-zZ][aA-zZ0-9_\\-.]*", options: .regularExpression, range: nil, locale: nil) != nil {
+            return true
+        }
+        return false
+    }
 }

--- a/Sources/OpenTelemetryApi/Metrics/BoundCounterMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/BoundCounterMetric.swift
@@ -1,0 +1,25 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+open class BoundCounterMetric<T> {
+    public init() {}
+    
+    open func add(inContext: SpanContext, value: T) {
+        fatalError()
+    }
+//    func  add(inContext: DistributedContext, value: T)
+}

--- a/Sources/OpenTelemetryApi/Metrics/BoundCounterMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/BoundCounterMetric.swift
@@ -15,9 +15,13 @@
 
 import Foundation
 
+/// Bound counter metric
 open class BoundCounterMetric<T> {
     public init() {}
 
+    /// Adds the given value to the bound counter metric.
+    /// - Parameters:
+    ///   - value: value by which the bound counter metric should be added
     open func add(value: T) {
         fatalError()
     }

--- a/Sources/OpenTelemetryApi/Metrics/BoundMeasureMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/BoundMeasureMetric.swift
@@ -15,10 +15,13 @@
 
 import Foundation
 
+/// Bound measure metric
 open class BoundMeasureMetric<T> {
-    public init() {
-    }
+    public init() {}
 
+    /// Record the given value to the bound measure metric.
+    /// - Parameters:
+    ///   - value: the measurement to be recorded.
     open func record(value: T) {
     }
 }

--- a/Sources/OpenTelemetryApi/Metrics/BoundMeasureMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/BoundMeasureMetric.swift
@@ -16,11 +16,9 @@
 import Foundation
 
 open class BoundMeasureMetric<T> {
-    
     public init() {
     }
-    
-    open func record(inContext: SpanContext, value: T) {
+
+    open func record(value: T) {
     }
-//    func  record(inContext: DistributedContext, value: T)
 }

--- a/Sources/OpenTelemetryApi/Metrics/BoundMeasureMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/BoundMeasureMetric.swift
@@ -1,0 +1,26 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+open class BoundMeasureMetric<T> {
+    
+    public init() {
+    }
+    
+    open func record(inContext: SpanContext, value: T) {
+    }
+//    func  record(inContext: DistributedContext, value: T)
+}

--- a/Sources/OpenTelemetryApi/Metrics/CounterMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/CounterMetric.swift
@@ -1,0 +1,75 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol CounterMetric {
+    associatedtype T
+
+    func add(inContext: SpanContext, value: T, labelset: LabelSet)
+    func add(inContext: SpanContext, value: T, labels: [String: String])
+//    func add(inContext: DistributedContext,  value: T,  labelset: LabelSet)
+//    func add(inContext: DistributedContext,  value: T, labels: [String: String])
+    func bind(labelset: LabelSet) -> BoundCounterMetric<T>
+    func bind(labels: [String: String]) -> BoundCounterMetric<T>
+}
+
+public struct AnyCounterMetric<T>: CounterMetric {
+    let internalCounter: Any
+    private let _addLabelSet: (SpanContext, T, LabelSet) -> Void
+    private let _addLabels: (SpanContext, T, [String: String]) -> Void
+    private let _bindLabelSet: (LabelSet) -> BoundCounterMetric<T>
+    private let _bindLabels: ([String: String]) -> BoundCounterMetric<T>
+
+    public init<U: CounterMetric>(_ countable: U) where U.T == T {
+        internalCounter = countable
+        _addLabelSet = countable.add(inContext:value:labelset:)
+        _addLabels = countable.add(inContext:value:labels:)
+        _bindLabelSet = countable.bind(labelset:)
+        _bindLabels = countable.bind(labels:)
+    }
+
+    public func add(inContext: SpanContext, value: T, labelset: LabelSet) {
+        _addLabelSet(inContext, value, labelset)
+    }
+
+    public func add(inContext: SpanContext, value: T, labels: [String: String]) {
+        _addLabels(inContext, value, labels)
+    }
+
+    public func bind(labelset: LabelSet) -> BoundCounterMetric<T> {
+        _bindLabelSet(labelset)
+    }
+
+    public func bind(labels: [String: String]) -> BoundCounterMetric<T> {
+        _bindLabels(labels)
+    }
+}
+
+struct NoopCounterMetric<T>: CounterMetric {
+    func add(inContext: SpanContext, value: T, labelset: LabelSet) {
+    }
+
+    func add(inContext: SpanContext, value: T, labels: [String: String]) {
+    }
+
+    func bind(labelset: LabelSet) -> BoundCounterMetric<T> {
+        return BoundCounterMetric<T>()
+    }
+
+    func bind(labels: [String: String]) -> BoundCounterMetric<T> {
+        return BoundCounterMetric<T>()
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/CounterMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/CounterMetric.swift
@@ -18,35 +18,33 @@ import Foundation
 public protocol CounterMetric {
     associatedtype T
 
-    func add(inContext: SpanContext, value: T, labelset: LabelSet)
-    func add(inContext: SpanContext, value: T, labels: [String: String])
-//    func add(inContext: DistributedContext,  value: T,  labelset: LabelSet)
-//    func add(inContext: DistributedContext,  value: T, labels: [String: String])
+    func add(value: T, labelset: LabelSet)
+    func add(value: T, labels: [String: String])
     func bind(labelset: LabelSet) -> BoundCounterMetric<T>
     func bind(labels: [String: String]) -> BoundCounterMetric<T>
 }
 
 public struct AnyCounterMetric<T>: CounterMetric {
     let internalCounter: Any
-    private let _addLabelSet: (SpanContext, T, LabelSet) -> Void
-    private let _addLabels: (SpanContext, T, [String: String]) -> Void
+    private let _addLabelSet: (T, LabelSet) -> Void
+    private let _addLabels: (T, [String: String]) -> Void
     private let _bindLabelSet: (LabelSet) -> BoundCounterMetric<T>
     private let _bindLabels: ([String: String]) -> BoundCounterMetric<T>
 
     public init<U: CounterMetric>(_ countable: U) where U.T == T {
         internalCounter = countable
-        _addLabelSet = countable.add(inContext:value:labelset:)
-        _addLabels = countable.add(inContext:value:labels:)
+        _addLabelSet = countable.add(value:labelset:)
+        _addLabels = countable.add(value:labels:)
         _bindLabelSet = countable.bind(labelset:)
         _bindLabels = countable.bind(labels:)
     }
 
-    public func add(inContext: SpanContext, value: T, labelset: LabelSet) {
-        _addLabelSet(inContext, value, labelset)
+    public func add(value: T, labelset: LabelSet) {
+        _addLabelSet(value, labelset)
     }
 
-    public func add(inContext: SpanContext, value: T, labels: [String: String]) {
-        _addLabels(inContext, value, labels)
+    public func add(value: T, labels: [String: String]) {
+        _addLabels(value, labels)
     }
 
     public func bind(labelset: LabelSet) -> BoundCounterMetric<T> {
@@ -59,10 +57,10 @@ public struct AnyCounterMetric<T>: CounterMetric {
 }
 
 struct NoopCounterMetric<T>: CounterMetric {
-    func add(inContext: SpanContext, value: T, labelset: LabelSet) {
+    func add(value: T, labelset: LabelSet) {
     }
 
-    func add(inContext: SpanContext, value: T, labels: [String: String]) {
+    func add(value: T, labels: [String: String]) {
     }
 
     func bind(labelset: LabelSet) -> BoundCounterMetric<T> {

--- a/Sources/OpenTelemetryApi/Metrics/CounterMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/CounterMetric.swift
@@ -15,12 +15,32 @@
 
 import Foundation
 
+/// Counter instrument.
 public protocol CounterMetric {
     associatedtype T
 
+    /// Adds or Increments the counter.
+    /// - Parameters:
+    ///   - value: value by which the counter should be incremented.
+    ///   - labelset: The labelset associated with this value.
     func add(value: T, labelset: LabelSet)
+
+    /// Adds or Increments the counter.
+    /// - Parameters:
+    ///   - value: value by which the counter should be incremented.
+    ///   - labels: The labels or dimensions associated with this value.
     func add(value: T, labels: [String: String])
+
+    /// Gets the bound counter metric with given labelset.
+    /// - Parameters:
+    ///   - labelset: The labelset associated with this value.
+    /// - Returns: The bound counter metric.
     func bind(labelset: LabelSet) -> BoundCounterMetric<T>
+
+    /// Gets the bound counter metric with given labels.
+    /// - Parameters:
+    ///   - labels: The labels or dimensions associated with this value.
+    /// - Returns: The bound counter metric.
     func bind(labels: [String: String]) -> BoundCounterMetric<T>
 }
 

--- a/Sources/OpenTelemetryApi/Metrics/DefaultMeterProvider.swift
+++ b/Sources/OpenTelemetryApi/Metrics/DefaultMeterProvider.swift
@@ -15,29 +15,30 @@
 
 import Foundation
 
-open class MeterFactoryBase {
-    static var defaultFactory = MeterFactoryBase()
+class DefaultMeterProvider: MeterProvider {
+    static var instance: MeterProvider = DefaultMeterProvider()
+
     static var proxyMeter = ProxyMeter()
     static var initialized = false
 
     public init() {}
 
-    static func setDefault(meterFactory: MeterFactoryBase) {
+    static func setDefault(meterFactory: MeterProvider) {
         guard !initialized else {
             return
         }
-        defaultFactory = meterFactory
-        proxyMeter.updateMeter(realMeter: meterFactory.getMeter(name: ""))
+        instance = meterFactory
+        proxyMeter.updateMeter(realMeter: meterFactory.get(instrumentationName: "", instrumentationVersion: nil))
         initialized = true
     }
 
-    open func getMeter(name: String, version: String? = nil) -> Meter {
-        return MeterFactoryBase.initialized ? MeterFactoryBase.defaultFactory.getMeter(name: name, version: version) : MeterFactoryBase.proxyMeter
+    func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Meter {
+        return DefaultMeterProvider.initialized ? DefaultMeterProvider.instance.get(instrumentationName: instrumentationName, instrumentationVersion: instrumentationVersion) : DefaultMeterProvider.proxyMeter
     }
 
-    internal func reset() {
-        MeterFactoryBase.defaultFactory = MeterFactoryBase()
-        MeterFactoryBase.proxyMeter = ProxyMeter()
-        MeterFactoryBase.initialized = false
+    internal static func reset() {
+        DefaultMeterProvider.instance = DefaultMeterProvider()
+        DefaultMeterProvider.proxyMeter = ProxyMeter()
+        DefaultMeterProvider.initialized = false
     }
 }

--- a/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetric.swift
@@ -1,0 +1,29 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol DoubleObserverMetric {
+    mutating func observe(value: Double, labelset: LabelSet)
+    mutating func observe(value: Double, labels: [String: String])
+}
+
+struct NoopDoubleObserverMetric: DoubleObserverMetric {
+    func observe(value: Double, labelset: LabelSet) {
+    }
+    
+    func observe(value: Double, labels: [String : String]) {
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetric.swift
@@ -15,8 +15,19 @@
 
 import Foundation
 
+/// Observer instrument for Double values.
 public protocol DoubleObserverMetric: AnyObject {
+    /// Observes a value.
+    /// - Parameters:
+    ///   - value: value to observe.
+    ///   - labelset: The labelset associated with this value.
     func observe(value: Double, labelset: LabelSet)
+
+    /// Observes a value.
+    /// - Parameters:
+    ///   - value: value to observe.
+    ///   - labels: The labels or dimensions associated with this value.
+    /// - Returns: The bound counter metric.
     func observe(value: Double, labels: [String: String])
 }
 

--- a/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetric.swift
@@ -15,15 +15,15 @@
 
 import Foundation
 
-public protocol DoubleObserverMetric {
-    mutating func observe(value: Double, labelset: LabelSet)
-    mutating func observe(value: Double, labels: [String: String])
+public protocol DoubleObserverMetric: AnyObject {
+    func observe(value: Double, labelset: LabelSet)
+    func observe(value: Double, labels: [String: String])
 }
 
-struct NoopDoubleObserverMetric: DoubleObserverMetric {
+class NoopDoubleObserverMetric: DoubleObserverMetric {
     func observe(value: Double, labelset: LabelSet) {
     }
-    
-    func observe(value: Double, labels: [String : String]) {
+
+    func observe(value: Double, labels: [String: String]) {
     }
 }

--- a/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetricHandle.swift
+++ b/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetricHandle.swift
@@ -15,6 +15,10 @@
 
 import Foundation
 
+/// Handle to the metrics observer
 public protocol DoubleObserverMetricHandle {
+    /// Observes the given value.
+    /// - Parameters:
+    ///   - value: value by which the observer handle should be Recorded.
     func observe(value: Double)
 }

--- a/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetricHandle.swift
+++ b/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetricHandle.swift
@@ -1,0 +1,20 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol DoubleObserverMetricHandle {
+    func observe(value: Double)
+}

--- a/Sources/OpenTelemetryApi/Metrics/IntObserverMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/IntObserverMetric.swift
@@ -15,12 +15,12 @@
 
 import Foundation
 
-public protocol IntObserverMetric {
-    mutating func observe(value: Int, labelset: LabelSet)
-    mutating func observe(value: Int, labels: [String: String])
+public protocol IntObserverMetric: AnyObject {
+    func observe(value: Int, labelset: LabelSet)
+    func observe(value: Int, labels: [String: String])
 }
 
-struct NoopIntObserverMetric: IntObserverMetric {
+class NoopIntObserverMetric: IntObserverMetric {
     func observe(value: Int, labelset: LabelSet) {
     }
 

--- a/Sources/OpenTelemetryApi/Metrics/IntObserverMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/IntObserverMetric.swift
@@ -1,0 +1,29 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol IntObserverMetric {
+    mutating func observe(value: Int, labelset: LabelSet)
+    mutating func observe(value: Int, labels: [String: String])
+}
+
+struct NoopIntObserverMetric: IntObserverMetric {
+    func observe(value: Int, labelset: LabelSet) {
+    }
+
+    func observe(value: Int, labels: [String: String]) {
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/IntObserverMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/IntObserverMetric.swift
@@ -15,8 +15,19 @@
 
 import Foundation
 
+/// Observer instrument for Int values.
 public protocol IntObserverMetric: AnyObject {
+    /// Observes a value.
+    /// - Parameters:
+    ///   - value: value to observe.
+    ///   - labelset: The labelset associated with this value.
     func observe(value: Int, labelset: LabelSet)
+
+    /// Observes a value.
+    /// - Parameters:
+    ///   - value: value to observe.
+    ///   - labels: The labels or dimensions associated with this value.
+    /// - Returns: The bound counter metric.
     func observe(value: Int, labels: [String: String])
 }
 

--- a/Sources/OpenTelemetryApi/Metrics/IntObserverMetricHandle.swift
+++ b/Sources/OpenTelemetryApi/Metrics/IntObserverMetricHandle.swift
@@ -1,0 +1,20 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol IntObserverMetricHandle {
+    func observe(value: Int)
+}

--- a/Sources/OpenTelemetryApi/Metrics/IntObserverMetricHandle.swift
+++ b/Sources/OpenTelemetryApi/Metrics/IntObserverMetricHandle.swift
@@ -15,6 +15,10 @@
 
 import Foundation
 
+/// Handle to the metrics observer
 public protocol IntObserverMetricHandle {
+    /// Observes the given value.
+    /// - Parameters:
+    ///   - value: value by which the observer handle should be Recorded.
     func observe(value: Int)
 }

--- a/Sources/OpenTelemetryApi/Metrics/LabelSet.swift
+++ b/Sources/OpenTelemetryApi/Metrics/LabelSet.swift
@@ -15,14 +15,24 @@
 
 import Foundation
 
-public struct LabelSet: Hashable {
-    public var labels: [String: String]
+open class LabelSet: Hashable {
+    public private(set) var labels: [String: String]
 
-    public init() {
-        self.labels = [String: String] ()
+    private init() {
+        labels = [String: String]()
     }
-    
-    public init(labels: [String: String] ) {
+
+    public required init(labels: [String: String]) {
         self.labels = labels
+    }
+
+    public static var empty = LabelSet()
+
+    public static func == (lhs: LabelSet, rhs: LabelSet) -> Bool {
+        return lhs.labels == rhs.labels
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(labels)
     }
 }

--- a/Sources/OpenTelemetryApi/Metrics/LabelSet.swift
+++ b/Sources/OpenTelemetryApi/Metrics/LabelSet.swift
@@ -15,8 +15,12 @@
 
 import Foundation
 
+/// Normalized name value pairs of metric labels.
 open class LabelSet: Hashable {
     public private(set) var labels: [String: String]
+
+    /// Empty LabelSet.
+    public static var empty = LabelSet()
 
     private init() {
         labels = [String: String]()
@@ -25,8 +29,6 @@ open class LabelSet: Hashable {
     public required init(labels: [String: String]) {
         self.labels = labels
     }
-
-    public static var empty = LabelSet()
 
     public static func == (lhs: LabelSet, rhs: LabelSet) -> Bool {
         return lhs.labels == rhs.labels

--- a/Sources/OpenTelemetryApi/Metrics/LabelSet.swift
+++ b/Sources/OpenTelemetryApi/Metrics/LabelSet.swift
@@ -1,0 +1,28 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public struct LabelSet: Hashable {
+    public var labels: [String: String]
+
+    public init() {
+        self.labels = [String: String] ()
+    }
+    
+    public init(labels: [String: String] ) {
+        self.labels = labels
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/MeasureMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeasureMetric.swift
@@ -1,0 +1,73 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol MeasureMetric {
+    associatedtype T
+
+    func record(inContext: SpanContext, value: T, labelset: LabelSet)
+    func record(inContext: SpanContext, value: T, labels: [String: String])
+//    func record(inContext: DistributedContext,  value: T,  labelset: LabelSet)
+//    func record(inContext: DistributedContext,  value: T, labels: [String: String])
+    func bind(labelset: LabelSet) -> BoundMeasureMetric<T>
+    func bind(labels: [String: String]) -> BoundMeasureMetric<T>
+}
+
+public struct AnyMeasureMetric<T>: MeasureMetric {
+    private let _recordLabelSet: (SpanContext, T, LabelSet) -> Void
+    private let _recordLabels: (SpanContext, T, [String: String]) -> Void
+    private let _bindLabelSet: (LabelSet) -> BoundMeasureMetric<T>
+    private let _bindLabels: ([String: String]) -> BoundMeasureMetric<T>
+
+    public init<U: MeasureMetric>(_ measurable: U) where U.T == T {
+        _recordLabelSet = measurable.record(inContext:value:labelset:)
+        _recordLabels = measurable.record
+        _bindLabelSet = measurable.bind(labelset:)
+        _bindLabels = measurable.bind(labels:)
+    }
+
+    public func record(inContext: SpanContext, value: T, labelset: LabelSet) {
+        _recordLabelSet(inContext, value, labelset)
+    }
+
+    public func record(inContext: SpanContext, value: T, labels: [String: String]) {
+        _recordLabels(inContext, value, labels)
+    }
+
+    public func bind(labelset: LabelSet) -> BoundMeasureMetric<T> {
+        _bindLabelSet(labelset)
+    }
+
+    public func bind(labels: [String: String]) -> BoundMeasureMetric<T> {
+        _bindLabels(labels)
+    }
+}
+
+struct NoopMeasureMetric<T>: MeasureMetric {
+    func record(inContext: SpanContext, value: T, labelset: LabelSet) {
+    }
+
+    func record(inContext: SpanContext, value: T, labels: [String: String]) {
+    }
+
+    func bind(labelset: LabelSet) -> BoundMeasureMetric<T> {
+        BoundMeasureMetric<T>()
+    }
+
+    func bind(labels: [String: String]) -> BoundMeasureMetric<T> {
+        BoundMeasureMetric<T>()
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/MeasureMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeasureMetric.swift
@@ -15,17 +15,36 @@
 
 import Foundation
 
+/// Measure instrument.
 public protocol MeasureMetric {
     associatedtype T
+    /// Gets the bound measure metric with given labelset.
+    /// - Parameters:
+    ///   - labelset: The labelset from which bound instrument should be constructed.
+    /// - Returns: The bound measure metric.
+
     func bind(labelset: LabelSet) -> BoundMeasureMetric<T>
+
+    /// Gets the bound measure metric with given labelset.
+    /// - Parameters:
+    ///   - labels: The labels or dimensions associated with this value.
+    /// - Returns: The bound measure metric.
     func bind(labels: [String: String]) -> BoundMeasureMetric<T>
 }
 
 public extension MeasureMetric {
+    /// Records a measure.
+    /// - Parameters:
+    ///   - value: value to record.
+    ///   - labelset: The labelset associated with this value.
     func record(value: T, labelset: LabelSet) {
         bind(labelset: labelset).record(value: value)
     }
 
+    /// Records a measure.
+    /// - Parameters:
+    ///   - value: value to record.
+    ///   - labels: The labels or dimensions associated with this value.
     func record(value: T, labels: [String: String]) {
         bind(labels: labels).record(value: value)
     }

--- a/Sources/OpenTelemetryApi/Metrics/MeasureMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeasureMetric.swift
@@ -17,34 +17,27 @@ import Foundation
 
 public protocol MeasureMetric {
     associatedtype T
-
-    func record(inContext: SpanContext, value: T, labelset: LabelSet)
-    func record(inContext: SpanContext, value: T, labels: [String: String])
-//    func record(inContext: DistributedContext,  value: T,  labelset: LabelSet)
-//    func record(inContext: DistributedContext,  value: T, labels: [String: String])
     func bind(labelset: LabelSet) -> BoundMeasureMetric<T>
     func bind(labels: [String: String]) -> BoundMeasureMetric<T>
 }
 
+public extension MeasureMetric {
+    func record(value: T, labelset: LabelSet) {
+        bind(labelset: labelset).record(value: value)
+    }
+
+    func record(value: T, labels: [String: String]) {
+        bind(labels: labels).record(value: value)
+    }
+}
+
 public struct AnyMeasureMetric<T>: MeasureMetric {
-    private let _recordLabelSet: (SpanContext, T, LabelSet) -> Void
-    private let _recordLabels: (SpanContext, T, [String: String]) -> Void
     private let _bindLabelSet: (LabelSet) -> BoundMeasureMetric<T>
     private let _bindLabels: ([String: String]) -> BoundMeasureMetric<T>
 
     public init<U: MeasureMetric>(_ measurable: U) where U.T == T {
-        _recordLabelSet = measurable.record(inContext:value:labelset:)
-        _recordLabels = measurable.record
         _bindLabelSet = measurable.bind(labelset:)
         _bindLabels = measurable.bind(labels:)
-    }
-
-    public func record(inContext: SpanContext, value: T, labelset: LabelSet) {
-        _recordLabelSet(inContext, value, labelset)
-    }
-
-    public func record(inContext: SpanContext, value: T, labels: [String: String]) {
-        _recordLabels(inContext, value, labels)
     }
 
     public func bind(labelset: LabelSet) -> BoundMeasureMetric<T> {
@@ -57,12 +50,6 @@ public struct AnyMeasureMetric<T>: MeasureMetric {
 }
 
 struct NoopMeasureMetric<T>: MeasureMetric {
-    func record(inContext: SpanContext, value: T, labelset: LabelSet) {
-    }
-
-    func record(inContext: SpanContext, value: T, labels: [String: String]) {
-    }
-
     func bind(labelset: LabelSet) -> BoundMeasureMetric<T> {
         BoundMeasureMetric<T>()
     }

--- a/Sources/OpenTelemetryApi/Metrics/Meter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Meter.swift
@@ -15,38 +15,38 @@
 
 import Foundation
 
-public protocol Meter {
-    mutating func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int>
-    mutating func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double>
-    mutating func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int>
-    mutating func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double>
-    mutating func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric
-    mutating func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric
+public protocol Meter: AnyObject {
+    func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int>
+    func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double>
+    func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int>
+    func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double>
+    func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric
+    func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric
     var labelSet: LabelSet { get }
 }
 
 extension Meter {
-    mutating func createIntCounter(name: String) -> AnyCounterMetric<Int> {
+    func createIntCounter(name: String) -> AnyCounterMetric<Int> {
         return createIntCounter(name: name, monotonic: true)
     }
 
-    mutating func createDoubleCounter(name: String) -> AnyCounterMetric<Double> {
+    func createDoubleCounter(name: String) -> AnyCounterMetric<Double> {
         return createDoubleCounter(name: name, monotonic: true)
     }
 
-    mutating func createIntMeasure(name: String) -> AnyMeasureMetric<Int> {
+    func createIntMeasure(name: String) -> AnyMeasureMetric<Int> {
         return createIntMeasure(name: name, absolute: true)
     }
 
-    mutating func createDoubleMeasure(name: String) -> AnyMeasureMetric<Double> {
+    func createDoubleMeasure(name: String) -> AnyMeasureMetric<Double> {
         return createDoubleMeasure(name: name, absolute: true)
     }
 
-    mutating func createIntObserver(name: String, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
+    func createIntObserver(name: String, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
         return createIntObserver(name: name, absolute: true, callback: callback)
     }
 
-    mutating func createDoubleObserver(name: String, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
+    func createDoubleObserver(name: String, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
         return createDoubleObserver(name: name, absolute: true, callback: callback)
     }
 }

--- a/Sources/OpenTelemetryApi/Metrics/Meter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Meter.swift
@@ -15,13 +15,56 @@
 
 import Foundation
 
+/// Main interface to obtain metric instruments.
 public protocol Meter: AnyObject {
+    /// Creates Int counter with given name.
+    /// - Parameters:
+    ///   - name: The name of the counter.
+    ///   - monotonic: indicates if only positive values are expected.
+    /// - Returns:The counter instance.
     func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int>
+
+    /// Creates double counter with given name.
+    /// - Parameters:
+    ///   - name: indicates if only positive values are expected.
+    ///   - monotonic: The name of the counter.
+    /// - Returns:The counter instance.
     func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double>
+
+    /// Creates Int Measure with given name.
+    /// - Parameters:
+    ///   - name: The name of the measure.
+    ///   - absolute: indicates if only positive values are expected.
+    /// - Returns:The measure instance.
     func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int>
+
+    /// Creates double Measure with given name.
+    /// - Parameters:
+    ///   - name: The name of the measure.
+    ///   - absolute: indicates if only positive values are expected.
+    /// - Returns:The measure instance.
     func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double>
+
+    /// Creates Int Observer with given name.
+    /// - Parameters:
+    ///   - name: The name of the observer.
+    ///   - callback: The callback to be called to observe metric value.
+    ///   - absolute: indicates if only positive values are expected.
+    /// - Returns:The observer instance.
     func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric
+
+    /// Creates Double Observer with given name.
+    /// - Parameters:
+    ///   - name: The name of the observer.
+    ///   - callback: The callback to be called to observe metric value.
+    ///   - absolute: indicates if only positive values are expected.
+    /// - Returns:The observer instance.
     func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric
+
+    /// Constructs or retrieves the LabelSet from the given dictionary.
+    /// - Parameters:
+    ///   - labels: dictionary with  key-value pairs.
+    /// - Returns:The LabelSet with given label key value pairs.
     func getLabelSet(labels: [String: String]) -> LabelSet
 }
 

--- a/Sources/OpenTelemetryApi/Metrics/Meter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Meter.swift
@@ -22,10 +22,10 @@ public protocol Meter: AnyObject {
     func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double>
     func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric
     func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric
-    var labelSet: LabelSet { get }
+    func getLabelSet(labels: [String: String]) -> LabelSet
 }
 
-extension Meter {
+public extension Meter {
     func createIntCounter(name: String) -> AnyCounterMetric<Int> {
         return createIntCounter(name: name, monotonic: true)
     }

--- a/Sources/OpenTelemetryApi/Metrics/Meter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Meter.swift
@@ -1,0 +1,52 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol Meter {
+    mutating func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int>
+    mutating func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double>
+    mutating func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int>
+    mutating func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double>
+    mutating func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric
+    mutating func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric
+    var labelSet: LabelSet { get }
+}
+
+extension Meter {
+    mutating func createIntCounter(name: String) -> AnyCounterMetric<Int> {
+        return createIntCounter(name: name, monotonic: true)
+    }
+
+    mutating func createDoubleCounter(name: String) -> AnyCounterMetric<Double> {
+        return createDoubleCounter(name: name, monotonic: true)
+    }
+
+    mutating func createIntMeasure(name: String) -> AnyMeasureMetric<Int> {
+        return createIntMeasure(name: name, absolute: true)
+    }
+
+    mutating func createDoubleMeasure(name: String) -> AnyMeasureMetric<Double> {
+        return createDoubleMeasure(name: name, absolute: true)
+    }
+
+    mutating func createIntObserver(name: String, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
+        return createIntObserver(name: name, absolute: true, callback: callback)
+    }
+
+    mutating func createDoubleObserver(name: String, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
+        return createDoubleObserver(name: name, absolute: true, callback: callback)
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/MeterFactoryBase.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeterFactoryBase.swift
@@ -19,8 +19,8 @@ open class MeterFactoryBase {
     static var defaultFactory = MeterFactoryBase()
     static var proxyMeter = ProxyMeter()
     static var initialized = false
-    
-    public init(){}
+
+    public init() {}
 
     static func setDefault(meterFactory: MeterFactoryBase) {
         guard !initialized else {
@@ -31,10 +31,10 @@ open class MeterFactoryBase {
         initialized = true
     }
 
-    func getMeter( name: String, version: String? = nil) -> Meter {
+    open func getMeter(name: String, version: String? = nil) -> Meter {
         return MeterFactoryBase.initialized ? MeterFactoryBase.defaultFactory.getMeter(name: name, version: version) : MeterFactoryBase.proxyMeter
     }
-    
+
     internal func reset() {
         MeterFactoryBase.defaultFactory = MeterFactoryBase()
         MeterFactoryBase.proxyMeter = ProxyMeter()

--- a/Sources/OpenTelemetryApi/Metrics/MeterFactoryBase.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeterFactoryBase.swift
@@ -1,0 +1,43 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+open class MeterFactoryBase {
+    static var defaultFactory = MeterFactoryBase()
+    static var proxyMeter = ProxyMeter()
+    static var initialized = false
+    
+    public init(){}
+
+    static func setDefault(meterFactory: MeterFactoryBase) {
+        guard !initialized else {
+            return
+        }
+        defaultFactory = meterFactory
+        proxyMeter.updateMeter(realMeter: meterFactory.getMeter(name: ""))
+        initialized = true
+    }
+
+    func getMeter( name: String, version: String? = nil) -> Meter {
+        return MeterFactoryBase.initialized ? MeterFactoryBase.defaultFactory.getMeter(name: name, version: version) : MeterFactoryBase.proxyMeter
+    }
+    
+    internal func reset() {
+        MeterFactoryBase.defaultFactory = MeterFactoryBase()
+        MeterFactoryBase.proxyMeter = ProxyMeter()
+        MeterFactoryBase.initialized = false
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/MeterProvider.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeterProvider.swift
@@ -15,6 +15,13 @@
 
 import Foundation
 
+/// Creates Meters for an instrumentation library.
+/// Libraries should use this class as follows to obtain Meter instance.
 public protocol MeterProvider: AnyObject {
+    /// Returns a Meter for a given name and version.
+    /// - Parameters:
+    ///   - instrumentationName: Name of the instrumentation library.
+    ///   - instrumentationVersion: Version of the instrumentation library (optional).
+    /// - Returns: Meter for the given name and version information.
     func get(instrumentationName: String, instrumentationVersion: String?) -> Meter
 }

--- a/Sources/OpenTelemetryApi/Metrics/MeterProvider.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeterProvider.swift
@@ -15,8 +15,6 @@
 
 import Foundation
 
-public struct MeterBuilder {
-    public private(set) var metricProcessor: MetricProcessor?
-    public private(set) var metricExporter: MetricExporter?
-    public private(set) var metricPushInterval: TimeInterval?
+public protocol MeterProvider: AnyObject {
+    func get(instrumentationName: String, instrumentationVersion: String?) -> Meter
 }

--- a/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
@@ -14,6 +14,8 @@
 //
 
 import Foundation
+
+/// Proxy Meter which act as a No-Op Meter, until real meter is provided.
 class ProxyMeter: Meter {
     private var realMeter: Meter?
 

--- a/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
@@ -17,7 +17,9 @@ import Foundation
 class ProxyMeter: Meter {
     private var realMeter: Meter?
 
-    var labelSet: LabelSet { return realMeter?.labelSet ?? LabelSet() }
+    func getLabelSet(labels: [String: String]) -> LabelSet {
+        return realMeter?.getLabelSet(labels: labels) ?? LabelSet.empty
+    }
 
     func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
         return realMeter?.createIntCounter(name: name, monotonic: monotonic) ?? AnyCounterMetric<Int>(NoopCounterMetric<Int>())

--- a/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
@@ -14,36 +14,36 @@
 //
 
 import Foundation
-struct ProxyMeter: Meter {
+class ProxyMeter: Meter {
     private var realMeter: Meter?
 
     var labelSet: LabelSet { return realMeter?.labelSet ?? LabelSet() }
 
-    mutating func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
+    func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
         return realMeter?.createIntCounter(name: name, monotonic: monotonic) ?? AnyCounterMetric<Int>(NoopCounterMetric<Int>())
     }
 
-    mutating func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
+    func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
         return realMeter?.createDoubleCounter(name: name, monotonic: monotonic) ?? AnyCounterMetric<Double>(NoopCounterMetric<Double>())
     }
 
-    mutating func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
+    func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
         return realMeter?.createIntMeasure(name: name, absolute: absolute) ?? AnyMeasureMetric<Int>(NoopMeasureMetric<Int>())
     }
 
-    mutating func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
+    func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
         return realMeter?.createDoubleMeasure(name: name, absolute: absolute) ?? AnyMeasureMetric<Double>(NoopMeasureMetric<Double>())
     }
 
-    mutating func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
+    func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
         return realMeter?.createIntObserver(name: name, absolute: absolute, callback: callback) ?? NoopIntObserverMetric()
     }
 
-    mutating func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
+    func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
         return realMeter?.createDoubleObserver(name: name, absolute: absolute, callback: callback) ?? NoopDoubleObserverMetric()
     }
 
-    mutating func updateMeter(realMeter: Meter) {
+    func updateMeter(realMeter: Meter) {
         guard self.realMeter == nil else {
             return
         }

--- a/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
@@ -1,0 +1,52 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+struct ProxyMeter: Meter {
+    private var realMeter: Meter?
+
+    var labelSet: LabelSet { return realMeter?.labelSet ?? LabelSet() }
+
+    mutating func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
+        return realMeter?.createIntCounter(name: name, monotonic: monotonic) ?? AnyCounterMetric<Int>(NoopCounterMetric<Int>())
+    }
+
+    mutating func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
+        return realMeter?.createDoubleCounter(name: name, monotonic: monotonic) ?? AnyCounterMetric<Double>(NoopCounterMetric<Double>())
+    }
+
+    mutating func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
+        return realMeter?.createIntMeasure(name: name, absolute: absolute) ?? AnyMeasureMetric<Int>(NoopMeasureMetric<Int>())
+    }
+
+    mutating func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
+        return realMeter?.createDoubleMeasure(name: name, absolute: absolute) ?? AnyMeasureMetric<Double>(NoopMeasureMetric<Double>())
+    }
+
+    mutating func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
+        return realMeter?.createIntObserver(name: name, absolute: absolute, callback: callback) ?? NoopIntObserverMetric()
+    }
+
+    mutating func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
+        return realMeter?.createDoubleObserver(name: name, absolute: absolute, callback: callback) ?? NoopDoubleObserverMetric()
+    }
+
+    mutating func updateMeter(realMeter: Meter) {
+        guard self.realMeter == nil else {
+            return
+        }
+        self.realMeter = realMeter
+    }
+}

--- a/Sources/OpenTelemetryApi/OpenTelemetry.swift
+++ b/Sources/OpenTelemetryApi/OpenTelemetry.swift
@@ -21,11 +21,11 @@ import Foundation
 public struct OpenTelemetry {
     public static var instance = OpenTelemetry()
 
-    /// Registered TracerFactory or default via DefaultTracerFactory.instance.
+    /// Registered tracerProvider or default via DefaultTracerProvider.instance.
     public private(set) var tracerProvider: TracerProvider
 
-//    /// Registered MeterFactory or default via DefaultMeterFactory.instance.
-//    public private(set)  var meter: MeterProvider
+    /// Registered MeterProvider or default via DefaultMeterProvider.instance.
+    public private(set) var meterProvider: MeterProvider
 
     /// registered manager or default via  DefaultCorrelationContextManager.instance.
     public private(set) var contextManager: CorrelationContextManager
@@ -35,12 +35,16 @@ public struct OpenTelemetry {
 
     private init() {
         tracerProvider = DefaultTracerProvider.instance
-//        meter = DefaultMeterFactory.instance;
+        meterProvider = DefaultMeterProvider.instance
         contextManager = DefaultCorrelationContextManager.instance
     }
 
     public static func registerTracerProvider(tracerProvider: TracerProvider) {
         instance.tracerProvider = tracerProvider
+    }
+
+    public static func registerMeterProvider(meterProvider: MeterProvider) {
+        instance.meterProvider = meterProvider
     }
 
     public static func registerCorrelationContextManager(correlationContextManager: CorrelationContextManager) {

--- a/Sources/OpenTelemetryApi/Trace/DefaultTracerProvider.swift
+++ b/Sources/OpenTelemetryApi/Trace/DefaultTracerProvider.swift
@@ -18,7 +18,7 @@ import Foundation
 public class DefaultTracerProvider: TracerProvider {
     public static let instance = DefaultTracerProvider()
 
-    public override func get(instrumentationName: String, instrumentationVersion: String?) -> Tracer {
+    public func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Tracer {
         return DefaultTracer.instance
     }
 }

--- a/Sources/OpenTelemetrySdk/Internal/Locks.swift
+++ b/Sources/OpenTelemetrySdk/Internal/Locks.swift
@@ -1,0 +1,208 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Metrics API open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the Swift Metrics API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Metrics API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
+#endif
+
+/// A threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO.
+internal final class Lock {
+    fileprivate let mutex: UnsafeMutablePointer<pthread_mutex_t> = UnsafeMutablePointer.allocate(capacity: 1)
+
+    /// Create a new lock.
+    public init() {
+        let err = pthread_mutex_init(self.mutex, nil)
+        precondition(err == 0, "pthread_mutex_init failed with error \(err)")
+    }
+
+    deinit {
+        let err = pthread_mutex_destroy(self.mutex)
+        precondition(err == 0, "pthread_mutex_destroy failed with error \(err)")
+        self.mutex.deallocate()
+    }
+
+    /// Acquire the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    public func lock() {
+        let err = pthread_mutex_lock(self.mutex)
+        precondition(err == 0, "pthread_mutex_lock failed with error \(err)")
+    }
+
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `lock`, to simplify lock handling.
+    public func unlock() {
+        let err = pthread_mutex_unlock(self.mutex)
+        precondition(err == 0, "pthread_mutex_unlock failed with error \(err)")
+    }
+}
+
+extension Lock {
+    /// Acquire the lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    internal func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    // specialise Void return (for performance)
+    @inlinable
+    internal func withLockVoid(_ body: () throws -> Void) rethrows {
+        try self.withLock(body)
+    }
+}
+
+/// A threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO.
+internal final class ReadWriteLock {
+    fileprivate let rwlock: UnsafeMutablePointer<pthread_rwlock_t> = UnsafeMutablePointer.allocate(capacity: 1)
+
+    /// Create a new lock.
+    public init() {
+        let err = pthread_rwlock_init(self.rwlock, nil)
+        precondition(err == 0, "pthread_rwlock_init failed with error \(err)")
+    }
+
+    deinit {
+        let err = pthread_rwlock_destroy(self.rwlock)
+        precondition(err == 0, "pthread_rwlock_destroy failed with error \(err)")
+        self.rwlock.deallocate()
+    }
+
+    /// Acquire a reader lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    public func lockRead() {
+        let err = pthread_rwlock_rdlock(self.rwlock)
+        precondition(err == 0, "pthread_rwlock_rdlock failed with error \(err)")
+    }
+
+    /// Acquire a writer lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    public func lockWrite() {
+        let err = pthread_rwlock_wrlock(self.rwlock)
+        precondition(err == 0, "pthread_rwlock_wrlock failed with error \(err)")
+    }
+
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `lock`, to simplify lock handling.
+    public func unlock() {
+        let err = pthread_rwlock_unlock(self.rwlock)
+        precondition(err == 0, "pthread_rwlock_unlock failed with error \(err)")
+    }
+}
+
+extension ReadWriteLock {
+    /// Acquire the reader lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    internal func withReaderLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lockRead()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    /// Acquire the writer lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    internal func withWriterLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lockWrite()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    // specialise Void return (for performance)
+    @inlinable
+    internal func withReaderLockVoid(_ body: () throws -> Void) rethrows {
+        try self.withReaderLock(body)
+    }
+
+    // specialise Void return (for performance)
+    @inlinable
+    internal func withWriterLockVoid(_ body: () throws -> Void) rethrows {
+        try self.withWriterLock(body)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/Aggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/Aggregator.swift
@@ -1,0 +1,54 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+protocol Aggregator: AnyObject {
+    associatedtype T
+    func update(value: T)
+    func checkpoint()
+    func toMetricData() -> MetricData
+    func getAggregationType() -> AggregationType
+}
+
+public class AnyAggregator<T>: Aggregator {
+    private let _update: (T) -> Void
+    private let _checkpoint: () -> Void
+    private let _toMetricData: () -> MetricData
+    private let _getAggregationType: () -> AggregationType
+
+    init<U: Aggregator>(_ aggregable: U) where U.T == T {
+        _update = aggregable.update
+        _checkpoint = aggregable.checkpoint
+        _toMetricData = aggregable.toMetricData
+        _getAggregationType = aggregable.getAggregationType
+    }
+
+    func update(value: T) {
+        _update(value)
+    }
+
+    func checkpoint() {
+        _checkpoint()
+    }
+
+    func toMetricData() -> MetricData {
+        return _toMetricData()
+    }
+
+    func getAggregationType() -> AggregationType {
+        return _getAggregationType()
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 
+/// Basic aggregator which calculates a Sum from individual measurements.
 public class CounterSumAggregator<T: SignedNumeric>: Aggregator {
     var sum: T = 0
     var pointCheck: T = 0

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
@@ -28,6 +28,7 @@ public class CounterSumAggregator<T: SignedNumeric>: Aggregator {
 
     func checkpoint() {
         lock.withLockVoid {
+            pointCheck = sum
             sum = 0
         }
     }

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
@@ -1,0 +1,46 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public class CounterSumAggregator<T: SignedNumeric>: Aggregator {
+    var sum: T = 0
+    var pointCheck: T = 0 
+    private let lock = Lock()
+
+    func update(value: T) {
+        lock.withLockVoid {
+            sum += value
+        }
+    }
+
+    func checkpoint() {
+        lock.withLockVoid {
+            sum = 0
+        }
+    }
+
+    func toMetricData() -> MetricData {
+        return SumData<T>(timestamp: Date(), sum: pointCheck)
+    }
+
+    func getAggregationType() -> AggregationType {
+        if T.self == Double.Type.self {
+            return .doubleSum
+        } else {
+            return .intSum
+        }
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
@@ -17,7 +17,7 @@ import Foundation
 
 public class CounterSumAggregator<T: SignedNumeric>: Aggregator {
     var sum: T = 0
-    var pointCheck: T = 0 
+    var pointCheck: T = 0
     private let lock = Lock()
 
     func update(value: T) {

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/LastValueAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/LastValueAggregator.swift
@@ -1,0 +1,47 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public class LastValueAggregator<T: SignedNumeric>: Aggregator {
+    var value: T = 0
+    var pointCheck: T = 0
+
+    private let lock = Lock()
+
+    func update(value: T) {
+        lock.withLockVoid {
+            self.value = value
+        }
+    }
+
+    func checkpoint() {
+        lock.withLockVoid {
+            self.pointCheck = self.value
+        }
+    }
+
+    func toMetricData() -> MetricData {
+        return SumData<T>(timestamp: Date(), sum: pointCheck)
+    }
+
+    func getAggregationType() -> AggregationType {
+        if T.self == Double.Type.self {
+            return .doubleSum
+        } else {
+            return .intSum
+        }
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/LastValueAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/LastValueAggregator.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 
+/// Simple aggregator that only keeps the last value.
 public class LastValueAggregator<T: SignedNumeric>: Aggregator {
     var value: T = 0
     var pointCheck: T = 0

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/MeasureMinMaxSumCountAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/MeasureMinMaxSumCountAggregator.swift
@@ -1,0 +1,86 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public class MeasureMinMaxSumCountAggregator<T: SignedNumeric & Comparable>: Aggregator {
+    fileprivate var summary = Summary<T>()
+    fileprivate var pointCheck = Summary<T>()
+
+    private let lock = Lock()
+
+    func update(value: T) {
+        lock.withLockVoid {
+            self.summary.count += 1
+            self.summary.sum += value
+            self.summary.max = max(self.summary.max, value)
+            self.summary.min = min(self.summary.min, value)
+        }
+    }
+
+    func checkpoint() {
+        summary = Summary<T>()
+    }
+
+    func toMetricData() -> MetricData {
+        return SummaryData<T>(timestamp: Date(),
+                              count: pointCheck.count,
+                              sum: pointCheck.sum,
+                              min: pointCheck.min,
+                              max: pointCheck.max)
+    }
+
+    func getAggregationType() -> AggregationType {
+        if T.self == Double.Type.self {
+            return .doubleSummary
+        } else {
+            return .intSummary
+        }
+    }
+}
+
+private struct Summary<T> where T: SignedNumeric {
+    var sum: T
+    var count: Int
+    var min: T
+    var max: T
+}
+
+extension Summary where T: FloatingPoint {
+    init() {
+        sum = 0
+        count = 0
+        min = T.greatestFiniteMagnitude
+        max = -T.greatestFiniteMagnitude
+    }
+}
+
+extension Summary where T == Int {
+    init() {
+        sum = 0
+        count = 0
+        min = Int.max
+        max = -Int.max
+    }
+}
+
+extension Summary {
+    init() {
+        sum = 0
+        count = 0
+        min = 0
+        max = 0
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/MeasureMinMaxSumCountAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/MeasureMinMaxSumCountAggregator.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 
+/// Aggregator which calculates summary (Min,Max,Sum,Count) from measures.
 public class MeasureMinMaxSumCountAggregator<T: SignedNumeric & Comparable>: Aggregator {
     fileprivate var summary = Summary<T>()
     fileprivate var pointCheck = Summary<T>()

--- a/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdk.swift
@@ -1,0 +1,38 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+
+class BoundCounterMetricSdk<T: SignedNumeric>: BoundCounterMetricSdkBase<T> {
+    private var sumAggregator = CounterSumAggregator<T>()
+
+    override init(recordStatus: RecordStatus) {
+        super.init(recordStatus: recordStatus)
+    }
+
+    override func add(inContext: SpanContext, value: T) {
+        sumAggregator.update(value: value)
+    }
+
+//    override func add(inContext: DistributedContext, value: T) {
+//      sumAggregator.update(value: value)
+//    }
+
+    override func getAggregator() -> AnyAggregator<T> {
+        return AnyAggregator<T>(sumAggregator)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdk.swift
@@ -16,7 +16,6 @@
 import Foundation
 import OpenTelemetryApi
 
-
 class BoundCounterMetricSdk<T: SignedNumeric>: BoundCounterMetricSdkBase<T> {
     private var sumAggregator = CounterSumAggregator<T>()
 
@@ -24,13 +23,9 @@ class BoundCounterMetricSdk<T: SignedNumeric>: BoundCounterMetricSdkBase<T> {
         super.init(recordStatus: recordStatus)
     }
 
-    override func add(inContext: SpanContext, value: T) {
+    override func add(value: T) {
         sumAggregator.update(value: value)
     }
-
-//    override func add(inContext: DistributedContext, value: T) {
-//      sumAggregator.update(value: value)
-//    }
 
     override func getAggregator() -> AnyAggregator<T> {
         return AnyAggregator<T>(sumAggregator)

--- a/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdkBase.swift
@@ -18,6 +18,7 @@ import OpenTelemetryApi
 
 class BoundCounterMetricSdkBase<T>: BoundCounterMetric<T> {
     internal var status: RecordStatus
+    internal let statusLock = Lock()
 
     init(recordStatus: RecordStatus) {
         status = recordStatus

--- a/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdkBase.swift
@@ -1,0 +1,30 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+class BoundCounterMetricSdkBase<T>: BoundCounterMetric<T> {
+    internal var status: RecordStatus
+
+    init(recordStatus: RecordStatus) {
+        status = recordStatus
+        super.init()
+    }
+
+    func getAggregator() -> AnyAggregator<T> {
+        fatalError()
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdk.swift
@@ -18,18 +18,14 @@ import OpenTelemetryApi
 
 internal class BoundMeasureMetricSdk<T: SignedNumeric & Comparable>: BoundMeasureMetricSdkBase<T> {
     private var measureAggregator = MeasureMinMaxSumCountAggregator<T>()
-    
+
     override init() {
         super.init()
     }
 
-    override func record(inContext: SpanContext, value: T) {
+    override func record(value: T) {
         measureAggregator.update(value: value)
     }
-
-//    override func record(inContext: DistributedContext, value: T) {
-//        measureAggregator.update(value: value)
-//    }
 
     override func getAggregator() -> AnyAggregator<T> {
         return AnyAggregator<T>(measureAggregator)

--- a/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdk.swift
@@ -1,0 +1,37 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+internal class BoundMeasureMetricSdk<T: SignedNumeric & Comparable>: BoundMeasureMetricSdkBase<T> {
+    private var measureAggregator = MeasureMinMaxSumCountAggregator<T>()
+    
+    override init() {
+        super.init()
+    }
+
+    override func record(inContext: SpanContext, value: T) {
+        measureAggregator.update(value: value)
+    }
+
+//    override func record(inContext: DistributedContext, value: T) {
+//        measureAggregator.update(value: value)
+//    }
+
+    override func getAggregator() -> AnyAggregator<T> {
+        return AnyAggregator<T>(measureAggregator)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdkBase.swift
@@ -1,0 +1,27 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+class BoundMeasureMetricSdkBase<T>: BoundMeasureMetric<T> {
+    override init() {
+        super.init()
+    }
+
+    func getAggregator() -> AnyAggregator<T> {
+        fatalError()
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterBuilder.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterBuilder.swift
@@ -1,0 +1,22 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public struct MeterBuilder {
+    public private(set) var metricProcessor: MetricProcessor?
+    public private(set) var metricExporter: MetricExporter?
+    public private(set) var metricPushInterval: TimeInterval?
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterFactory.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterFactory.swift
@@ -1,0 +1,87 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+public class MeterFactory: MeterFactoryBase {
+    fileprivate let lock = Lock()
+
+    var meterRegistry = [MeterRegistryKey: MeterSdk]()
+
+    let metricProcessor: MetricProcessor
+    let metricExporter: MetricExporter
+    let pushMetricController: PushMetricController
+    let defaultPushInterval: TimeInterval = 60
+    var defaultMeter: MeterSdk
+
+    init(meterBuilder: MeterBuilder) {
+        metricProcessor = meterBuilder.metricProcessor ?? NoopMetricProcessor()
+        metricExporter = meterBuilder.metricExporter ?? NoopMetricExporter()
+
+        defaultMeter = MeterSdk(meterName: "", metricProcessor: metricProcessor)
+        meterRegistry[MeterRegistryKey(name: "", version: "")] = defaultMeter
+
+        let defaultPushInterval = self.defaultPushInterval
+        pushMetricController = PushMetricController(
+            meters: meterRegistry,
+            metricProcessor: metricProcessor,
+            metricExporter: metricExporter,
+            pushInterval: meterBuilder.metricPushInterval ?? defaultPushInterval) {
+            false
+        }
+
+        super.init()
+    }
+
+    public static func create(configure: (MeterBuilder) -> Void) -> MeterFactory {
+        let builder = MeterBuilder()
+        configure(builder)
+
+        return MeterFactory(meterBuilder: builder)
+    }
+
+    public func getMeter(name: String, version: String? = nil) -> Meter {
+        if name.isEmpty {
+            return defaultMeter
+        }
+
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        let key = MeterRegistryKey(name: name, version: version)
+        var meter: MeterSdk! = meterRegistry[key]
+        if meter == nil {
+            meter = MeterSdk(meterName: name, metricProcessor: metricProcessor)
+            defaultMeter = meter!
+            meterRegistry[key] = meter!
+        }
+        return meter!
+    }
+
+    private static func createLibraryResourceLabels(name: String, version: String) -> [String: String] {
+        var labels = ["name": name]
+        if !version.isEmpty {
+            labels["version"] = version
+        }
+        return labels
+    }
+}
+
+struct MeterRegistryKey: Hashable {
+    var name: String
+    var version: String?
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterFactory.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterFactory.swift
@@ -32,7 +32,7 @@ public class MeterFactory: MeterFactoryBase {
         metricExporter = meterBuilder.metricExporter ?? NoopMetricExporter()
 
         defaultMeter = MeterSdk(meterName: "", metricProcessor: metricProcessor)
-        meterRegistry[MeterRegistryKey(name: "", version: "")] = defaultMeter
+        meterRegistry[MeterRegistryKey(name: "")] = defaultMeter
 
         let defaultPushInterval = self.defaultPushInterval
         pushMetricController = PushMetricController(
@@ -53,7 +53,7 @@ public class MeterFactory: MeterFactoryBase {
         return MeterFactory(meterBuilder: builder)
     }
 
-    public func getMeter(name: String, version: String? = nil) -> Meter {
+    public override func getMeter(name: String, version: String? = nil) -> Meter {
         if name.isEmpty {
             return defaultMeter
         }

--- a/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterSharedState.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterSharedState.swift
@@ -16,7 +16,12 @@
 import Foundation
 
 public struct MeterSharedState {
+    /// Configures metric processor. (aka batcher).
+    
     public private(set) var metricProcessor: MetricProcessor?
+    /// Configures Metric Exporter.
     public private(set) var metricExporter: MetricExporter?
+    
+    /// Sets the push interval.
     public private(set) var metricPushInterval: TimeInterval?
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterSharedState.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Configuration/MeterSharedState.swift
@@ -15,11 +15,8 @@
 
 import Foundation
 
-/// A factory for creating named Tracers.
-public protocol TracerProvider {
-    /// Gets or creates a named tracer instance.
-    /// - Parameters:
-    ///   - instrumentationName: the name of the instrumentation library, not the name of the instrumented library
-    ///   - instrumentationVersion:  The version of the instrumentation library (e.g., "semver:1.0.0"). Optional
-    func get(instrumentationName: String, instrumentationVersion: String?) -> Tracer
+public struct MeterSharedState {
+    public private(set) var metricProcessor: MetricProcessor?
+    public private(set) var metricExporter: MetricExporter?
+    public private(set) var metricPushInterval: TimeInterval?
 }

--- a/Sources/OpenTelemetrySdk/Metrics/CounterMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/CounterMetricSdk.swift
@@ -21,12 +21,12 @@ class CounterMetricSdk<T: SignedNumeric>: CounterMetricSdkBase<T> {
         super.init(name: name)
     }
 
-    override func add(inContext: SpanContext, value: T, labelset: LabelSet) {
-        bind(labelset: labelset, isShortLived: true).add(inContext: inContext, value: value)
+    override func add(value: T, labelset: LabelSet) {
+        bind(labelset: labelset, isShortLived: true).add(value: value)
     }
 
-    override func add(inContext: SpanContext, value: T, labels: [String: String]) {
-        bind(labelset: LabelSet(labels: labels), isShortLived: true).add(inContext: inContext, value: value)
+    override func add(value: T, labels: [String: String]) {
+        bind(labelset: LabelSetSdk(labels: labels), isShortLived: true).add(value: value)
     }
 
     override func createMetric(recordStatus: RecordStatus) -> BoundCounterMetricSdkBase<T> {

--- a/Sources/OpenTelemetrySdk/Metrics/CounterMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/CounterMetricSdk.swift
@@ -1,0 +1,35 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+class CounterMetricSdk<T: SignedNumeric>: CounterMetricSdkBase<T> {
+    override init(name: String) {
+        super.init(name: name)
+    }
+
+    override func add(inContext: SpanContext, value: T, labelset: LabelSet) {
+        bind(labelset: labelset, isShortLived: true).add(inContext: inContext, value: value)
+    }
+
+    override func add(inContext: SpanContext, value: T, labels: [String: String]) {
+        bind(labelset: LabelSet(labels: labels), isShortLived: true).add(inContext: inContext, value: value)
+    }
+
+    override func createMetric(recordStatus: RecordStatus) -> BoundCounterMetricSdkBase<T> {
+        return BoundCounterMetricSdk<T>(recordStatus: recordStatus)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/CounterMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/CounterMetricSdkBase.swift
@@ -25,11 +25,11 @@ class CounterMetricSdkBase<T>: CounterMetric {
         metricName = name
     }
 
-    func add(inContext: SpanContext, value: T, labelset: LabelSet) {
+    func add(value: T, labelset: LabelSet) {
         fatalError()
     }
 
-    func add(inContext: SpanContext, value: T, labels: [String: String]) {
+    func add(value: T, labels: [String: String]) {
         fatalError()
     }
 

--- a/Sources/OpenTelemetrySdk/Metrics/CounterMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/CounterMetricSdkBase.swift
@@ -1,0 +1,86 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+class CounterMetricSdkBase<T>: CounterMetric {
+    private let bindUnbindLock = Lock()
+    public private(set) var boundInstruments = [LabelSet: BoundCounterMetricSdkBase<T>]()
+    let metricName: String
+
+    init(name: String) {
+        metricName = name
+    }
+
+    func add(inContext: SpanContext, value: T, labelset: LabelSet) {
+        fatalError()
+    }
+
+    func add(inContext: SpanContext, value: T, labels: [String: String]) {
+        fatalError()
+    }
+
+    func bind(labelset: LabelSet) -> BoundCounterMetric<T> {
+        return bind(labelset: labelset, isShortLived: false)
+    }
+
+    func bind(labels: [String: String]) -> BoundCounterMetric<T> {
+        return bind(labelset: LabelSet(labels: labels), isShortLived: false)
+    }
+
+    internal func bind(labelset: LabelSet, isShortLived: Bool) -> BoundCounterMetric<T> {
+        var boundInstrument = boundInstruments[labelset]
+
+        bindUnbindLock.withLockVoid {
+            if boundInstrument == nil {
+                let status = isShortLived ? RecordStatus.updatePending : RecordStatus.bound
+                boundInstrument = createMetric(recordStatus: status)
+                boundInstruments[labelset] = boundInstrument
+            }
+        }
+
+        switch boundInstrument!.status {
+        case .noPendingUpdate:
+            boundInstrument!.status = .updatePending
+            break
+        case .candidateForRemoval:
+            bindUnbindLock.withLockVoid {
+                boundInstrument!.status = .updatePending
+
+                if boundInstruments[labelset] == nil {
+                    boundInstruments[labelset] = boundInstrument!
+                }
+            }
+        case .bound, .updatePending:
+            break
+        }
+
+        return boundInstrument!
+    }
+
+    internal func unBind(labelSet: LabelSet) {
+        bindUnbindLock.withLockVoid {
+            if let boundInstrument = boundInstruments[labelSet],
+                boundInstrument.status == .candidateForRemoval {
+                boundInstruments[labelSet] = nil
+            }
+        }
+    }
+
+    func createMetric(recordStatus: RecordStatus) -> BoundCounterMetricSdkBase<T> {
+        fatalError()
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/DoubleObserverMetricHandle.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/DoubleObserverMetricHandle.swift
@@ -1,0 +1,40 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+struct DoubleObserverMetricSdk: DoubleObserverMetric {
+    public private(set) var observerHandles = [LabelSet: DoubleObserverMetricHandleSdk]()
+    let metricName: String
+    var callback: (DoubleObserverMetric) -> Void
+
+    mutating func observe(value: Double, labels: [String: String]) {
+        observe(value: value, labelset: LabelSet(labels: labels))
+    }
+
+    mutating func observe(value: Double, labelset: LabelSet) {
+        var boundInstrument = observerHandles[labelset]
+        if boundInstrument == nil {
+            boundInstrument = DoubleObserverMetricHandleSdk()
+            observerHandles[labelset] = boundInstrument
+        }
+        boundInstrument?.observe(value: value)
+    }
+
+    func invokeCallback() {
+        callback(self)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/DoubleObserverMetricHandle.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/DoubleObserverMetricHandle.swift
@@ -16,16 +16,21 @@
 import Foundation
 import OpenTelemetryApi
 
-struct DoubleObserverMetricSdk: DoubleObserverMetric {
+class DoubleObserverMetricSdk: DoubleObserverMetric {
     public private(set) var observerHandles = [LabelSet: DoubleObserverMetricHandleSdk]()
     let metricName: String
     var callback: (DoubleObserverMetric) -> Void
 
-    mutating func observe(value: Double, labels: [String: String]) {
+    init(metricName: String, callback: @escaping (DoubleObserverMetric) -> Void) {
+        self.metricName = metricName
+        self.callback = callback
+    }
+
+    func observe(value: Double, labels: [String: String]) {
         observe(value: value, labelset: LabelSet(labels: labels))
     }
 
-    mutating func observe(value: Double, labelset: LabelSet) {
+    func observe(value: Double, labelset: LabelSet) {
         var boundInstrument = observerHandles[labelset]
         if boundInstrument == nil {
             boundInstrument = DoubleObserverMetricHandleSdk()

--- a/Sources/OpenTelemetrySdk/Metrics/DoubleObserverMetricHandleSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/DoubleObserverMetricHandleSdk.swift
@@ -1,0 +1,26 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+struct DoubleObserverMetricHandleSdk: DoubleObserverMetricHandle {
+    
+     public private(set) var aggregator = LastValueAggregator<Double>()
+    
+    func observe(value: Double) {
+        aggregator.update(value: value)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/DoubleObserverMetricHandleSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/DoubleObserverMetricHandleSdk.swift
@@ -17,9 +17,8 @@ import Foundation
 import OpenTelemetryApi
 
 struct DoubleObserverMetricHandleSdk: DoubleObserverMetricHandle {
-    
-     public private(set) var aggregator = LastValueAggregator<Double>()
-    
+    public private(set) var aggregator = LastValueAggregator<Double>()
+
     func observe(value: Double) {
         aggregator.update(value: value)
     }

--- a/Sources/OpenTelemetrySdk/Metrics/Export/AggregationType.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/AggregationType.swift
@@ -1,0 +1,23 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public enum AggregationType {
+    case doubleSum
+    case intSum
+    case doubleSummary
+    case intSummary
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/Metric.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/Metric.swift
@@ -1,0 +1,31 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public struct Metric {
+    public private(set) var metricNamespace: String
+    public private(set) var metricName: String
+    public private(set) var metricDescription: String
+    public private(set) var aggregationType: AggregationType
+    public internal(set) var data = [MetricData]()
+
+    init(metricNamespace: String, metricName: String, desc: String, type: AggregationType) {
+        self.metricNamespace = metricNamespace
+        self.metricName = metricName
+        self.metricDescription = desc
+        self.aggregationType = type
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/Metric.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/Metric.swift
@@ -25,7 +25,7 @@ public struct Metric {
     init(metricNamespace: String, metricName: String, desc: String, type: AggregationType) {
         self.metricNamespace = metricNamespace
         self.metricName = metricName
-        self.metricDescription = desc
-        self.aggregationType = type
+        metricDescription = desc
+        aggregationType = type
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Export/MetricData.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/MetricData.swift
@@ -1,0 +1,36 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol MetricData {
+    var timestamp: Date { get set }
+    var labels: [String: String] { get set }
+}
+
+public struct SumData<T>: MetricData {
+    public var timestamp: Date
+    public var labels: [String: String] = [String: String]()
+    public var sum: T
+}
+
+public struct SummaryData<T>: MetricData {
+    public var timestamp: Date
+    public var labels: [String: String] = [String: String]()
+    public var count: Int
+    public var sum: T
+    public var min: T
+    public var max: T
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/MetricExporter.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/MetricExporter.swift
@@ -1,0 +1,32 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public enum MetricExporterResultCode {
+    case success
+    case failureNotRetryable
+    case failureRetryable
+}
+
+public protocol MetricExporter {
+    func export(metrics: [Metric], shouldCancel: () -> Bool) -> MetricExporterResultCode
+}
+
+struct NoopMetricExporter: MetricExporter {
+    func export(metrics: [Metric], shouldCancel: () -> Bool) -> MetricExporterResultCode {
+        return .success
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/MetricExporter.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/MetricExporter.swift
@@ -22,11 +22,11 @@ public enum MetricExporterResultCode {
 }
 
 public protocol MetricExporter {
-    func export(metrics: [Metric], shouldCancel: () -> Bool) -> MetricExporterResultCode
+    func export(metrics: [Metric], shouldCancel: (() -> Bool)?) -> MetricExporterResultCode
 }
 
 struct NoopMetricExporter: MetricExporter {
-    func export(metrics: [Metric], shouldCancel: () -> Bool) -> MetricExporterResultCode {
+    func export(metrics: [Metric], shouldCancel: (() -> Bool)?) -> MetricExporterResultCode {
         return .success
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Export/MetricProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/MetricProcessor.swift
@@ -16,7 +16,15 @@
 import Foundation
 
 public protocol MetricProcessor {
+    /// Finish the current collection cycle and return the metrics it holds.
+    /// This is called at the end of one collection cycle by the Controller.
+    /// MetricProcessor can use this to clear its Metrics (in case of stateless).
+    /// - Returns: The list of metrics from this cycle, which are to be exported.
     mutating func finishCollectionCycle() -> [Metric]
+    
+    /// Process the metric. This method is called once every collection interval.
+    /// - PArameters:
+    ///   - metric: the metric record.
     mutating func process(metric: Metric)
 }
 

--- a/Sources/OpenTelemetrySdk/Metrics/Export/MetricProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/MetricProcessor.swift
@@ -1,0 +1,30 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public protocol MetricProcessor {
+    mutating func finishCollectionCycle() -> [Metric]
+    mutating func process(metric: Metric)
+}
+
+struct NoopMetricProcessor: MetricProcessor {
+    func finishCollectionCycle() -> [Metric] {
+        return [Metric]()
+    }
+
+    func process(metric: Metric) {
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -22,13 +22,13 @@ class PushMetricController {
 
     let pushMetricQueue = DispatchQueue(label: "org.opentelemetry.PushMetricController.pushMetricQueue")
 
-    init(meters: [MeterRegistryKey: MeterSdk], metricProcessor: MetricProcessor, metricExporter: MetricExporter, pushInterval: TimeInterval, shouldCancel:@escaping  () -> Bool) {
+    init(meters: [MeterRegistryKey: MeterSdk], metricProcessor: MetricProcessor, metricExporter: MetricExporter, pushInterval: TimeInterval, shouldCancel: (() -> Bool)? = nil) {
         self.meters = meters
         self.metricProcessor = metricProcessor
         self.metricExporter = metricExporter
         self.pushInterval = pushInterval
         pushMetricQueue.asyncAfter(deadline: .now() + pushInterval) {
-            while !shouldCancel() {
+            while !(shouldCancel?() ?? false) {
                 let start = DispatchTime.now()
                 for index in meters.values.indices {
                     self.meters.values[index].collect()

--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -1,0 +1,48 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+import Foundation
+
+class PushMetricController {
+    public private(set) var pushInterval: TimeInterval
+    var metricExporter: MetricExporter
+    var metricProcessor: MetricProcessor
+    var meters: [MeterRegistryKey: MeterSdk]
+
+    let pushMetricQueue = DispatchQueue(label: "org.opentelemetry.PushMetricController.pushMetricQueue")
+
+    init(meters: [MeterRegistryKey: MeterSdk], metricProcessor: MetricProcessor, metricExporter: MetricExporter, pushInterval: TimeInterval, shouldCancel:@escaping  () -> Bool) {
+        self.meters = meters
+        self.metricProcessor = metricProcessor
+        self.metricExporter = metricExporter
+        self.pushInterval = pushInterval
+        pushMetricQueue.asyncAfter(deadline: .now() + pushInterval) {
+            while !shouldCancel() {
+                let start = DispatchTime.now()
+                for index in meters.values.indices {
+                    self.meters.values[index].collect()
+                }
+
+                let metricToExport = self.metricProcessor.finishCollectionCycle()
+
+                _ = metricExporter.export(metrics: metricToExport, shouldCancel: shouldCancel)
+                let timeInterval = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1000000000
+                let remainingWait = pushInterval - timeInterval
+                if remainingWait > 0 {
+                    usleep(UInt32(remainingWait * 1000000))
+                }
+            }
+        }
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/UngroupedBatcher.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/UngroupedBatcher.swift
@@ -1,0 +1,31 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+public struct UngroupedBatcher: MetricProcessor {
+    var metrics = [Metric]()
+
+    public mutating func finishCollectionCycle() -> [Metric] {
+        defer {
+            self.metrics = [Metric]()
+        }
+        return metrics
+    }
+
+    public mutating func process(metric: Metric) {
+        metrics.append(metric)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/UngroupedBatcher.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/UngroupedBatcher.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 
+/// Batcher which retains all dimensions/labels.
 public struct UngroupedBatcher: MetricProcessor {
     var metrics = [Metric]()
 

--- a/Sources/OpenTelemetrySdk/Metrics/InsObserverMetricHandle.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/InsObserverMetricHandle.swift
@@ -1,0 +1,40 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+struct IntObserverMetricSdk: IntObserverMetric {
+    public private(set) var observerHandles = [LabelSet: IntObserverMetricHandleSdk]()
+    let metricName: String
+    var callback: (IntObserverMetric) -> Void
+
+    mutating func observe(value: Int, labels: [String: String]) {
+        observe(value: value, labelset: LabelSet(labels: labels))
+    }
+
+    mutating func observe(value: Int, labelset: LabelSet) {
+        var boundInstrument = observerHandles[labelset]
+        if boundInstrument == nil {
+            boundInstrument = IntObserverMetricHandleSdk()
+            observerHandles[labelset] = boundInstrument
+        }
+        boundInstrument?.observe(value: value)
+    }
+
+    func invokeCallback() {
+        callback(self)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/IntObserverMetricHandle.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/IntObserverMetricHandle.swift
@@ -16,16 +16,21 @@
 import Foundation
 import OpenTelemetryApi
 
-struct IntObserverMetricSdk: IntObserverMetric {
+class IntObserverMetricSdk: IntObserverMetric {
     public private(set) var observerHandles = [LabelSet: IntObserverMetricHandleSdk]()
     let metricName: String
     var callback: (IntObserverMetric) -> Void
 
-    mutating func observe(value: Int, labels: [String: String]) {
+    init(metricName: String, callback: @escaping (IntObserverMetric) -> Void) {
+        self.metricName = metricName
+        self.callback = callback
+    }
+
+    func observe(value: Int, labels: [String: String]) {
         observe(value: value, labelset: LabelSet(labels: labels))
     }
 
-    mutating func observe(value: Int, labelset: LabelSet) {
+    func observe(value: Int, labelset: LabelSet) {
         var boundInstrument = observerHandles[labelset]
         if boundInstrument == nil {
             boundInstrument = IntObserverMetricHandleSdk()

--- a/Sources/OpenTelemetrySdk/Metrics/IntObserverMetricHandleSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/IntObserverMetricHandleSdk.swift
@@ -1,0 +1,26 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+struct IntObserverMetricHandleSdk: IntObserverMetricHandle {
+    
+     public private(set) var aggregator = LastValueAggregator<Int>()
+    
+    func observe(value: Int) {
+        aggregator.update(value: value)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/IntObserverMetricHandleSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/IntObserverMetricHandleSdk.swift
@@ -17,9 +17,8 @@ import Foundation
 import OpenTelemetryApi
 
 struct IntObserverMetricHandleSdk: IntObserverMetricHandle {
-    
-     public private(set) var aggregator = LastValueAggregator<Int>()
-    
+    public private(set) var aggregator = LastValueAggregator<Int>()
+
     func observe(value: Int) {
         aggregator.update(value: value)
     }

--- a/Sources/OpenTelemetrySdk/Metrics/LabelSetSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/LabelSetSdk.swift
@@ -14,11 +14,28 @@
 //
 
 import Foundation
+import OpenTelemetryApi
 
-open class BoundCounterMetric<T> {
-    public init() {}
+class LabelSetSdk: LabelSet {
+    internal var labelSetEncoded: String
 
-    open func add(value: T) {
-        fatalError()
+    required init(labels: [String: String]) {
+        labelSetEncoded = LabelSetSdk.getLabelSetEncoded(labels: labels)
+        super.init(labels: labels)
+    }
+
+    private static func getLabelSetEncoded(labels: [String: String]) -> String {
+        var output = ""
+        var isFirstLabel = true
+
+        labels.map { "\($0)=\($1)" }.sorted().forEach {
+            if !isFirstLabel {
+                output += ","
+            }
+            output += $0
+            isFirstLabel = false
+        }
+
+        return output
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/LabelSetSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/LabelSetSdk.swift
@@ -16,6 +16,7 @@
 import Foundation
 import OpenTelemetryApi
 
+/// LabelSet implementation.
 class LabelSetSdk: LabelSet {
     internal var labelSetEncoded: String
 

--- a/Sources/OpenTelemetrySdk/Metrics/MeasureMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeasureMetricSdk.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 import OpenTelemetryApi
- 
+
 internal class MeasureMetricSdk<T: SignedNumeric & Comparable>: MeasureMetric {
     public private(set) var boundInstruments = [LabelSet: BoundMeasureMetricSdkBase<T>]()
     let metricName: String
@@ -35,14 +35,6 @@ internal class MeasureMetricSdk<T: SignedNumeric & Comparable>: MeasureMetric {
 
     func bind(labels: [String: String]) -> BoundMeasureMetric<T> {
         return bind(labelset: LabelSet(labels: labels))
-    }
-
-    func record(inContext: SpanContext, value: T, labelset: LabelSet) {
-        fatalError()
-    }
-
-    func record(inContext: SpanContext, value: T, labels: [String: String]) {
-        fatalError()
     }
 
     func createMetric() -> BoundMeasureMetricSdkBase<T> {

--- a/Sources/OpenTelemetrySdk/Metrics/MeasureMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeasureMetricSdk.swift
@@ -1,0 +1,51 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+ 
+internal class MeasureMetricSdk<T: SignedNumeric & Comparable>: MeasureMetric {
+    public private(set) var boundInstruments = [LabelSet: BoundMeasureMetricSdkBase<T>]()
+    let metricName: String
+
+    init(name: String) {
+        metricName = name
+    }
+
+    func bind(labelset: LabelSet) -> BoundMeasureMetric<T> {
+        var boundInstrument = boundInstruments[labelset]
+        if boundInstrument == nil {
+            boundInstrument = createMetric()
+            boundInstruments[labelset] = boundInstrument!
+        }
+        return boundInstrument!
+    }
+
+    func bind(labels: [String: String]) -> BoundMeasureMetric<T> {
+        return bind(labelset: LabelSet(labels: labels))
+    }
+
+    func record(inContext: SpanContext, value: T, labelset: LabelSet) {
+        fatalError()
+    }
+
+    func record(inContext: SpanContext, value: T, labels: [String: String]) {
+        fatalError()
+    }
+
+    func createMetric() -> BoundMeasureMetricSdkBase<T> {
+        return BoundMeasureMetricSdk<T>()
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
@@ -16,7 +16,7 @@
 import Foundation
 import OpenTelemetryApi
 
-struct MeterSdk: Meter {
+class MeterSdk: Meter {
     fileprivate let collectLock = Lock()
     let meterName: String
     var metricProcessor: MetricProcessor
@@ -30,7 +30,12 @@ struct MeterSdk: Meter {
 
     var labelSet = LabelSet()
 
-    mutating func collect() {
+    init(meterName: String, metricProcessor: MetricProcessor) {
+        self.meterName = meterName
+        self.metricProcessor = metricProcessor
+    }
+
+    func collect() {
         collectLock.withLock {
             var boundInstrumentsToRemove = [LabelSet]()
 
@@ -148,7 +153,7 @@ struct MeterSdk: Meter {
                 }
                 metricProcessor.process(metric: metric)
             }
-            
+
             doubleObservers.forEach { observer in
                 let metricName = observer.key
                 let observerInstrument = observer.value
@@ -169,7 +174,7 @@ struct MeterSdk: Meter {
         }
     }
 
-    mutating func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
+    func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
         var counter = intCounters[name]
         if counter == nil {
             counter = CounterMetricSdk<Int>(name: name)
@@ -178,7 +183,7 @@ struct MeterSdk: Meter {
         return AnyCounterMetric<Int>(counter!)
     }
 
-    mutating func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
+    func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
         var counter = doubleCounters[name]
         if counter == nil {
             counter = CounterMetricSdk<Double>(name: name)
@@ -187,7 +192,7 @@ struct MeterSdk: Meter {
         return AnyCounterMetric<Double>(counter!)
     }
 
-    mutating func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
+    func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
         var measure = intMeasures[name]
         if measure == nil {
             measure = MeasureMetricSdk<Int>(name: name)
@@ -196,7 +201,7 @@ struct MeterSdk: Meter {
         return AnyMeasureMetric<Int>(measure!)
     }
 
-    mutating func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
+    func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
         var measure = doubleMeasures[name]
         if measure == nil {
             measure = MeasureMetricSdk<Double>(name: name)
@@ -205,7 +210,7 @@ struct MeterSdk: Meter {
         return AnyMeasureMetric<Double>(measure!)
     }
 
-    mutating func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
+    func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
         var observer = intObservers[name]
         if observer == nil {
             observer = IntObserverMetricSdk(metricName: name, callback: callback)
@@ -214,7 +219,7 @@ struct MeterSdk: Meter {
         return observer!
     }
 
-    mutating func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
+    func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
         var observer = doubleObservers[name]
         if observer == nil {
             observer = DoubleObserverMetricSdk(metricName: name, callback: callback)

--- a/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
@@ -1,0 +1,225 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+struct MeterSdk: Meter {
+    fileprivate let collectLock = Lock()
+    let meterName: String
+    var metricProcessor: MetricProcessor
+
+    var intCounters = [String: CounterMetricSdk<Int>]()
+    var doubleCounters = [String: CounterMetricSdk<Double>]()
+    var intMeasures = [String: MeasureMetricSdk<Int>]()
+    var doubleMeasures = [String: MeasureMetricSdk<Double>]()
+    var intObservers = [String: IntObserverMetricSdk]()
+    var doubleObservers = [String: DoubleObserverMetricSdk]()
+
+    var labelSet = LabelSet()
+
+    mutating func collect() {
+        collectLock.withLock {
+            var boundInstrumentsToRemove = [LabelSet]()
+
+            intCounters.forEach { counter in
+                let metricName = counter.key
+                let counterInstrument = counter.value
+
+                var metric = Metric(metricNamespace: meterName, metricName: metricName, desc: meterName + metricName, type: AggregationType.intSum)
+
+                counterInstrument.boundInstruments.forEach { handle in
+                    let labelSet = handle.key
+                    let aggregator = handle.value.getAggregator()
+                    aggregator.checkpoint()
+
+                    var metricData = aggregator.toMetricData()
+                    metricData.labels = labelSet.labels
+                    metric.data.append(metricData)
+
+                    switch handle.value.status {
+                    case .updatePending:
+                        handle.value.status = .noPendingUpdate
+                    case .noPendingUpdate:
+                        handle.value.status = .candidateForRemoval
+                    case .candidateForRemoval:
+                        boundInstrumentsToRemove.append(labelSet)
+                    case .bound:
+                        break
+                    }
+                }
+
+                metricProcessor.process(metric: metric)
+                boundInstrumentsToRemove.forEach { boundInstrument in
+                    counterInstrument.unBind(labelSet: boundInstrument)
+                }
+                boundInstrumentsToRemove.removeAll()
+            }
+
+            doubleCounters.forEach { counter in
+                let metricName = counter.key
+                let counterInstrument = counter.value
+
+                var metric = Metric(metricNamespace: meterName, metricName: metricName, desc: meterName + metricName, type: AggregationType.doubleSum)
+
+                counterInstrument.boundInstruments.forEach { boundInstrument in
+                    let labelSet = boundInstrument.key
+                    let aggregator = boundInstrument.value.getAggregator()
+                    aggregator.checkpoint()
+
+                    var metricData = aggregator.toMetricData()
+                    metricData.labels = labelSet.labels
+                    metric.data.append(metricData)
+
+                    switch boundInstrument.value.status {
+                    case .updatePending:
+                        boundInstrument.value.status = .noPendingUpdate
+                    case .noPendingUpdate:
+                        boundInstrument.value.status = .candidateForRemoval
+                    case .candidateForRemoval:
+                        boundInstrumentsToRemove.append(labelSet)
+                    case .bound:
+                        break
+                    }
+                }
+
+                metricProcessor.process(metric: metric)
+                boundInstrumentsToRemove.forEach { boundInstrument in
+                    counterInstrument.unBind(labelSet: boundInstrument)
+                }
+                boundInstrumentsToRemove.removeAll()
+            }
+
+            intMeasures.forEach { measure in
+                let metricName = measure.key
+                let measureInstrument = measure.value
+                var metric = Metric(metricNamespace: meterName, metricName: metricName, desc: meterName + metricName, type: AggregationType.intSummary)
+                measureInstrument.boundInstruments.forEach { boundInstrument in
+                    let labelSet = boundInstrument.key
+                    let aggregator = boundInstrument.value.getAggregator()
+                    aggregator.checkpoint()
+                    var metricData = aggregator.toMetricData()
+                    metricData.labels = labelSet.labels
+                    metric.data.append(metricData)
+                }
+                metricProcessor.process(metric: metric)
+            }
+
+            doubleMeasures.forEach { measure in
+                let metricName = measure.key
+                let measureInstrument = measure.value
+                var metric = Metric(metricNamespace: meterName, metricName: metricName, desc: meterName + metricName, type: AggregationType.doubleSummary)
+                measureInstrument.boundInstruments.forEach { boundInstrument in
+                    let labelSet = boundInstrument.key
+                    let aggregator = boundInstrument.value.getAggregator()
+                    aggregator.checkpoint()
+                    var metricData = aggregator.toMetricData()
+                    metricData.labels = labelSet.labels
+                    metric.data.append(metricData)
+                }
+                metricProcessor.process(metric: metric)
+            }
+
+            intObservers.forEach { observer in
+                let metricName = observer.key
+                let observerInstrument = observer.value
+                var metric = Metric(metricNamespace: meterName, metricName: metricName, desc: meterName + metricName, type: AggregationType.intSum)
+                observerInstrument.invokeCallback()
+
+                observerInstrument.observerHandles.forEach { handle in
+                    let labelSet = handle.key
+                    let aggregator = handle.value.aggregator
+                    aggregator.checkpoint()
+                    var metricData = aggregator.toMetricData()
+                    metricData.labels = labelSet.labels
+                    metric.data.append(metricData)
+                }
+                metricProcessor.process(metric: metric)
+            }
+            
+            doubleObservers.forEach { observer in
+                let metricName = observer.key
+                let observerInstrument = observer.value
+                var metric = Metric(metricNamespace: meterName, metricName: metricName, desc: meterName + metricName, type: AggregationType.doubleSum)
+                observerInstrument.invokeCallback()
+
+                observerInstrument.observerHandles.forEach { handle in
+                    let labelSet = handle.key
+                    let aggregator = handle.value.aggregator
+                    aggregator.checkpoint()
+                    var metricData = aggregator.toMetricData()
+                    metricData.labels = labelSet.labels
+                    metric.data.append(metricData)
+                }
+
+                metricProcessor.process(metric: metric)
+            }
+        }
+    }
+
+    mutating func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
+        var counter = intCounters[name]
+        if counter == nil {
+            counter = CounterMetricSdk<Int>(name: name)
+            intCounters[name] = counter!
+        }
+        return AnyCounterMetric<Int>(counter!)
+    }
+
+    mutating func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
+        var counter = doubleCounters[name]
+        if counter == nil {
+            counter = CounterMetricSdk<Double>(name: name)
+            doubleCounters[name] = counter!
+        }
+        return AnyCounterMetric<Double>(counter!)
+    }
+
+    mutating func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
+        var measure = intMeasures[name]
+        if measure == nil {
+            measure = MeasureMetricSdk<Int>(name: name)
+            intMeasures[name] = measure!
+        }
+        return AnyMeasureMetric<Int>(measure!)
+    }
+
+    mutating func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
+        var measure = doubleMeasures[name]
+        if measure == nil {
+            measure = MeasureMetricSdk<Double>(name: name)
+            doubleMeasures[name] = measure
+        }
+        return AnyMeasureMetric<Double>(measure!)
+    }
+
+    mutating func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
+        var observer = intObservers[name]
+        if observer == nil {
+            observer = IntObserverMetricSdk(metricName: name, callback: callback)
+            intObservers[name] = observer!
+        }
+        return observer!
+    }
+
+    mutating func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
+        var observer = doubleObservers[name]
+        if observer == nil {
+            observer = DoubleObserverMetricSdk(metricName: name, callback: callback)
+            doubleObservers[name] = observer!
+        }
+        return observer!
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
@@ -28,11 +28,13 @@ class MeterSdk: Meter {
     var intObservers = [String: IntObserverMetricSdk]()
     var doubleObservers = [String: DoubleObserverMetricSdk]()
 
-    var labelSet = LabelSet()
-
     init(meterName: String, metricProcessor: MetricProcessor) {
         self.meterName = meterName
         self.metricProcessor = metricProcessor
+    }
+
+    func getLabelSet(labels: [String: String]) -> LabelSet {
+        return LabelSetSdk(labels: labels)
     }
 
     func collect() {

--- a/Sources/OpenTelemetrySdk/Metrics/RecordStatus.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/RecordStatus.swift
@@ -16,8 +16,23 @@
 import Foundation
 
 enum RecordStatus {
+    /// This applies to bound instruments that was created in response to user explicitly calling Bind.
+    /// They must never be removed.
     case bound
+    
+    /// This applies to bound instruments that was created by MeterSDK intended to be short lived one.
+    /// They currently have pending updates to be sent to MetricProcessor/Batcher/Exporter.
+    /// Collect will move them to NoPendingUpdate after exporting updates.
     case updatePending
+    
+    /// This status is applied to UpdatePending instruments after Collect() is done.
+    /// This will be moved to  CandidateForRemoval during the next Collect() cycle.
+    /// If an update occurs, the instrument promotes them to UpdatePending.
     case noPendingUpdate
+    
+    /// This also applies to bound instruments that was created by MeterSDK intended to be short lived one.
+    /// They have no pending update and has not been used since atleast one collect() cycle.
+    /// Collect will set this status to all noPendingUpdate bound instruments after finishing a collect pass.
+    /// Instrument records with this status are removed after collect().
     case candidateForRemoval
 }

--- a/Sources/OpenTelemetrySdk/Metrics/RecordStatus.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/RecordStatus.swift
@@ -1,0 +1,23 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+enum RecordStatus {
+    case bound
+    case updatePending
+    case noPendingUpdate
+    case candidateForRemoval
+}

--- a/Sources/OpenTelemetrySdk/OpenTelemetrySdk.swift
+++ b/Sources/OpenTelemetrySdk/OpenTelemetrySdk.swift
@@ -22,23 +22,21 @@ import OpenTelemetryApi
 public struct OpenTelemetrySDK {
     public static var instance = OpenTelemetrySDK()
 
-    /// TracerFactory returned by OpenTelemetry.getTracerFactory().
-    public var tracerFactory: TracerSdkProvider {
+    public var tracerProvider: TracerSdkProvider {
         return OpenTelemetry.instance.tracerProvider as! TracerSdkProvider
     }
 
-//    /// Meter returned by OpenTelemetry.getMeter().
-//    public var meter: MeterSdkFactory  {
-//            return OpenTelemetry.instance.meterFactory as! MeterSdkFactory//
-//    }
+    public var meter: MeterSdkProvider {
+        return OpenTelemetry.instance.meterProvider as! MeterSdkProvider
+    }
 
-    /// Context manager returned by OpenTelemetry.getCorrelationContextManager().
     public var correlationContextManager: CorrelationContextManagerSdk {
         return OpenTelemetry.instance.contextManager as! CorrelationContextManagerSdk
     }
 
     private init() {
         OpenTelemetry.registerTracerProvider(tracerProvider: TracerSdkProvider())
+        OpenTelemetry.registerMeterProvider(meterProvider: MeterSdkProvider())
         OpenTelemetry.registerCorrelationContextManager(correlationContextManager: CorrelationContextManagerSdk())
     }
 }

--- a/Sources/OpenTelemetrySdk/Trace/TracerSdkProvider.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TracerSdkProvider.swift
@@ -22,16 +22,15 @@ public class TracerSdkProvider: TracerProvider {
     private var sharedState: TracerSharedState
 
     /// Returns a new TracerSdkProvider with default Clock, IdsGenerator and Resource.
-    public convenience override init() {
+    public convenience init() {
         self.init(clock: MillisClock(), idsGenerator: RandomIdsGenerator(), resource: EnvVarResource.resource)
     }
 
     init(clock: Clock, idsGenerator: IdsGenerator, resource: Resource) {
         sharedState = TracerSharedState(clock: clock, idsGenerator: idsGenerator, resource: resource)
-        super.init()
     }
 
-    public override func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Tracer {
+    public func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Tracer {
         let instrumentationLibraryInfo = InstrumentationLibraryInfo(name: instrumentationName, version: instrumentationVersion ?? "")
         if let tracer = tracerProvider[instrumentationLibraryInfo] {
             return tracer

--- a/Tests/OpenTelemetryApiTests/Metrics/MeterFactoryBaseTests.swift
+++ b/Tests/OpenTelemetryApiTests/Metrics/MeterFactoryBaseTests.swift
@@ -1,0 +1,106 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import OpenTelemetryApi
+import XCTest
+
+final class MeterFactoryBaseTests: XCTestCase {
+    override func setUp() {
+        MeterFactoryBase.defaultFactory.reset()
+    }
+
+    func testDefault() {
+        let defaultMeter = MeterFactoryBase.defaultFactory.getMeter(name: "")
+        XCTAssert(defaultMeter is ProxyMeter)
+        let otherMeter = MeterFactoryBase.defaultFactory.getMeter(name: "named meter")
+        XCTAssert(otherMeter is ProxyMeter)
+        XCTAssert(defaultMeter === otherMeter)
+        
+        let counter = defaultMeter.createDoubleCounter(name: "ctr")
+        XCTAssert(counter.internalCounter is NoopCounterMetric<Double>)
+    }
+
+    func testSetDefault() {
+        let factory = TestMeter()
+        MeterFactoryBase.setDefault(meterFactory: factory)
+        XCTAssert(MeterFactoryBase.initialized)
+
+        let defaultMeter = MeterFactoryBase.defaultFactory.getMeter(name: "")
+        XCTAssert(defaultMeter is TestNoopMeter)
+        
+        let otherMeter = MeterFactoryBase.defaultFactory.getMeter(name: "named meter")
+        XCTAssert(defaultMeter !== otherMeter)
+        
+        let counter = defaultMeter.createIntCounter(name: "ctr")
+        XCTAssert(counter.internalCounter is NoopCounterMetric<Int>)
+    }
+
+    func testSetDefaultTwice() {
+        let factory = TestMeter()
+        MeterFactoryBase.setDefault(meterFactory: factory)
+
+        let factory2 = TestMeter()
+        MeterFactoryBase.setDefault(meterFactory: factory2)
+
+        XCTAssert(MeterFactoryBase.defaultFactory === factory)
+    }
+
+    func testUpdateDefault_CachedTracer() {
+        let defaultMeter = MeterFactoryBase.defaultFactory.getMeter(name: "")
+        let noOpCounter = defaultMeter.createDoubleCounter(name: "ctr")
+        XCTAssert(noOpCounter.internalCounter is NoopCounterMetric<Double>)
+
+        MeterFactoryBase.setDefault(meterFactory: TestMeter())
+        let counter = defaultMeter.createDoubleCounter(name: "ctr")
+        XCTAssert(counter.internalCounter is NoopCounterMetric<Double>)
+
+        let newdefaultMeter = MeterFactoryBase.defaultFactory.getMeter(name: "")
+        XCTAssert(defaultMeter !== newdefaultMeter)
+    }
+}
+
+class TestMeter: MeterFactoryBase {
+    override func getMeter(name: String, version: String? = nil) -> Meter {
+        return TestNoopMeter()
+    }
+}
+
+class TestNoopMeter: Meter {
+    var labelSet = LabelSet()
+
+    func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
+        return AnyCounterMetric<Int>(NoopCounterMetric<Int>())
+    }
+
+    func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
+        return AnyCounterMetric<Double>(NoopCounterMetric<Double>())
+    }
+
+    func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
+        return AnyMeasureMetric<Int>(NoopMeasureMetric<Int>())
+    }
+
+    func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
+        return AnyMeasureMetric<Double>(NoopMeasureMetric<Double>())
+    }
+
+    func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
+        return NoopIntObserverMetric()
+    }
+
+    func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
+        return NoopDoubleObserverMetric()
+    }
+}

--- a/Tests/OpenTelemetryApiTests/Metrics/MeterFactoryBaseTests.swift
+++ b/Tests/OpenTelemetryApiTests/Metrics/MeterFactoryBaseTests.swift
@@ -27,7 +27,7 @@ final class MeterFactoryBaseTests: XCTestCase {
         let otherMeter = MeterFactoryBase.defaultFactory.getMeter(name: "named meter")
         XCTAssert(otherMeter is ProxyMeter)
         XCTAssert(defaultMeter === otherMeter)
-        
+
         let counter = defaultMeter.createDoubleCounter(name: "ctr")
         XCTAssert(counter.internalCounter is NoopCounterMetric<Double>)
     }
@@ -39,10 +39,10 @@ final class MeterFactoryBaseTests: XCTestCase {
 
         let defaultMeter = MeterFactoryBase.defaultFactory.getMeter(name: "")
         XCTAssert(defaultMeter is TestNoopMeter)
-        
+
         let otherMeter = MeterFactoryBase.defaultFactory.getMeter(name: "named meter")
         XCTAssert(defaultMeter !== otherMeter)
-        
+
         let counter = defaultMeter.createIntCounter(name: "ctr")
         XCTAssert(counter.internalCounter is NoopCounterMetric<Int>)
     }
@@ -78,8 +78,6 @@ class TestMeter: MeterFactoryBase {
 }
 
 class TestNoopMeter: Meter {
-    var labelSet = LabelSet()
-
     func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
         return AnyCounterMetric<Int>(NoopCounterMetric<Int>())
     }
@@ -102,5 +100,9 @@ class TestNoopMeter: Meter {
 
     func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
         return NoopDoubleObserverMetric()
+    }
+
+    func getLabelSet(labels: [String: String]) -> LabelSet {
+        return LabelSet.empty
     }
 }

--- a/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/CounterSumAggregatorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/CounterSumAggregatorTests.swift
@@ -1,0 +1,63 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class MeterFactoryBaseTests: XCTestCase {
+    public func testAggregatesCorrectlyWhenMultipleThreadsUpdatesInt() {
+        // create an aggregator
+        let aggregator = CounterSumAggregator<Int>()
+        var sum = aggregator.toMetricData() as! SumData<Int>
+
+        // we start with 0.
+        XCTAssertEqual(sum.sum, 0)
+
+        DispatchQueue.concurrentPerform(iterations: 10) { _ in
+            for _ in 0 ..< 10000 {
+                aggregator.update(value: 10)
+            }
+        }
+
+        // check point.
+        aggregator.checkpoint()
+        sum = aggregator.toMetricData() as! SumData<Int>
+
+        // 100000 times 10 by each thread
+        XCTAssertEqual(sum.sum, 1000000)
+    }
+    
+    public func testAggregatesCorrectlyWhenMultipleThreadsUpdatesDouble() {
+        // create an aggregator
+        let aggregator = CounterSumAggregator<Double>()
+        var sum = aggregator.toMetricData() as! SumData<Double>
+
+        // we start with 0.0
+        XCTAssertEqual(sum.sum, 0.0)
+
+        DispatchQueue.concurrentPerform(iterations: 10) { _ in
+            for _ in 0 ..< 10000 {
+                aggregator.update(value: 10.5)
+            }
+        }
+
+        // check point.
+        aggregator.checkpoint()
+        sum = aggregator.toMetricData() as! SumData<Double>
+
+        // 100000 times 10.5 by each thread
+        XCTAssertEqual(sum.sum, 1050000)
+    }
+}

--- a/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/LastValueAggregatorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/LastValueAggregatorTests.swift
@@ -1,0 +1,55 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class LastValueAggregatorTests: XCTestCase {
+    public func testAggregatesCorrectlyInt() {
+        // create an aggregator
+        let aggregator = LastValueAggregator<Int>()
+        var sum = aggregator.toMetricData() as! SumData<Int>
+
+        // we start with 0.
+        XCTAssertEqual(0, sum.sum)
+
+        aggregator.update(value: 10)
+        aggregator.update(value: 20)
+        aggregator.update(value: 30)
+        aggregator.update(value: 40)
+
+        aggregator.checkpoint()
+        sum = aggregator.toMetricData() as! SumData<Int>
+        XCTAssertEqual(40, sum.sum)
+    }
+    
+    public func testAggregatesCorrectlyDouble() {
+        // create an aggregator
+        let aggregator = LastValueAggregator<Double>()
+        var sum = aggregator.toMetricData() as! SumData<Double>
+
+        // we start with 0.
+        XCTAssertEqual(0.0, sum.sum)
+
+        aggregator.update(value: 40.5)
+        aggregator.update(value: 30.5)
+        aggregator.update(value: 20.5)
+        aggregator.update(value: 10.5)
+
+        aggregator.checkpoint()
+        sum = aggregator.toMetricData() as! SumData<Double>
+        XCTAssertEqual(10.5, sum.sum)
+    }
+}

--- a/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/MeasureMixMaxSumCountAggregatorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/MeasureMixMaxSumCountAggregatorTests.swift
@@ -1,0 +1,83 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class MeasureMixMaxSumCountAggregatorTests: XCTestCase {
+    public func testAggregatesCorrectlyWhenMultipleThreadsUpdatesInt() {
+        // create an aggregator
+        let aggregator = MeasureMinMaxSumCountAggregator<Int>()
+        var summary = aggregator.toMetricData() as! SummaryData<Int>
+
+        // we start with 0.
+        XCTAssertEqual(0, summary.sum)
+        XCTAssertEqual(0, summary.count)
+
+        DispatchQueue.concurrentPerform(iterations: 10) { _ in
+            for _ in 0 ..< 10000 {
+                aggregator.update(value: 10)
+                aggregator.update(value: 50)
+                aggregator.update(value: 100)
+            }
+        }
+
+        // check point.
+        aggregator.checkpoint()
+        summary = aggregator.toMetricData() as! SummaryData<Int>
+
+        // 100000 times (10+50+100) by each thread.
+        XCTAssertEqual(16000000, summary.sum)
+
+        // 100000 times 3 by each thread
+        XCTAssertEqual(300000, summary.count)
+
+        // Min and Max are 10 and 100
+        XCTAssertEqual(10, summary.min)
+        XCTAssertEqual(100, summary.max)
+    }
+    
+    public func testAggregatesCorrectlyWhenMultipleThreadsUpdatesDouble() {
+           // create an aggregator
+           let aggregator = MeasureMinMaxSumCountAggregator<Double>()
+           var summary = aggregator.toMetricData() as! SummaryData<Double>
+
+           // we start with 0.0
+           XCTAssertEqual(0, summary.sum)
+           XCTAssertEqual(0, summary.count)
+
+           DispatchQueue.concurrentPerform(iterations: 10) { _ in
+               for _ in 0 ..< 10000 {
+                aggregator.update(value: 10.0)
+                aggregator.update(value: 50.0)
+                aggregator.update(value: 100.0)
+               }
+           }
+
+           // check point.
+           aggregator.checkpoint()
+           summary = aggregator.toMetricData() as! SummaryData<Double>
+
+           // 100000 times (10+50+100) by each thread.
+        XCTAssertEqual(16000000.0, summary.sum)
+
+           // 100000 times 3 by each thread
+        XCTAssertEqual(300000, summary.count)
+
+           // Min and Max are 10 and 100
+        XCTAssertEqual(10.0, summary.min)
+        XCTAssertEqual(100.0, summary.max)
+       }
+}

--- a/Tests/OpenTelemetrySdkTests/Metrics/CounterTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/CounterTests.swift
@@ -21,8 +21,8 @@ final class CounterTests: XCTestCase {
     public func testIntCounterBoundInstrumentsStatusUpdatedCorrectlySingleThread() {
         let testProcessor = TestMetricProcessor()
 
-        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
-        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let meterSharedState = MeterSharedState(metricProcessor: testProcessor)
+        let meter = MeterSdkProvider(meterSharedState: meterSharedState).get(instrumentationName: "library1") as! MeterSdk
         let testCounter = meter.createIntCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Int>
 
         let labels1 = ["dim1": "value1"]
@@ -82,8 +82,8 @@ final class CounterTests: XCTestCase {
 
     public func testDoubleCounterBoundInstrumentsStatusUpdatedCorrectlySingleThread() {
         let testProcessor = TestMetricProcessor()
-        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
-        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let meterSharedState = MeterSharedState(metricProcessor: testProcessor)
+        let meter = MeterSdkProvider(meterSharedState: meterSharedState).get(instrumentationName: "library1") as! MeterSdk
         let testCounter = meter.createDoubleCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Double>
 
         let labels1 = ["dim1": "value1"]
@@ -143,8 +143,8 @@ final class CounterTests: XCTestCase {
 
     public func testIntCounterBoundInstrumentsStatusUpdatedCorrectlyMultiThread() {
         let testProcessor = TestMetricProcessor()
-        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
-        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let meterSharedState = MeterSharedState(metricProcessor: testProcessor)
+        let meter = MeterSdkProvider(meterSharedState: meterSharedState).get(instrumentationName: "library1") as! MeterSdk
         let testCounter = meter.createIntCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Int>
 
         let labels1 = ["dim1": "value1"]
@@ -192,8 +192,8 @@ final class CounterTests: XCTestCase {
 
     public func testDoubleCounterBoundInstrumentsStatusUpdatedCorrectlyMultiThread() {
         let testProcessor = TestMetricProcessor()
-        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
-        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let meterSharedState = MeterSharedState(metricProcessor: testProcessor)
+        let meter = MeterSdkProvider(meterSharedState: meterSharedState).get(instrumentationName: "library1") as! MeterSdk
         let testCounter = meter.createDoubleCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Double>
 
         let labels1 = ["dim1": "value1"]

--- a/Tests/OpenTelemetrySdkTests/Metrics/CounterTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/CounterTests.swift
@@ -1,0 +1,241 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class CounterTests: XCTestCase {
+    public func testIntCounterBoundInstrumentsStatusUpdatedCorrectlySingleThread() {
+        let testProcessor = TestMetricProcessor()
+
+        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
+        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let testCounter = meter.createIntCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Int>
+
+        let labels1 = ["dim1": "value1"]
+        let ls1 = meter.getLabelSet(labels: labels1)
+        let labels2 = ["dim1": "value2"]
+        let ls2 = meter.getLabelSet(labels: labels2)
+        let labels3 = ["dim1": "value3"]
+        let ls3 = meter.getLabelSet(labels: labels3)
+
+        // We have ls1, ls2, ls3
+        // ls1 and ls3 are not bound so they should removed when no usage for a Collect cycle.
+        // ls2 is bound by user.
+        testCounter.add(  value: 100, labelset: ls1)
+        testCounter.add(  value: 10, labelset: ls1)
+        // initial status for temp bound instruments are UpdatePending.
+        XCTAssertEqual(RecordStatus.updatePending, testCounter.boundInstruments[ls1]?.status)
+
+        let boundCounterLabel2 = testCounter.bind(labelset: ls2)
+        boundCounterLabel2.add(  value: 200)
+        // initial/forever status for user bound instruments are Bound.
+        XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
+
+        testCounter.add(  value: 200, labelset: ls3)
+        testCounter.add(  value: 10, labelset: ls3)
+        // initial status for temp bound instruments are UpdatePending.
+        XCTAssertEqual(RecordStatus.updatePending, testCounter.boundInstruments[ls3]?.status)
+
+        // This collect should mark ls1, ls3 as noPendingUpdate, leave ls2 untouched.
+        meter.collect()
+
+        // Validate collect() has marked records correctly.
+        XCTAssertEqual(RecordStatus.noPendingUpdate, testCounter.boundInstruments[ls1]?.status)
+        XCTAssertEqual(RecordStatus.noPendingUpdate, testCounter.boundInstruments[ls3]?.status)
+        XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
+
+        // Use ls1 again, so that it'll be promoted to UpdatePending
+        testCounter.add(  value: 100, labelset: ls1)
+
+        // This collect should mark ls1 as noPendingUpdate, leave ls2 untouched.
+        // And ls3 as candidateForRemoval, as it was not used since last Collect
+        meter.collect()
+
+        // Validate collect() has marked records correctly.
+        XCTAssertEqual(RecordStatus.noPendingUpdate, testCounter.boundInstruments[ls1]?.status)
+        XCTAssertEqual(RecordStatus.candidateForRemoval, testCounter.boundInstruments[ls3]?.status)
+        XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
+
+        // This collect should mark
+        // ls1 as candidateForRemoval as it was not used since last Collect
+        // leave ls2 untouched.
+        // ls3 should be physically removed as it remained candidateForRemoval during an entire Collect cycle.
+        meter.collect()
+        XCTAssertEqual(RecordStatus.candidateForRemoval, testCounter.boundInstruments[ls1]?.status)
+        XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
+        XCTAssertNil(testCounter.boundInstruments[ls3])
+    }
+
+    public func testDoubleCounterBoundInstrumentsStatusUpdatedCorrectlySingleThread() {
+        let testProcessor = TestMetricProcessor()
+        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
+        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let testCounter = meter.createDoubleCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Double>
+
+        let labels1 = ["dim1": "value1"]
+        let ls1 = meter.getLabelSet(labels: labels1)
+        let labels2 = ["dim1": "value2"]
+        let ls2 = meter.getLabelSet(labels: labels2)
+        let labels3 = ["dim1": "value3"]
+        let ls3 = meter.getLabelSet(labels: labels3)
+
+        // We have ls1, ls2, ls3
+        // ls1 and ls3 are not bound so they should removed when no usage for a Collect cycle.
+        // ls2 is bound by user.
+        testCounter.add(  value: 100.0, labelset: ls1)
+        testCounter.add(  value: 10.0, labelset: ls1)
+        // initial status for temp bound instruments are UpdatePending.
+        XCTAssertEqual(RecordStatus.updatePending, testCounter.boundInstruments[ls1]?.status)
+
+        let boundCounterLabel2 = testCounter.bind(labelset: ls2)
+        boundCounterLabel2.add(  value: 200.0)
+        // initial/forever status for user bound instruments are Bound.
+        XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
+
+        testCounter.add(  value: 200.0, labelset: ls3)
+        testCounter.add(  value: 10.0, labelset: ls3)
+        // initial status for temp bound instruments are UpdatePending.
+        XCTAssertEqual(RecordStatus.updatePending, testCounter.boundInstruments[ls3]?.status)
+
+        // This collect should mark ls1, ls3 as noPendingUpdate, leave ls2 untouched.
+        meter.collect()
+
+        // Validate collect() has marked records correctly.
+        XCTAssertEqual(RecordStatus.noPendingUpdate, testCounter.boundInstruments[ls1]?.status)
+        XCTAssertEqual(RecordStatus.noPendingUpdate, testCounter.boundInstruments[ls3]?.status)
+        XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
+
+        // Use ls1 again, so that it'll be promoted to UpdatePending
+        testCounter.add(  value: 100.0, labelset: ls1)
+
+        // This collect should mark ls1 as noPendingUpdate, leave ls2 untouched.
+        // And ls3 as candidateForRemoval, as it was not used since last Collect
+        meter.collect()
+
+        // Validate collect() has marked records correctly.
+        XCTAssertEqual(RecordStatus.noPendingUpdate, testCounter.boundInstruments[ls1]?.status)
+        XCTAssertEqual(RecordStatus.candidateForRemoval, testCounter.boundInstruments[ls3]?.status)
+        XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
+
+        // This collect should mark
+        // ls1 as candidateForRemoval as it was not used since last Collect
+        // leave ls2 untouched.
+        // ls3 should be physically removed as it remained candidateForRemoval during an entire Collect cycle.
+        meter.collect()
+        XCTAssertEqual(RecordStatus.candidateForRemoval, testCounter.boundInstruments[ls1]?.status)
+        XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
+        XCTAssertNil(testCounter.boundInstruments[ls3])
+    }
+
+    public func testIntCounterBoundInstrumentsStatusUpdatedCorrectlyMultiThread() {
+        let testProcessor = TestMetricProcessor()
+        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
+        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let testCounter = meter.createIntCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Int>
+
+        let labels1 = ["dim1": "value1"]
+        let ls1 = meter.getLabelSet(labels: labels1)
+
+        // Call metric update with ls1 so that ls1 wont be brand new labelset when doing multi-thread test.
+        testCounter.add(  value: 100, labelset: ls1)
+        testCounter.add(  value: 10, labelset: ls1)
+
+        // This collect should mark ls1 NoPendingUpdate
+        meter.collect()
+
+        // Validate collect() has marked records correctly.
+        XCTAssertEqual(RecordStatus.noPendingUpdate, testCounter.boundInstruments[ls1]?.status)
+
+        // Another collect(). This collect should mark ls1 as CandidateForRemoval.
+        meter.collect()
+        XCTAssertEqual(RecordStatus.candidateForRemoval, testCounter.boundInstruments[ls1]?.status)
+
+        let mygroup = DispatchGroup()
+        DispatchQueue.global().async(group: mygroup) {
+            for _ in 0 ..< 5 {
+                meter.collect()
+            }
+        }
+        DispatchQueue.global().async(group: mygroup) {
+            for _ in 0 ..< 5 {
+                testCounter.add(  value: 100, labelset: ls1)
+            }
+        }
+        mygroup.wait()
+
+        // Validate that the exported record doesn't miss any update.
+        // The Add(100) value must have already been exported, or must be exported in the next Collect().
+        meter.collect()
+        var sum = 0
+        testProcessor.metrics.forEach {
+            $0.data.forEach {
+                sum += ($0 as! SumData<Int>).sum
+            }
+        }
+        // 610 = 110 from initial update, 500 from the multi-thread test case.
+        XCTAssertEqual(610, sum)
+    }
+
+    public func testDoubleCounterBoundInstrumentsStatusUpdatedCorrectlyMultiThread() {
+        let testProcessor = TestMetricProcessor()
+        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
+        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let testCounter = meter.createDoubleCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Double>
+
+        let labels1 = ["dim1": "value1"]
+        let ls1 = meter.getLabelSet(labels: labels1)
+
+        // Call metric update with ls1 so that ls1 wont be brand new labelset when doing multi-thread test.
+        testCounter.add(  value: 100.0, labelset: ls1)
+        testCounter.add(  value: 10.0, labelset: ls1)
+
+        // This collect should mark ls1 NoPendingUpdate
+        meter.collect()
+
+        // Validate collect() has marked records correctly.
+        XCTAssertEqual(RecordStatus.noPendingUpdate, testCounter.boundInstruments[ls1]?.status)
+
+        // Another collect(). This collect should mark ls1 as CandidateForRemoval.
+        meter.collect()
+        XCTAssertEqual(RecordStatus.candidateForRemoval, testCounter.boundInstruments[ls1]?.status)
+
+        let mygroup = DispatchGroup()
+        DispatchQueue.global().async(group: mygroup) {
+            for _ in 0 ..< 5 {
+                meter.collect()
+            }
+        }
+        DispatchQueue.global().async(group: mygroup) {
+            for _ in 0 ..< 5 {
+                testCounter.add(  value: 100.0, labelset: ls1)
+            }
+        }
+        mygroup.wait()
+
+        // Validate that the exported record doesn't miss any update.
+        // The Add(100) value must have already been exported, or must be exported in the next Collect().
+        meter.collect()
+        var sum = 0.0
+        testProcessor.metrics.forEach {
+            $0.data.forEach {
+                sum += ($0 as! SumData<Double>).sum
+            }
+        }
+        // 610 = 110 from initial update, 500 from the multi-thread test case.
+        XCTAssertEqual(610.0, sum)
+    }
+}

--- a/Tests/OpenTelemetrySdkTests/Metrics/LabelSetSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/LabelSetSdkTests.swift
@@ -1,0 +1,46 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class LabelSetSdkTests: XCTestCase {
+    func testRemovesDuplicates() {
+        var labels = [String: String]()
+        labels.updateValue("value1", forKey: "dim1")
+        labels.updateValue("value2", forKey: "dim1")
+        labels.updateValue("value3", forKey: "dim3")
+        labels.updateValue("value4", forKey: "dim4")
+
+        let labelSet = LabelSetSdk(labels: labels)
+        XCTAssertEqual(labelSet.labels.count, 3)
+        XCTAssertEqual(labelSet.labels["dim1"], "value2")
+        XCTAssertEqual(labelSet.labels["dim3"], "value3")
+        XCTAssertEqual(labelSet.labels["dim4"], "value4")
+    }
+
+    func testLabelSetEncodingIsSameInDifferentOrder() {
+        let labels1 = ["dim1": "value1","dim2":"value2","dim3": "value3" ]
+        // Construct labelset some labels.
+        let labelSet1 = LabelSetSdk(labels: labels1)
+
+        let labels2 = ["dim3": "value3","dim2":"value2","dim1": "value1" ]
+        // Construct another labelset with same labels but in different order.
+        let labelSet2 = LabelSetSdk(labels: labels2)
+
+        XCTAssertEqual(labelSet1, labelSet2)
+        XCTAssertEqual(labelSet1.labelSetEncoded, labelSet2.labelSetEncoded)
+    }
+}

--- a/Tests/OpenTelemetrySdkTests/Metrics/MetricsTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/MetricsTests.swift
@@ -20,8 +20,8 @@ import XCTest
 final class MetricsTests: XCTestCase {
     func testCounterSendsAggregateToRegisteredProcessor() {
         let testProcessor = TestMetricProcessor()
-        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
-        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let meterSharedState = MeterSharedState(metricProcessor: testProcessor)
+        let meter = MeterSdkProvider(meterSharedState: meterSharedState).get(instrumentationName: "library1") as! MeterSdk
         let testCounter = meter.createIntCounter(name: "testCounter")
 
         let labels1 = ["dim1": "value1"]
@@ -63,8 +63,8 @@ final class MetricsTests: XCTestCase {
 
     func testMeasureSendsAggregateToRegisteredProcessor() {
         let testProcessor = TestMetricProcessor()
-        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
-        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let meterSharedState = MeterSharedState(metricProcessor: testProcessor)
+        let meter = MeterSdkProvider(meterSharedState: meterSharedState).get(instrumentationName: "library1") as! MeterSdk
         let testMeasure = meter.createIntMeasure(name: "testMeasure")
 
         let labels1 = ["dim1": "value1"]
@@ -103,8 +103,8 @@ final class MetricsTests: XCTestCase {
 
     func testIntObserverSendsAggregateToRegisteredProcessor() {
         let testProcessor = TestMetricProcessor()
-        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
-        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let meterSharedState = MeterSharedState(metricProcessor: testProcessor)
+        let meter = MeterSdkProvider(meterSharedState: meterSharedState).get(instrumentationName: "library1") as! MeterSdk
         _ = meter.createIntObserver(name: "testObserver", callback: callbackInt)
 
         meter.collect()
@@ -141,8 +141,8 @@ final class MetricsTests: XCTestCase {
 
     func testDoubleObserverSendsAggregateToRegisteredProcessor() {
         let testProcessor = TestMetricProcessor()
-        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
-        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let meterSharedState = MeterSharedState(metricProcessor: testProcessor)
+        let meter = MeterSdkProvider(meterSharedState: meterSharedState).get(instrumentationName: "library1") as! MeterSdk
         _ = meter.createDoubleObserver(name: "testObserver", callback: callbackDouble)
 
         meter.collect()

--- a/Tests/OpenTelemetrySdkTests/Metrics/MetricsTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/MetricsTests.swift
@@ -1,0 +1,179 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class MetricsTests: XCTestCase {
+    func testCounterSendsAggregateToRegisteredProcessor() {
+        let testProcessor = TestMetricProcessor()
+        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
+        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let testCounter = meter.createIntCounter(name: "testCounter")
+
+        let labels1 = ["dim1": "value1"]
+        let labels2 = ["dim1": "value2"]
+        let labels3 = ["dim1": "value3"]
+
+        testCounter.add(value: 100, labelset: meter.getLabelSet(labels: labels1))
+        testCounter.add(value: 10, labelset: meter.getLabelSet(labels: labels1))
+
+        let boundCounterLabel2 = testCounter.bind(labels: labels2)
+        boundCounterLabel2.add(value: 200)
+
+        testCounter.add(value: 200, labelset: meter.getLabelSet(labels: labels3))
+        testCounter.add(value: 10, labelset: meter.getLabelSet(labels: labels3))
+
+        meter.collect()
+
+        XCTAssertEqual(testProcessor.metrics.count, 1)
+        let metric = testProcessor.metrics[0]
+
+        XCTAssertEqual("testCounter", metric.metricName)
+        XCTAssertEqual("library1", metric.metricNamespace)
+
+        // 3 time series, as 3 unique label sets.
+        XCTAssertEqual(3, metric.data.count)
+
+        var metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value1" })
+        var metricInt = metricSeries as! SumData<Int>
+        XCTAssertEqual(110, metricInt.sum)
+
+        metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value2" })
+        metricInt = metricSeries as! SumData<Int>
+        XCTAssertEqual(200, metricInt.sum)
+
+        metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value3" })
+        metricInt = metricSeries as! SumData<Int>
+        XCTAssertEqual(210, metricInt.sum)
+    }
+
+    func testMeasureSendsAggregateToRegisteredProcessor() {
+        let testProcessor = TestMetricProcessor()
+        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
+        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        let testMeasure = meter.createIntMeasure(name: "testMeasure")
+
+        let labels1 = ["dim1": "value1"]
+        let labels2 = ["dim1": "value2"]
+
+        testMeasure.record(value: 100, labelset: meter.getLabelSet(labels: labels1))
+        testMeasure.record(value: 10, labelset: meter.getLabelSet(labels: labels1))
+        testMeasure.record(value: 1, labelset: meter.getLabelSet(labels: labels1))
+        testMeasure.record(value: 200, labelset: meter.getLabelSet(labels: labels2))
+        testMeasure.record(value: 20, labelset: meter.getLabelSet(labels: labels2))
+
+        meter.collect()
+
+        XCTAssertEqual(testProcessor.metrics.count, 1)
+        let metric = testProcessor.metrics[0]
+        XCTAssertEqual("testMeasure", metric.metricName)
+        XCTAssertEqual("library1", metric.metricNamespace)
+
+        // 2 time series, as 2 unique label sets.
+        XCTAssertEqual(2, metric.data.count)
+
+        var metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value1" })
+        var metricSummary = metricSeries as! SummaryData<Int>
+        XCTAssertEqual(111, metricSummary.sum)
+        XCTAssertEqual(3, metricSummary.count)
+        XCTAssertEqual(1, metricSummary.min)
+        XCTAssertEqual(100, metricSummary.max)
+
+        metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value2" })
+        metricSummary = metricSeries as! SummaryData<Int>
+        XCTAssertEqual(220, metricSummary.sum)
+        XCTAssertEqual(2, metricSummary.count)
+        XCTAssertEqual(20, metricSummary.min)
+        XCTAssertEqual(200, metricSummary.max)
+    }
+
+    func testIntObserverSendsAggregateToRegisteredProcessor() {
+        let testProcessor = TestMetricProcessor()
+        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
+        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        _ = meter.createIntObserver(name: "testObserver", callback: callbackInt)
+
+        meter.collect()
+
+        XCTAssertEqual(testProcessor.metrics.count, 1)
+        let metric = testProcessor.metrics[0]
+        XCTAssertEqual("testObserver", metric.metricName)
+        XCTAssertEqual("library1", metric.metricNamespace)
+
+        // 2 time series, as 2 unique label sets.
+        XCTAssertEqual(2, metric.data.count)
+
+        var metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value1" })
+        var metricInt = metricSeries as! SumData<Int>
+        XCTAssertEqual(30, metricInt.sum)
+
+        metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value2" })
+        metricInt = metricSeries as! SumData<Int>
+        XCTAssertEqual(300, metricInt.sum)
+    }
+
+    private func callbackInt(observerMetric: IntObserverMetric) {
+        let labels1 = ["dim1": "value1"]
+        let labels2 = ["dim1": "value2"]
+
+        observerMetric.observe(value: 10, labels: labels1)
+        observerMetric.observe(value: 20, labels: labels1)
+        observerMetric.observe(value: 30, labels: labels1)
+
+        observerMetric.observe(value: 100, labels: labels2)
+        observerMetric.observe(value: 200, labels: labels2)
+        observerMetric.observe(value: 300, labels: labels2)
+    }
+
+    func testDoubleObserverSendsAggregateToRegisteredProcessor() {
+        let testProcessor = TestMetricProcessor()
+        let meterBuilder = MeterBuilder(metricProcessor: testProcessor)
+        let meter = MeterFactory(meterBuilder: meterBuilder).getMeter(name: "library1") as! MeterSdk
+        _ = meter.createDoubleObserver(name: "testObserver", callback: callbackDouble)
+
+        meter.collect()
+
+        XCTAssertEqual(testProcessor.metrics.count, 1)
+        let metric = testProcessor.metrics[0]
+        XCTAssertEqual("testObserver", metric.metricName)
+        XCTAssertEqual("library1", metric.metricNamespace)
+
+        // 2 time series, as 2 unique label sets.
+        XCTAssertEqual(2, metric.data.count)
+
+        var metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value1" })
+        var metricDouble = metricSeries as! SumData<Double>
+        XCTAssertEqual(30, metricDouble.sum)
+
+        metricSeries = metric.data.first(where: { $0.labels["dim1"] == "value2" })
+        metricDouble = metricSeries as! SumData<Double>
+        XCTAssertEqual(300, metricDouble.sum)
+    }
+
+    private func callbackDouble(observerMetric: DoubleObserverMetric) {
+        let labels1 = ["dim1": "value1"]
+        let labels2 = ["dim1": "value2"]
+
+        observerMetric.observe(value: 10, labels: labels1)
+        observerMetric.observe(value: 20, labels: labels1)
+        observerMetric.observe(value: 30, labels: labels1)
+
+        observerMetric.observe(value: 100, labels: labels2)
+        observerMetric.observe(value: 200, labels: labels2)
+        observerMetric.observe(value: 300, labels: labels2)
+    }
+}

--- a/Tests/OpenTelemetrySdkTests/Metrics/PushControllerTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/PushControllerTests.swift
@@ -1,0 +1,72 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class PushControllerTests: XCTestCase {
+    func testPushControllerCollectsAllMeters() {
+        let controllerPushIntervalInSec = 0.025
+        let collectionCountExpectedMin = 3
+        let maxWaitInSec = (controllerPushIntervalInSec * Double(collectionCountExpectedMin)) + 2
+
+        var exportCalledCount = 0
+        let testExporter = TestMetricExporter(onExport: {
+            exportCalledCount += 1
+        })
+        let testProcessor = TestMetricProcessor()
+
+        // Setup 2 meters whose Collect will increment the collect count.
+        var meter1CollectCount = 0
+        var meter2CollectCount = 0
+        var meters = [MeterRegistryKey: MeterSdk]()
+        let testMeter1 = TestMeter(meterName: "meter1", metricProcessor: testProcessor) {
+            meter1CollectCount += 1
+        }
+        meters[MeterRegistryKey(name: "meter1")] = testMeter1
+
+        let testMeter2 = TestMeter(meterName: "meter2", metricProcessor: testProcessor) {
+            meter2CollectCount += 1
+        }
+        meters[MeterRegistryKey(name: "meter2")] = testMeter2
+
+        let pushInterval = controllerPushIntervalInSec
+
+        _ = PushMetricController(meters: meters, metricProcessor: testProcessor, metricExporter: testExporter, pushInterval: pushInterval)
+
+        // Validate that collect is called on Meter1, Meter2.
+        validateMeterCollect(meterCollectCount: &meter1CollectCount, expectedMeterCollectCount: collectionCountExpectedMin, meterName: "meter1", timeout: maxWaitInSec)
+        validateMeterCollect(meterCollectCount: &meter2CollectCount, expectedMeterCollectCount: collectionCountExpectedMin, meterName: "meter2", timeout: maxWaitInSec)
+
+        // Export must be called same no: of times as Collect.
+        XCTAssertTrue(exportCalledCount >= collectionCountExpectedMin)
+    }
+
+    func validateMeterCollect( meterCollectCount: inout Int, expectedMeterCollectCount: Int, meterName: String, timeout: TimeInterval) {
+        // Sleep in short intervals, so the actual test duration is not always the max wait time.
+        let start = DispatchTime.now()
+
+        while meterCollectCount < expectedMeterCollectCount {
+            let elapsed = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1000000000
+            if elapsed <= timeout {
+                usleep(1000000)
+            } else {
+                break
+            }
+        }
+
+        XCTAssertGreaterThanOrEqual(meterCollectCount, expectedMeterCollectCount)
+    }
+}

--- a/Tests/OpenTelemetrySdkTests/Metrics/TestMeter.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/TestMeter.swift
@@ -13,12 +13,18 @@
 // limitations under the License.
 //
 
-import Foundation
+@testable import OpenTelemetrySdk
+import XCTest
 
-open class BoundCounterMetric<T> {
-    public init() {}
+class TestMeter: MeterSdk {
+    let collectAction: () -> Void
 
-    open func add(value: T) {
-        fatalError()
+    init(meterName: String, metricProcessor: MetricProcessor, collectAction: @escaping () -> Void) {
+        self.collectAction = collectAction
+        super.init(meterName: meterName, metricProcessor: metricProcessor)
+    }
+
+    override func collect() {
+        collectAction()
     }
 }

--- a/Tests/OpenTelemetrySdkTests/Metrics/TestMetricExporter.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/TestMetricExporter.swift
@@ -13,12 +13,20 @@
 // limitations under the License.
 //
 
-import Foundation
+@testable import OpenTelemetrySdk
+import XCTest
 
-open class BoundCounterMetric<T> {
-    public init() {}
+class TestMetricExporter: MetricExporter {
+    var metrics = [Metric]()
+    let onExport: () -> Void
 
-    open func add(value: T) {
-        fatalError()
+    init(onExport: @escaping () -> Void) {
+        self.onExport = onExport
+    }
+
+    func export(metrics: [Metric], shouldCancel: (() -> Bool)? = nil) -> MetricExporterResultCode {
+        onExport()
+        self.metrics.append(contentsOf: metrics)
+        return .success
     }
 }

--- a/Tests/OpenTelemetrySdkTests/Metrics/TestMetricProcessor.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/TestMetricProcessor.swift
@@ -13,12 +13,18 @@
 // limitations under the License.
 //
 
-import Foundation
+@testable import OpenTelemetrySdk
+import XCTest
 
-open class BoundCounterMetric<T> {
-    public init() {}
+class TestMetricProcessor: MetricProcessor {
+    var metrics = [Metric]()
+    func finishCollectionCycle() -> [Metric] {
+        let metrics = self.metrics
+        self.metrics = [Metric]()
+        return metrics
+    }
 
-    open func add(value: T) {
-        fatalError()
+    func process(metric: Metric) {
+        metrics.append(metric)
     }
 }


### PR DESCRIPTION
This is the first version of the Metrics implementation, heavily influenced in dotnet implementation.
Many iterations in code still needed but is a good starting point and fills the biggest existing gap in opentelemetry-swift

Close #14 