### PR TITLE
Allow creating sdk spans directly without using SpanBuilder.

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/AttributesWithCapacity.swift
+++ b/Sources/OpenTelemetrySdk/Trace/AttributesWithCapacity.swift
@@ -24,14 +24,14 @@ public struct AttributesWithCapacity {
     private var capacity: Int
     private var recordedAttributes: Int
 
-    init(capacity: Int) {
+    public init(capacity: Int) {
         attributes = [String: AttributeValue]()
         keys = [String]()
         recordedAttributes = 0
         self.capacity = capacity
     }
 
-    subscript(key: String) -> AttributeValue? {
+    public subscript(key: String) -> AttributeValue? {
         get {
             attributes[key]
         }
@@ -44,7 +44,7 @@ public struct AttributesWithCapacity {
         }
     }
 
-    @discardableResult mutating func updateValue(value: AttributeValue, forKey key: String) -> AttributeValue? {
+    @discardableResult public mutating func updateValue(value: AttributeValue, forKey key: String) -> AttributeValue? {
         let oldValue = attributes.updateValue(value, forKey: key)
         if oldValue == nil {
             recordedAttributes += 1
@@ -60,39 +60,39 @@ public struct AttributesWithCapacity {
         return oldValue
     }
 
-    mutating func updateValues(attributes: [String: AttributeValue]) {
+    public mutating func updateValues(attributes: [String: AttributeValue]) {
         _ = attributes.keys.map {
             updateValue(value: attributes[$0]!, forKey: $0)
         }
     }
 
-    mutating func updateValues(attributes: AttributesWithCapacity) {
+    public mutating func updateValues(attributes: AttributesWithCapacity) {
         _ = attributes.keys.map {
             updateValue(value: attributes[$0]!, forKey: $0)
         }
     }
 
-    mutating func removeValueForKey(key: String) {
+    public mutating func removeValueForKey(key: String) {
         keys = keys.filter {
             $0 != key
         }
         attributes.removeValue(forKey: key)
     }
 
-    mutating func removeAll(keepCapacity: Int) {
+    public mutating func removeAll(keepCapacity: Int) {
         keys = []
         attributes = Dictionary<String, AttributeValue>(minimumCapacity: keepCapacity)
     }
 
-    var count: Int {
+    public var count: Int {
         attributes.count
     }
 
-    var numberOfDroppedAttributes: Int {
+    public var numberOfDroppedAttributes: Int {
         recordedAttributes - attributes.count
     }
 
-    var values: Array<AttributeValue> {
+    public var values: Array<AttributeValue> {
         keys.map { attributes[$0]! }
     }
 

--- a/Sources/OpenTelemetrySdk/Trace/Config/TraceConfig.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Config/TraceConfig.swift
@@ -22,38 +22,38 @@ public struct TraceConfig: Equatable {
     // TODO: decide which default sampler to use
 
     /// Returns the global default Sampler which is used when constructing a new Span
-    var sampler: Sampler = Samplers.alwaysOn
+    public private(set) var sampler: Sampler = Samplers.alwaysOn
 
     /// The global default max number of attributes perSpan.
-    var maxNumberOfAttributes: Int = 32 {
+    public private(set) var maxNumberOfAttributes: Int = 32 {
         didSet {
             maxNumberOfAttributes < 0 ? maxNumberOfAttributes = 0 : Void()
         }
     }
 
     ///  the global default max number of Events per Span.
-    var maxNumberOfEvents: Int = 128 {
+    public private(set) var maxNumberOfEvents: Int = 128 {
         didSet {
             maxNumberOfEvents < 0 ? maxNumberOfEvents = 0 : Void()
         }
     }
 
     /// the global default max number of Link entries per Span.
-    var maxNumberOfLinks: Int = 32 {
+    public private(set) var maxNumberOfLinks: Int = 32 {
         didSet {
             maxNumberOfLinks < 0 ? maxNumberOfLinks = 0 : Void()
         }
     }
 
     /// the global default max number of attributes per Event.
-    var maxNumberOfAttributesPerEvent: Int = 32 {
+    public private(set) var maxNumberOfAttributesPerEvent: Int = 32 {
         didSet {
             maxNumberOfAttributesPerEvent < 0 ? maxNumberOfAttributesPerEvent = 0 : Void()
         }
     }
 
     /// the global default max number of attributes per Link.
-    var maxNumberOfAttributesPerLink: Int = 32 {
+    public private(set) var maxNumberOfAttributesPerLink: Int = 32 {
         didSet {
             maxNumberOfAttributesPerLink < 0 ? maxNumberOfAttributesPerLink = 0 : Void()
         }


### PR DESCRIPTION
`RecordEventsReadableSpan.startSpan()` was already a public method, but could not be used because of some access control limitations, solve them:
* `AttributesWithCapacity` methods are public now
* `TraceConfig` settings are now readable