### PR TITLE
Improvements to locks in RecordsEventReadableSpan

### DIFF
--- a/Tests/ExportersTests/Prometheus/PrometheusExporterTests.swift
+++ b/Tests/ExportersTests/Prometheus/PrometheusExporterTests.swift
@@ -109,6 +109,6 @@ class PrometheusExporterTests: XCTestCase {
         // Min is 5
         XCTAssert(responseText.contains("testMeasure{dim1=\"value1\",quantile=\"0\"} 5") || responseText.contains("testMeasure{quantile=\"0\",dim1=\"value1\"} 5"))
         // Max is 500
-        XCTAssert(responseText.contains("testMeasure{dim1=\"value1\",quantile=\"1\"} 500") || responseText.contains("testMeasure{quantile=\"1\", dim1=\"value1\",} 500"))
+        XCTAssert(responseText.contains("testMeasure{dim1=\"value1\",quantile=\"1\"} 500") || responseText.contains("testMeasure{quantile=\"1\", dim1=\"value1\"} 500"))
     }
 }

--- a/Tests/ExportersTests/Prometheus/PrometheusExporterTests.swift
+++ b/Tests/ExportersTests/Prometheus/PrometheusExporterTests.swift
@@ -109,6 +109,6 @@ class PrometheusExporterTests: XCTestCase {
         // Min is 5
         XCTAssert(responseText.contains("testMeasure{dim1=\"value1\",quantile=\"0\"} 5") || responseText.contains("testMeasure{quantile=\"0\",dim1=\"value1\"} 5"))
         // Max is 500
-        XCTAssert(responseText.contains("testMeasure{dim1=\"value1\",quantile=\"1\"} 500") || responseText.contains("testMeasure{quantile=\"1\", dim1=\"value1\"} 500"))
+        XCTAssert(responseText.contains("testMeasure{dim1=\"value1\",quantile=\"1\"} 500") || responseText.contains("testMeasure{quantile=\"1\",dim1=\"value1\"} 500"))
     }
 }


### PR DESCRIPTION
Use locks instead of queues for attributes and events, they should be faster end lighter