### PR TITLE
Fix ZipkinTraceExporter crashing on JSON export

### DIFF
--- a/Examples/Simple Exporter/main.swift
+++ b/Examples/Simple Exporter/main.swift
@@ -17,6 +17,7 @@ import Foundation
 import JaegerExporter
 import OpenTelemetrySdk
 import StdoutExporter
+import ZipkinExporter
 
 let sampleKey = "sampleKey"
 let sampleValue = "sampleValue"
@@ -55,7 +56,10 @@ let jaegerCollectorAdress = "localhost"
 let jaegerExporter = JaegerSpanExporter(serviceName: "SimpleExporter", collectorAddress: jaegerCollectorAdress)
 let stdoutExporter = StdoutExporter()
 
-let spanExporter = MultiSpanExporter(spanExporters: [jaegerExporter, stdoutExporter])
+//let zipkinExporterOptions = ZipkinTraceExporterOptions()
+//let zipkinExporter = ZipkinTraceExporter(options: zipkinExporterOptions)
+
+let spanExporter = MultiSpanExporter(spanExporters: [jaegerExporter, stdoutExporter/*, zipkinExporter*/])
 
 let spanProcessor = SimpleSpanProcessor(spanExporter: spanExporter)
 OpenTelemetrySDK.instance.tracerProvider.addSpanProcessor(spanProcessor)

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .target(  name: "OpenTelemetryProtocolExporter", dependencies: ["OpenTelemetrySdk", "GRPC"], path: "Sources/Exporters/OpenTelemetryProtocol"),
         .testTarget(  name: "OpenTelemetryProtocolExporterTests", dependencies: ["OpenTelemetryProtocolExporter"], path: "Tests/ExportersTests/OpenTelemetryProtocol"),
         .target(  name: "LoggingTracer", dependencies: ["OpenTelemetryApi"], path: "Examples/Logging Tracer"),
-        .target(  name: "SimpleExporter", dependencies: ["OpenTelemetrySdk", "JaegerExporter", "StdoutExporter"], path: "Examples/Simple Exporter"),
+        .target(  name: "SimpleExporter", dependencies: ["OpenTelemetrySdk", "JaegerExporter", "StdoutExporter", "ZipkinExporter"], path: "Examples/Simple Exporter"),
         .target(  name: "PrometheusSample", dependencies: ["OpenTelemetrySdk", "PrometheusExporter"], path: "Examples/Prometheus Sample"),
     ]
 )

--- a/Sources/Exporters/Zipkin/Implementation/ZipkinAnnotation.swift
+++ b/Sources/Exporters/Zipkin/Implementation/ZipkinAnnotation.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-struct ZipkinAnnotation {
+struct ZipkinAnnotation: Encodable {
     var timestamp: UInt64
     var value: String
 }

--- a/Sources/Exporters/Zipkin/Implementation/ZipkinEndpoint.swift
+++ b/Sources/Exporters/Zipkin/Implementation/ZipkinEndpoint.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-class ZipkinEndpoint {
+class ZipkinEndpoint: Encodable {
     var serviceName: String
     var ipv4: String?
     var ipv6: String?

--- a/Sources/Exporters/Zipkin/Implementation/ZipkinSpan.swift
+++ b/Sources/Exporters/Zipkin/Implementation/ZipkinSpan.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-struct ZipkinSpan {
+struct ZipkinSpan: Encodable {
     var traceId: String
     var parentId: String?
     var id: String

--- a/Sources/Exporters/Zipkin/ZipkinTraceExporter.swift
+++ b/Sources/Exporters/Zipkin/ZipkinTraceExporter.swift
@@ -32,8 +32,9 @@ public class ZipkinTraceExporter: SpanExporter {
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
+        let spans = encodeSpans(spans: spans)
         do {
-            request.httpBody = try JSONSerialization.data(withJSONObject: encodeSpans(spans: spans), options: [])
+            request.httpBody = try JSONEncoder().encode(spans)
         } catch {
             return .failure
         }
@@ -63,7 +64,7 @@ public class ZipkinTraceExporter: SpanExporter {
     public func shutdown() {
     }
 
-    func encodeSpans(spans: [SpanData]) -> [Any] {
+    func encodeSpans(spans: [SpanData]) -> [ZipkinSpan] {
         return spans.map { ZipkinConversionExtension.toZipkinSpan(otelSpan: $0, defaultLocalEndpoint: localEndPoint) }
     }
 


### PR DESCRIPTION
Zipkin was crashing on JSON conversion of output.
Make ZipkinSpan Encodable so we can use native swift JSONEncoder