### PR TITLE
Testing on forks

### DIFF
--- a/.github/workflows/ScopeTesting.yml
+++ b/.github/workflows/ScopeTesting.yml
@@ -16,6 +16,7 @@ jobs:
         dsn: ${{ secrets.SCOPE_DSN }}
         platform: macos
         codePath: true
+        agentVersion: 0.6.2
     - name: Testing for macOS (only run on pull_request)
       if: github.event_name == 'pull_request'
       uses: undefinedlabs/scope-for-swift-action@v1
@@ -23,3 +24,4 @@ jobs:
         dsn: https://d6756ad6b68e4df7a3cd93693139ad35@app.scope.dev
         platform: macos
         codePath: true
+        agentVersion: 0.6.2

--- a/.github/workflows/ScopeTesting.yml
+++ b/.github/workflows/ScopeTesting.yml
@@ -9,15 +9,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set push SCOPE_DSN
+    - name: Testing for macOS (push)
       if: github.event_name == 'push'
-      run: echo '::set-env name=SCOPE_DSN::${{ secrets.SCOPE_DSN }}'
-    - name: Set pull_request SCOPE_DSN
-      if: github.event_name == 'pull_request'
-      run: echo '::set-env name=SCOPE_DSN::https://d6756ad6b68e4df7a3cd93693139ad35@app.scope.dev'
-    - name: Testing for macOS
       uses: undefinedlabs/scope-for-swift-action@v1
       with:
-        dsn: ${{ SCOPE_DSN }}
+        dsn: ${{ secrets.SCOPE_DSN }}
+        platform: macos
+        codePath: true
+    - name: Testing for macOS (pull)
+      if: github.event_name == 'pull_request'
+      uses: undefinedlabs/scope-for-swift-action@v1
+      with:
+        dsn: https://d6756ad6b68e4df7a3cd93693139ad35@app.scope.dev
         platform: macos
         codePath: true

--- a/.github/workflows/ScopeTesting.yml
+++ b/.github/workflows/ScopeTesting.yml
@@ -9,14 +9,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Testing for macOS (push)
+    - name: Testing for macOS (only on push)
       if: github.event_name == 'push'
       uses: undefinedlabs/scope-for-swift-action@v1
       with:
         dsn: ${{ secrets.SCOPE_DSN }}
         platform: macos
         codePath: true
-    - name: Testing for macOS (pull)
+    - name: Testing for macOS (only run on pull_request)
       if: github.event_name == 'pull_request'
       uses: undefinedlabs/scope-for-swift-action@v1
       with:

--- a/.github/workflows/ScopeTesting.yml
+++ b/.github/workflows/ScopeTesting.yml
@@ -9,9 +9,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set push SCOPE_DSN
+      if: github.event_name == 'push'
+      run: echo '::set-env name=SCOPE_DSN::${{ secrets.SCOPE_DSN }}'
+    - name: Set pull_request SCOPE_DSN
+      if: github.event_name == 'pull_request'
+      run: echo '::set-env name=SCOPE_DSN::https://d6756ad6b68e4df7a3cd93693139ad35@app.scope.dev'
     - name: Testing for macOS
       uses: undefinedlabs/scope-for-swift-action@v1
       with:
-        dsn: https://d6756ad6b68e4df7a3cd93693139ad35@app.scope.dev
+        dsn: ${{ SCOPE_DSN }}
         platform: macos
         codePath: true


### PR DESCRIPTION
It uses the public `SCOPE_DSN` for pull requests but It uses the repository `secret.SCOPE_DSN` on push so forks can test before creating a PR

Also force to use  previous agent version (0.6.2), since versions from 0.7.0 uses opentelemetry internally and when testing  swift clashes with the symbols and does funny thing on runtime.