### PR TITLE
Datadog Exporter: Fix some system version support for macOS and tvOS

### DIFF
--- a/Sources/Exporters/DatadogExporter/Files/File.swift
+++ b/Sources/Exporters/DatadogExporter/Files/File.swift
@@ -71,7 +71,7 @@ internal struct File: WritableFile, ReadableFile {
           ```
           This is fixed in iOS 14/Xcode 12
          */
-        if #available(OSX 10.15, iOS 13.4, watchOS 6.0, tvOS 13.0, *) {
+        if #available(OSX 10.15.4, iOS 13.4, watchOS 6.0, tvOS 13.4, *) {
             defer {
                 try? fileHandle.close()
                 if synchronized {
@@ -116,7 +116,7 @@ internal struct File: WritableFile, ReadableFile {
           ```
          This is fixed in iOS 14/Xcode 12
          */
-        if #available(OSX 10.15, iOS 13.4, watchOS 6.0, tvOS 13.0, *) {
+        if #available(OSX 10.15.4, iOS 13.4, watchOS 6.0, tvOS 13.4, *) {
             defer { try? fileHandle.close() }
             return try fileHandle.readToEnd() ?? Data()
         } else {

--- a/Sources/Exporters/DatadogExporter/Utils/JSONEncoder.swift
+++ b/Sources/Exporters/DatadogExporter/Utils/JSONEncoder.swift
@@ -23,7 +23,7 @@ extension JSONEncoder {
             let formatted = iso8601DateFormatter.string(from: date)
             try container.encode(formatted)
         }
-        if #available(iOS 13.0, OSX 10.15, *) {
+        if #available(iOS 13.0, OSX 10.15, watchOS 6.0, tvOS 13.0, *) {
             encoder.outputFormatting = [.withoutEscapingSlashes]
         }
         return encoder


### PR DESCRIPTION
Some of the availability checks for OS versions were not correct, and it failed compiling on them