### PR TITLE
Datadog exporter: Add a config setting to avoid exporting unsampled spans or logs from unsampled spans

### DIFF
--- a/Sources/Exporters/DatadogExporter/DatadogExporter.swift
+++ b/Sources/Exporters/DatadogExporter/DatadogExporter.swift
@@ -33,8 +33,12 @@ public class DatadogExporter: SpanExporter {
 
     public func export(spans: [SpanData]) -> SpanExporterResultCode {
         spans.forEach {
-            spansExporter.exportSpan(span: $0)
-            logsExporter.exportLogs(fromSpan: $0)
+            if $0.traceFlags.sampled || configuration.exportUnsampledSpans {
+                spansExporter.exportSpan(span: $0)
+            }
+            if $0.traceFlags.sampled || configuration.exportUnsampledLogs {
+                logsExporter.exportLogs(fromSpan: $0)
+            }
         }
         return .success
     }

--- a/Sources/Exporters/DatadogExporter/ExporterConfiguration.swift
+++ b/Sources/Exporters/DatadogExporter/ExporterConfiguration.swift
@@ -32,8 +32,13 @@ public struct ExporterConfiguration {
     var uploadCondition: () -> Bool
     /// Performance preset for reporting
     var performancePreset: PerformancePreset = .default
+    /// Option to export spans that have TraceFlag off, true by default
+    var exportUnsampledSpans: Bool = true
+    /// Option to export logs from spans that have TraceFlag off, true by default
+    var exportUnsampledLogs: Bool = true
 
-    public init(serviceName: String, resource: String, applicationName: String, applicationVersion: String, environment: String, clientToken: String, endpoint: Endpoint, uploadCondition: @escaping () -> Bool, performancePreset: PerformancePreset = .default) {
+
+    public init(serviceName: String, resource: String, applicationName: String, applicationVersion: String, environment: String, clientToken: String, endpoint: Endpoint, uploadCondition: @escaping () -> Bool, performancePreset: PerformancePreset = .default, exportUnsampledSpans: Bool = true, exportUnsampledLogs: Bool = true ) {
         self.serviceName = serviceName
         self.resource = resource
         self.applicationName = applicationName
@@ -43,5 +48,7 @@ public struct ExporterConfiguration {
         self.endpoint = endpoint
         self.uploadCondition = uploadCondition
         self.performancePreset = performancePreset
+        self.exportUnsampledSpans = exportUnsampledSpans
+        self.exportUnsampledLogs = exportUnsampledLogs
     }
 }


### PR DESCRIPTION
Datadog exporter: Add a config setting to avoid exporting unsampled spans or logs from unsampled spans