### PR TITLE
Datadog Exporter: Minor improvements and new example

### DIFF
--- a/Examples/Datadog Sample/README.md
+++ b/Examples/Datadog Sample/README.md
@@ -1,0 +1,7 @@
+### Datadog sample
+
+This example shows the Datadog exporter used with a Simple Exporter, showing how to configure for sending.
+
+User must write the clientKey for Datadog at the begining of code.
+
+

--- a/Examples/Datadog Sample/main.swift
+++ b/Examples/Datadog Sample/main.swift
@@ -1,0 +1,79 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import DatadogExporter
+import Foundation
+import OpenTelemetrySdk
+import OpenTelemetryApi
+
+
+let clientKey = ""
+
+let sampleKey = "sampleKey"
+let sampleValue = "sampleValue"
+
+let instrumentationLibraryName = "DatadogExporter"
+let instrumentationLibraryVersion = "semver:0.1.0"
+var instrumentationLibraryInfo = InstrumentationLibraryInfo(name: instrumentationLibraryName, version: instrumentationLibraryVersion)
+
+var tracer: TracerSdk
+tracer = OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: instrumentationLibraryName, instrumentationVersion: instrumentationLibraryVersion) as! TracerSdk
+
+func simpleSpan() {
+    let span = tracer.spanBuilder(spanName: "SimpleSpan").setSpanKind(spanKind: .client).startSpan()
+    span.setAttribute(key: sampleKey, value: sampleValue)
+    span.addEvent(name: "My event", attributes: ["message": AttributeValue.string("test message")])
+    span.end()
+}
+
+func childSpan() {
+    let span = tracer.spanBuilder(spanName: "parentSpan").setSpanKind(spanKind: .client).startSpan()
+    span.setAttribute(key: sampleKey, value: sampleValue)
+    do {
+        var scope = tracer.withSpan(span)
+        let childSpan = tracer.spanBuilder(spanName: "childSpan").setSpanKind(spanKind: .client).startSpan()
+        do {
+            var childScope = tracer.withSpan(childSpan)
+            childSpan.setAttribute(key: sampleKey, value: sampleValue)
+            childScope.close()
+        }
+        childSpan.end()
+        scope.close()
+    }
+    span.end()
+}
+
+let exporterConfiguration = ExporterConfiguration(
+    serviceName: "Otel exporter Example",
+    resource: "OTel exporter",
+    applicationName: "SimpleExample",
+    applicationVersion: "0.0.1",
+    environment: "test",
+    clientToken: clientKey,
+    endpoint: Endpoint.us,
+    uploadCondition: { true },
+    performancePreset: .instantDataDelivery
+)
+
+let datadogExporter = try! DatadogExporter(config: exporterConfiguration)
+
+var spanProcessor = SimpleSpanProcessor(spanExporter: datadogExporter)
+OpenTelemetrySDK.instance.tracerProvider.addSpanProcessor(spanProcessor)
+
+simpleSpan()
+childSpan()
+spanProcessor.shutdown()
+
+sleep(10)

--- a/Package.swift
+++ b/Package.swift
@@ -63,5 +63,6 @@ let package = Package(
         .target(  name: "LoggingTracer", dependencies: ["OpenTelemetryApi"], path: "Examples/Logging Tracer"),
         .target(  name: "SimpleExporter", dependencies: ["OpenTelemetrySdk", "JaegerExporter", "StdoutExporter", "ZipkinExporter"], path: "Examples/Simple Exporter"),
         .target(  name: "PrometheusSample", dependencies: ["OpenTelemetrySdk", "PrometheusExporter"], path: "Examples/Prometheus Sample"),
+        .target(  name: "DatadogSample", dependencies: ["DatadogExporter"], path: "Examples/Datadog Sample"),
     ]
 )

