### PR TITLE
Make TraceId and SpanId raw identifiers available

### DIFF
--- a/Sources/Exporters/Zipkin/Implementation/ZipkinConversionExtension.swift
+++ b/Sources/Exporters/Zipkin/Implementation/ZipkinConversionExtension.swift
@@ -106,7 +106,7 @@ struct ZipkinConversionExtension {
 
     private static func EncodeTraceId(traceId: TraceId, useShortTraceIds: Bool) -> String {
         if useShortTraceIds {
-            return String(format: "%016llx", traceId.lowerLong)
+            return String(format: "%016llx", traceId.rawLowerLong)
         } else {
             return traceId.hexString
         }

--- a/Sources/OpenTelemetryApi/Trace/SpanId.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanId.swift
@@ -126,9 +126,14 @@ public struct SpanId: Equatable, Comparable, Hashable, CustomStringConvertible {
         self.init(id: id)
     }
 
-    ///  Returns the lowercase base16 encoding of this SpanId.
+    ///  Returns the base16 encoding of this SpanId.
     public var hexString: String {
         return String(format: "%016llx", id)
+    }
+
+    ///  Returns the raw id value of this SpanId.
+    public var rawValue: UInt64 {
+        return id
     }
 
     /// Returns whether the span identifier is valid. A valid span identifier is an 8-byte array with

--- a/Sources/OpenTelemetryApi/Trace/TraceId.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceId.swift
@@ -160,8 +160,14 @@ public struct TraceId: Comparable, Hashable, CustomStringConvertible, Equatable 
 
     /// Returns the lower 8 bytes of the trace-id as a long value, assuming little-endian order. This
     /// is used in ProbabilitySampler.
-    public var lowerLong: UInt64 {
+    public var rawHigherLong: UInt64 {
         return idHi
+    }
+
+    /// Returns the lower 8 bytes of the trace-id as a long value, assuming little-endian order. This
+    /// is used in ProbabilitySampler.
+    public var rawLowerLong: UInt64 {
+        return idLo
     }
 
     public var description: String {

--- a/Sources/OpenTelemetrySdk/Trace/Export/SimpleSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/SimpleSpanProcessor.swift
@@ -36,7 +36,7 @@ public struct SimpleSpanProcessor: SpanProcessor {
         spanExporter.export(spans: [span])
     }
 
-    public mutating func shutdown() {
+    public func shutdown() {
         spanExporter.shutdown()
     }
 

--- a/Sources/OpenTelemetrySdk/Trace/Samplers.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Samplers.swift
@@ -107,7 +107,7 @@ class Probability: Sampler {
         /// while allowing for a (very) small chance of *not* sampling if the id == Long.MAX_VALUE.
         /// This is considered a reasonable tradeoff for the simplicity/performance requirements (this
         /// code is executed in-line for every Span creation).
-        if traceId.lowerLong < idUpperBound {
+        if traceId.rawLowerLong < idUpperBound {
             return Samplers.alwaysOnDecision
         } else {
             return Samplers.alwaysOffDecision

--- a/Tests/OpenTelemetryApiTests/Trace/TraceIdTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/TraceIdTests.swift
@@ -43,9 +43,14 @@ final class TraceIdTests: XCTestCase {
         XCTAssertTrue(short.isValid)
     }
 
+    func testGetHigherLong() {
+        XCTAssertEqual(first.rawHigherLong, 0)
+        XCTAssertEqual(second.rawHigherLong, 0xFF00000000000000)
+    }
+
     func testGetLowerLong() {
-        XCTAssertEqual(first.lowerLong, 0)
-        XCTAssertEqual(second.lowerLong, 0xFF00000000000000)
+        XCTAssertEqual(first.rawLowerLong, 0x61)
+        XCTAssertEqual(second.rawLowerLong, 0x41)
     }
 
     func testFromHexString() {

--- a/Tests/OpenTelemetrySdkTests/Trace/SamplersTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/SamplersTests.swift
@@ -136,7 +136,7 @@ class ProbabilitySamplerTest: XCTestCase {
         let defaultProbability = Probability(probability: 0.0001)
         // This traceId will not be sampled by the ProbabilitySampler because the first 8 bytes as long
         // is not less than probability * Long.MAX_VALUE;
-        let notSampledtraceId = TraceId(fromBytes: [0x8F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0])
+        let notSampledtraceId = TraceId(fromBytes: [0, 0, 0, 0, 0, 0, 0, 0, 0x8F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
 
         let decision1 = defaultProbability.shouldSample(parentContext: nil,
                                                         traceId: notSampledtraceId,


### PR DESCRIPTION
Make TraceId and SpanId raw identifiers available:
* Add rawHigherLong and rawLowerLong to TraceId (replacing and fixing lowerLong, that was incorrectly returning high Long)
* Add rawValue accessor to SpanId
* Fix tests that were using wrong behaviour of lTraceId.lowerLong