### PR TITLE
Datadog exporter: Properly encode errors

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/Export/SimpleSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/SimpleSpanProcessor.swift
@@ -41,7 +41,7 @@ public struct SimpleSpanProcessor: SpanProcessor {
     }
 
     public func forceFlush() {
-        spanExporter.flush()
+        _ = spanExporter.flush()
     }
 
     /// Returns a new SimpleSpansProcessor that converts spans to proto and forwards them to


### PR DESCRIPTION
Some of the error tags were not encoded correctly and were getting lost
Also clean a compiler warning