--- a/Sources/Exporters/DatadogExporter/Logs/LogsExporter.swift
+++ b/Sources/Exporters/DatadogExporter/Logs/LogsExporter.swift
@@ -41,7 +41,7 @@ internal class LogsExporter {
 
         let filesOrchestrator = FilesOrchestrator(
             directory: try Directory(withSubdirectoryPath: logsDirectory),
-            performance: configuration.performancePreset,
+             performance: configuration.performancePreset,
             dateProvider: SystemDateProvider()
         )
 
@@ -64,6 +64,7 @@ internal class LogsExporter {
         let urlProvider = UploadURLProvider(
             urlWithClientToken: try configuration.endpoint.logsUrlWithClientToken(clientToken: configuration.clientToken),
             queryItemProviders: [
+                .ddsource(),
                 .batchTime(using: SystemDateProvider())
             ]
         )

--- a/Sources/Exporters/DatadogExporter/Spans/SpanEncoder.swift
+++ b/Sources/Exporters/DatadogExporter/Spans/SpanEncoder.swift
@@ -18,15 +18,7 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 
 internal struct Constants {
-    #if os(iOS)
     static let ddsource = "ios"
-    #elseif os(tvOS)
-    static let ddsource = "tvos"
-    #elseif os(watchOS)
-    static let ddsource = "watchos"
-    #else
-    static let ddsource = "macos"
-    #endif
 }
 
 /// `SpanEnvelope` allows encoding multiple spans sharing the same `traceID` to a single payload.
@@ -103,21 +95,16 @@ internal struct DDSpan: Encodable {
         self.startTime = spanData.startEpochNanos
         self.duration = spanData.endEpochNanos - spanData.startEpochNanos
 
-        if spanData.attributes["error"] != nil {
-            self.error = true
-            self.errorMessage = spanData.attributes["error.message"]?.description
-            self.errorType = spanData.attributes["error.type"]?.description
-            self.errorStack = spanData.attributes["error.stack"]?.description
-        } else if !(spanData.status?.isOk ?? false) {
-            self.error = true
-            self.errorMessage = spanData.status?.description ?? "error"
-            self.errorType = spanData.status?.description ?? "error"
-            self.errorStack = nil
-        } else {
+        if spanData.status?.isOk ?? true {
             self.error = false
             self.errorMessage = nil
             self.errorType = nil
             self.errorStack = nil
+        } else {
+            self.error = true
+            self.errorType = spanData.attributes["error.type"]?.description ?? spanData.status?.description
+            self.errorMessage = spanData.attributes["error.message"]?.description
+            self.errorStack = spanData.attributes["error.stack"]?.description
         }
 
         let spanType = spanData.attributes["type"] ?? spanData.attributes["db.type"]

--- a/Tests/ExportersTests/DatadogExporter/Upload/DataUploaderTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/DataUploaderTests.swift
@@ -17,23 +17,11 @@
 import XCTest
 
 class DataUploadURLProviderTests: XCTestCase {
-    let platform: String = {
-        #if os(iOS)
-        return "ios"
-        #elseif os(tvOS)
-        return "tvos"
-        #elseif os(watchOS)
-        return "watchos"
-        #else
-        return "macos"
-        #endif
-    }()
-
     func testDDSourceQueryItem() {
         let item: UploadURLProvider.QueryItemProvider = .ddsource()
 
         XCTAssertEqual(item.value().name, "ddsource")
-        XCTAssertEqual(item.value().value, platform)
+        XCTAssertEqual(item.value().value, "ios")
     }
 
     func testBatchTimeQueryItem() {
@@ -63,9 +51,9 @@ class DataUploadURLProviderTests: XCTestCase {
             queryItemProviders: [.ddsource(), .batchTime(using: dateProvider)]
         )
 
-        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=\(platform)&batch_time=1576404000000"))
+        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&batch_time=1576404000000"))
         dateProvider.advance(bySeconds: 9.999)
-        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=\(platform)&batch_time=1576404009999"))
+        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&batch_time=1576404009999"))
     }
 }
 


### PR DESCRIPTION
* Use a non default source for logs
* Improve error encoding, now we use Opentelemetry status instead of a boolean attribute
* Add a simple datadog example where configuration of exporter is shown