### PR TITLE
Fix TimedEvent creation with Date loses precission

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/SpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanBuilder.swift
@@ -146,7 +146,7 @@ extension SpanBuilder {
     }
     
     @discardableResult public func setStartTimestamp(timestamp: Date) -> Self {
-        return setStartEpochNano(epochNano: UInt64(timestamp.timeIntervalSince1970) )
+        return setStartEpochNano(epochNano: UInt64(timestamp.timeIntervalSince1970 * 1000000000) )
     }
 
 }

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -250,6 +250,10 @@ public class RecordEventsReadableSpan: ReadableSpan {
         addTimedEvent(timedEvent: TimedEvent(epochNanos: clock.now, event: event))
     }
 
+    public func addEvent(event: TimedEvent){
+        addTimedEvent(timedEvent: event)
+    }
+
     public func addEvent<E>(event: E, timestamp: Date) where E: Event {
         addTimedEvent(timedEvent: TimedEvent(timestamp: timestamp, event: event))
     }

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSDK.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSDK.swift
@@ -121,7 +121,7 @@ public class SpanBuilderSdk: SpanBuilder {
     }
     
     public func setStartTimestamp(timestamp: Date) -> Self {
-        return setStartEpochNano(epochNano: UInt64(timestamp.timeIntervalSince1970) )
+        return setStartEpochNano(epochNano: UInt64(timestamp.timeIntervalSince1970 * 1000000000) )
     }
 
     public func startSpan() -> Span {

--- a/Sources/OpenTelemetrySdk/Trace/TimedEvent.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TimedEvent.swift
@@ -47,7 +47,7 @@ public struct TimedEvent: Equatable {
     ///   - name: the name of this TimedEvent.
     ///   - attributes: the attributes of this TimedEvent. Empty by default.
     public init(name: String, timestamp: Date, attributes: [String: AttributeValue] = [String: AttributeValue]()) {
-        epochNanos = UInt64(timestamp.timeIntervalSince1970) * 1000000000
+        epochNanos = UInt64(timestamp.timeIntervalSince1970 * 1000000000)
         self.name = name
         self.attributes = attributes
     }
@@ -57,6 +57,6 @@ public struct TimedEvent: Equatable {
     ///   - timestamp: timestamp in Date format.
     ///   - event: the event.
     public init(timestamp: Date, event: Event) {
-        self.init(name: event.name, epochNanos: UInt64(timestamp.timeIntervalSince1970) * 1000000000, attributes: event.attributes)
+        self.init(name: event.name, epochNanos: UInt64(timestamp.timeIntervalSince1970 * 1000000000), attributes: event.attributes)
     }
 }

--- a/Sources/OpenTelemetrySdk/Trace/TimedEvent.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TimedEvent.swift
@@ -17,7 +17,7 @@ import Foundation
 import OpenTelemetryApi
 
 /// Timed event.
-public struct TimedEvent: Equatable {
+public struct TimedEvent: Equatable, Event {
     public private(set) var epochNanos: UInt64
     public private(set) var name: String
     public private(set) var attributes: [String: AttributeValue]

--- a/Sources/OpenTracingShim/SpanShim.swift
+++ b/Sources/OpenTracingShim/SpanShim.swift
@@ -121,7 +121,7 @@ public class SpanShim: OTSpan, BaseShimProtocol {
     }
 
     public func finish(withTime finishTime: Date?) {
-        span.end(endOptions: EndSpanOptions(timestamp: UInt64(finishTime?.timeIntervalSince1970 ?? Date().timeIntervalSince1970)))
+        span.end(endOptions: EndSpanOptions(timestamp: UInt64((finishTime?.timeIntervalSince1970 ?? Date().timeIntervalSince1970)) * 1000000000))
     }
 
     static func getEventNameFrom(fields: [String: NSObject]) -> String {

--- a/Tests/ExportersTests/Zipkin/Implementation/ZipkinSpanConverterTests.swift
+++ b/Tests/ExportersTests/Zipkin/Implementation/ZipkinSpanConverterTests.swift
@@ -45,7 +45,7 @@ class ZipkinSpanConverterTests: XCTestCase {
     }
 
     public static func createTestSpan(setAttributes: Bool = true, additionalAttributes: [String: Any]? = nil, addEvents: Bool = true, addLinks: Bool = true) -> SpanData {
-        let startTimestamp = Date()
+        let startTimestamp = Date(timeIntervalSince1970: Double(Int(Date().timeIntervalSince1970))) // Round for comparison
         let endTimestamp = startTimestamp.addingTimeInterval(60)
         let eventTimestamp = startTimestamp
         let traceId = TraceId(fromHexString: "e8ea7e9ac72de94e91fabc613f9686b2")
@@ -68,7 +68,7 @@ class ZipkinSpanConverterTests: XCTestCase {
 
 //        let linkedSpanId = SpanId(fromHexString: "888915b6286b9c41")
 
-        return SpanData(traceId: traceId, spanId: spanId, parentSpanId: parentSpanId, name: "Name", kind: .client, startEpochNanos: UInt64(startTimestamp.timeIntervalSince1970) * 1000000000, attributes: attributes, timedEvents: events, status: Status.ok, endEpochNanos: UInt64(endTimestamp.timeIntervalSince1970) * 1000000000
+        return SpanData(traceId: traceId, spanId: spanId, parentSpanId: parentSpanId, name: "Name", kind: .client, startEpochNanos: UInt64(startTimestamp.timeIntervalSince1970 * 1000000000), attributes: attributes, timedEvents: events, status: Status.ok, endEpochNanos: UInt64(endTimestamp.timeIntervalSince1970 * 1000000000)
         )
     }
 }

--- a/Tests/OpenTelemetrySdkTests/Trace/TimedEventTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/TimedEventTests.swift
@@ -49,4 +49,12 @@ class TimedEventTests: XCTestCase {
         XCTAssertEqual(event.name, TimedEventTests.eventName2)
         XCTAssertEqual(event.attributes, TimedEventTests.attributes2)
     }
+
+    func testRawTimedEventWithDate() {
+        let dateForEvent = Date()
+        let event = TimedEvent(name: TimedEventTests.eventName, timestamp: dateForEvent)
+        XCTAssertEqual(event.epochNanos, UInt64(dateForEvent.timeIntervalSince1970 * 1000000000))
+        XCTAssertEqual(event.name, TimedEventTests.eventName)
+        XCTAssertEqual(event.attributes.count, 0)
+    }
 }


### PR DESCRIPTION
Sub-second precision was being lost in the creation of timed event with a Date
Also modify zipkin test so it doesn't fail in rounding error comparison of timed events