### PR TITLE
Review visibility of classes and methods

### DIFF
--- a/Sources/OpenTelemetryApi/Context/Propagation/DefaultContextPropagators.swift
+++ b/Sources/OpenTelemetryApi/Context/Propagation/DefaultContextPropagators.swift
@@ -21,11 +21,11 @@ import Foundation
 public struct DefaultContextPropagators: ContextPropagators {
     public var httpTextFormat: HTTPTextFormattable
 
-    init() {
+    public init() {
         httpTextFormat = NoopHttpTextFormat()
     }
 
-    init(textPropagators: [HTTPTextFormattable]) {
+    public init(textPropagators: [HTTPTextFormattable]) {
         httpTextFormat = MultiHttpTextFormat(textPropagators: textPropagators)
     }
 
@@ -76,8 +76,7 @@ public struct DefaultContextPropagators: ContextPropagators {
     struct NoopHttpTextFormat: HTTPTextFormattable {
         public var fields = Set<String>()
 
-        public func inject<S>(spanContext: SpanContext, carrier: inout [String: String], setter: S) where S: Setter {
-        }
+        public func inject<S>(spanContext: SpanContext, carrier: inout [String: String], setter: S) where S: Setter {}
 
         public func extract<G>(spanContext: SpanContext?, carrier: [String: String], getter: G) -> SpanContext? where G: Getter {
             return spanContext

--- a/Sources/OpenTelemetryApi/CorrelationContext/DefaultCorrelationContextManager.swift
+++ b/Sources/OpenTelemetryApi/CorrelationContext/DefaultCorrelationContextManager.swift
@@ -19,7 +19,7 @@ import Foundation
 public class DefaultCorrelationContextManager: CorrelationContextManager {
     ///  Returns a CorrelationContextManager singleton that is the default implementation for
     ///  CorrelationContextManager.
-    static var instance = DefaultCorrelationContextManager()
+    public static var instance = DefaultCorrelationContextManager()
 
     private init() {}
 

--- a/Sources/OpenTelemetryApi/CorrelationContext/EntryMetadata.swift
+++ b/Sources/OpenTelemetryApi/CorrelationContext/EntryMetadata.swift
@@ -38,7 +38,7 @@ public enum EntryTtl: Equatable {
 }
 
 public struct EntryMetadata: Equatable {
-    var entryTtl: EntryTtl
+    public var entryTtl: EntryTtl
 
     public init(entryTtl: EntryTtl) {
         self.entryTtl = entryTtl

--- a/Sources/OpenTelemetryApi/Metrics/CounterMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/CounterMetric.swift
@@ -76,18 +76,18 @@ public struct AnyCounterMetric<T>: CounterMetric {
     }
 }
 
-struct NoopCounterMetric<T>: CounterMetric {
-    func add(value: T, labelset: LabelSet) {
-    }
+public struct NoopCounterMetric<T>: CounterMetric {
+    public init() {}
 
-    func add(value: T, labels: [String: String]) {
-    }
+    public func add(value: T, labelset: LabelSet) {}
 
-    func bind(labelset: LabelSet) -> BoundCounterMetric<T> {
+    public func add(value: T, labels: [String: String]) {}
+
+    public func bind(labelset: LabelSet) -> BoundCounterMetric<T> {
         return BoundCounterMetric<T>()
     }
 
-    func bind(labels: [String: String]) -> BoundCounterMetric<T> {
+    public func bind(labels: [String: String]) -> BoundCounterMetric<T> {
         return BoundCounterMetric<T>()
     }
 }

--- a/Sources/OpenTelemetryApi/Metrics/DefaultMeterProvider.swift
+++ b/Sources/OpenTelemetryApi/Metrics/DefaultMeterProvider.swift
@@ -15,15 +15,15 @@
 
 import Foundation
 
-class DefaultMeterProvider: MeterProvider {
-    static var instance: MeterProvider = DefaultMeterProvider()
+public class DefaultMeterProvider: MeterProvider {
+    public static var instance: MeterProvider = DefaultMeterProvider()
 
     static var proxyMeter = ProxyMeter()
     static var initialized = false
 
-    public init() {}
+    init() {}
 
-    static func setDefault(meterFactory: MeterProvider) {
+    public static func setDefault(meterFactory: MeterProvider) {
         guard !initialized else {
             return
         }
@@ -32,7 +32,7 @@ class DefaultMeterProvider: MeterProvider {
         initialized = true
     }
 
-    func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Meter {
+    public func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Meter {
         return DefaultMeterProvider.initialized ? DefaultMeterProvider.instance.get(instrumentationName: instrumentationName, instrumentationVersion: instrumentationVersion) : DefaultMeterProvider.proxyMeter
     }
 

--- a/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/DoubleObserverMetric.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 /// Observer instrument for Double values.
-public protocol DoubleObserverMetric: AnyObject {
+public protocol DoubleObserverMetric {
     /// Observes a value.
     /// - Parameters:
     ///   - value: value to observe.
@@ -31,10 +31,10 @@ public protocol DoubleObserverMetric: AnyObject {
     func observe(value: Double, labels: [String: String])
 }
 
-class NoopDoubleObserverMetric: DoubleObserverMetric {
-    func observe(value: Double, labelset: LabelSet) {
-    }
+public struct NoopDoubleObserverMetric: DoubleObserverMetric {
+    public init() {}
 
-    func observe(value: Double, labels: [String: String]) {
-    }
+    public func observe(value: Double, labelset: LabelSet) {}
+
+    public func observe(value: Double, labels: [String: String]) {}
 }

--- a/Sources/OpenTelemetryApi/Metrics/IntObserverMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/IntObserverMetric.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 /// Observer instrument for Int values.
-public protocol IntObserverMetric: AnyObject {
+public protocol IntObserverMetric {
     /// Observes a value.
     /// - Parameters:
     ///   - value: value to observe.
@@ -31,10 +31,10 @@ public protocol IntObserverMetric: AnyObject {
     func observe(value: Int, labels: [String: String])
 }
 
-class NoopIntObserverMetric: IntObserverMetric {
-    func observe(value: Int, labelset: LabelSet) {
-    }
+public struct NoopIntObserverMetric: IntObserverMetric {
+    public init() {}
 
-    func observe(value: Int, labels: [String: String]) {
-    }
+    public func observe(value: Int, labelset: LabelSet) {}
+
+    public func observe(value: Int, labels: [String: String]) {}
 }

--- a/Sources/OpenTelemetryApi/Metrics/MeasureMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeasureMetric.swift
@@ -68,12 +68,14 @@ public struct AnyMeasureMetric<T>: MeasureMetric {
     }
 }
 
-struct NoopMeasureMetric<T>: MeasureMetric {
-    func bind(labelset: LabelSet) -> BoundMeasureMetric<T> {
+public struct NoopMeasureMetric<T>: MeasureMetric {
+    public init() {}
+
+    public func bind(labelset: LabelSet) -> BoundMeasureMetric<T> {
         BoundMeasureMetric<T>()
     }
 
-    func bind(labels: [String: String]) -> BoundMeasureMetric<T> {
+    public func bind(labels: [String: String]) -> BoundMeasureMetric<T> {
         BoundMeasureMetric<T>()
     }
 }

--- a/Sources/OpenTelemetryApi/Metrics/Meter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Meter.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 /// Main interface to obtain metric instruments.
-public protocol Meter: AnyObject {
+public protocol Meter {
     /// Creates Int counter with given name.
     /// - Parameters:
     ///   - name: The name of the counter.

--- a/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
@@ -16,38 +16,38 @@
 import Foundation
 
 /// Proxy Meter which act as a No-Op Meter, until real meter is provided.
-class ProxyMeter: Meter {
+public struct ProxyMeter: Meter {
     private var realMeter: Meter?
 
-    func getLabelSet(labels: [String: String]) -> LabelSet {
+    public func getLabelSet(labels: [String: String]) -> LabelSet {
         return realMeter?.getLabelSet(labels: labels) ?? LabelSet.empty
     }
 
-    func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
+    public func createIntCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Int> {
         return realMeter?.createIntCounter(name: name, monotonic: monotonic) ?? AnyCounterMetric<Int>(NoopCounterMetric<Int>())
     }
 
-    func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
+    public func createDoubleCounter(name: String, monotonic: Bool) -> AnyCounterMetric<Double> {
         return realMeter?.createDoubleCounter(name: name, monotonic: monotonic) ?? AnyCounterMetric<Double>(NoopCounterMetric<Double>())
     }
 
-    func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
+    public func createIntMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Int> {
         return realMeter?.createIntMeasure(name: name, absolute: absolute) ?? AnyMeasureMetric<Int>(NoopMeasureMetric<Int>())
     }
 
-    func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
+    public func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
         return realMeter?.createDoubleMeasure(name: name, absolute: absolute) ?? AnyMeasureMetric<Double>(NoopMeasureMetric<Double>())
     }
 
-    func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
+    public func createIntObserver(name: String, absolute: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
         return realMeter?.createIntObserver(name: name, absolute: absolute, callback: callback) ?? NoopIntObserverMetric()
     }
 
-    func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
+    public func createDoubleObserver(name: String, absolute: Bool, callback: @escaping (DoubleObserverMetric) -> Void) -> DoubleObserverMetric {
         return realMeter?.createDoubleObserver(name: name, absolute: absolute, callback: callback) ?? NoopDoubleObserverMetric()
     }
 
-    func updateMeter(realMeter: Meter) {
+    mutating func updateMeter(realMeter: Meter) {
         guard self.realMeter == nil else {
             return
         }

--- a/Sources/OpenTelemetryApi/Trace/TraceFlags.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceFlags.swift
@@ -33,7 +33,7 @@ public struct TraceFlags: Equatable, CustomStringConvertible {
     private var options: UInt8 = 0
 
     /// Returns the one byte representation of the TraceFlags.
-    var byte: UInt8 {
+    public var byte: UInt8 {
         return options
     }
 
@@ -43,8 +43,7 @@ public struct TraceFlags: Equatable, CustomStringConvertible {
     }
 
     /// Creates the default TraceFlags
-    public init() {
-    }
+    public init() {}
 
     /// Creates a new TraceFlags with the given options.
     /// - Parameter fromByte: the byte representation of the TraceFlags.
@@ -102,9 +101,9 @@ public struct TraceFlags: Equatable, CustomStringConvertible {
 
 extension TraceFlags: Encodable {
     enum CodingKeys: String, CodingKey {
-        case sampled = "sampled"
+        case sampled
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(sampled, forKey: .sampled)

--- a/Sources/OpenTelemetryApi/Trace/TraceId.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceId.swift
@@ -23,8 +23,8 @@ public struct TraceId: Comparable, Hashable, CustomStringConvertible, Equatable 
     public static let invalid = TraceId()
 
     // The internal representation of the TraceId.
-    var idHi: UInt64 = invalidId
-    var idLo: UInt64 = invalidId
+    public private(set) var idHi: UInt64 = invalidId
+    public private(set) var idLo: UInt64 = invalidId
 
     /// Constructs a TraceId whose representation is specified by two long values representing
     /// the lower and higher parts.
@@ -42,8 +42,7 @@ public struct TraceId: Comparable, Hashable, CustomStringConvertible, Equatable 
     }
 
     /// Returns an invalid TraceId. All bytes are '\0'.
-    public init() {
-    }
+    public init() {}
 
     /// Generates a new random TraceId.
     public static func random() -> TraceId {
@@ -70,7 +69,7 @@ public struct TraceId: Comparable, Hashable, CustomStringConvertible, Equatable 
 
     /// Returns a TraceId whose representation is copied from the src beginning at the offset.
     /// - Parameter data: the byte array from where the representation of the TraceId is copied.
-    public init(fromBytes bytes: Array<UInt8>) {
+    public init(fromBytes bytes: [UInt8]) {
         self.init(fromData: Data(bytes))
     }
 
@@ -103,7 +102,7 @@ public struct TraceId: Comparable, Hashable, CustomStringConvertible, Equatable 
     /// - Parameters:
     ///   - dest: the destination buffer.
     ///   - destOffset: the starting offset in the destination buffer.
-    public func copyBytesTo(dest: inout Array<UInt8>, destOffset: Int) {
+    public func copyBytesTo(dest: inout [UInt8], destOffset: Int) {
         dest.replaceSubrange(destOffset ..< destOffset + MemoryLayout<UInt64>.size,
                              with: withUnsafeBytes(of: idHi.bigEndian) { Array($0) })
         dest.replaceSubrange(destOffset + MemoryLayout<UInt64>.size ..< destOffset + MemoryLayout<UInt64>.size * 2,
@@ -177,7 +176,7 @@ public struct TraceId: Comparable, Hashable, CustomStringConvertible, Equatable 
     public static func < (lhs: TraceId, rhs: TraceId) -> Bool {
         if lhs.idHi < rhs.idHi {
             return true
-        } else if lhs.idHi == rhs.idHi && lhs.idLo < rhs.idLo {
+        } else if lhs.idHi == rhs.idHi, lhs.idLo < rhs.idLo {
             return true
         } else {
             return false

--- a/Sources/OpenTelemetryApi/Trace/TraceState.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceState.swift
@@ -26,13 +26,12 @@ import Foundation
 public struct TraceState: Equatable {
     private static let maxKeyValuePairs = 32
 
-    private(set) var entries = [Entry]()
+    public private(set) var entries = [Entry]()
 
     /// Returns the default with no entries.
-    public init() {
-    }
+    public init() {}
 
-    init?(entries: [Entry]) {
+    public init?(entries: [Entry]) {
         guard entries.count <= TraceState.maxKeyValuePairs else { return nil }
 
         self.entries = entries
@@ -100,8 +99,8 @@ public struct TraceState: Equatable {
         /// - Parameters:
         ///   - key: the Entry's key.
         ///   - value: the Entry's value.
-        init?(key: String, value: String) {
-            if TraceStateUtils.validateKey(key: key) && TraceStateUtils.validateValue(value: value) {
+        public init?(key: String, value: String) {
+            if TraceStateUtils.validateKey(key: key), TraceStateUtils.validateValue(value: value) {
                 self.key = key
                 self.value = value
                 return
@@ -113,9 +112,9 @@ public struct TraceState: Equatable {
 
 extension TraceState: Encodable {
     enum CodingKeys: String, CodingKey {
-        case entries = "entries"
+        case entries
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(entries, forKey: .entries)

--- a/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
@@ -18,12 +18,11 @@ import OpenTelemetryApi
 
 /// representation of all data collected by the Span.
 public struct SpanData: Equatable {
-
     public class Link: OpenTelemetryApi.Link {
         public let context: SpanContext
         public let attributes: [String: AttributeValue]
 
-        init(context: SpanContext, attributes: [String: AttributeValue] = [String: AttributeValue]()) {
+        public init(context: SpanContext, attributes: [String: AttributeValue] = [String: AttributeValue]()) {
             self.context = context
             self.attributes = attributes
         }

--- a/Sources/OpenTelemetrySdk/Trace/Export/BatchSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/BatchSpanProcessor.swift
@@ -27,7 +27,7 @@ public struct BatchSpanProcessor: SpanProcessor {
     var sampled: Bool
     fileprivate var worker: BatchWorker
 
-    init(spanExporter: SpanExporter, sampled: Bool = true, scheduleDelay: TimeInterval = 5, maxQueueSize: Int = 2048, maxExportBatchSize: Int = 512) {
+    public init(spanExporter: SpanExporter, sampled: Bool = true, scheduleDelay: TimeInterval = 5, maxQueueSize: Int = 2048, maxExportBatchSize: Int = 512) {
         worker = BatchWorker(spanExporter: spanExporter,
                              scheduleDelay: scheduleDelay,
                              maxQueueSize: maxQueueSize,
@@ -35,15 +35,14 @@ public struct BatchSpanProcessor: SpanProcessor {
         worker.start()
         self.sampled = sampled
     }
-    
+
     public let isStartRequired = false
     public let isEndRequired = true
 
-    public func onStart(span: ReadableSpan) {
-    }
+    public func onStart(span: ReadableSpan) {}
 
     public func onEnd(span: ReadableSpan) {
-        if sampled && !span.context.traceFlags.sampled {
+        if sampled, !span.context.traceFlags.sampled {
             return
         }
         worker.addSpan(span: span)

--- a/Sources/OpenTelemetrySdk/Trace/NoopSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/NoopSpanProcessor.swift
@@ -16,18 +16,16 @@
 import Foundation
 
 public struct NoopSpanProcessor: SpanProcessor {
+    public init() {}
+
     public let isStartRequired = false
     public let isEndRequired = false
 
-    public func onStart(span: ReadableSpan) {
-    }
+    public func onStart(span: ReadableSpan) {}
 
-    public func onEnd(span: ReadableSpan) {
-    }
+    public func onEnd(span: ReadableSpan) {}
 
-    public func shutdown() {
-    }
+    public func shutdown() {}
 
-    public func forceFlush() {
-    }
+    public func forceFlush() {}
 }

--- a/Sources/OpenTelemetrySdk/Trace/RandomIdsGenerator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RandomIdsGenerator.swift
@@ -17,6 +17,8 @@ import Foundation
 import OpenTelemetryApi
 
 public struct RandomIdsGenerator: IdsGenerator {
+    public init() {}
+
     public func generateSpanId() -> SpanId {
         var id: UInt64
         repeat {

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -33,7 +33,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
     /// Contains the identifiers associated with this Span.
     public private(set) var context: SpanContext
     /// The parent SpanId of this span. Invalid if this is a root span.
-    private(set) var parentSpanId: SpanId?
+    public private(set) var parentSpanId: SpanId?
     /// True if the parent is on a different process.
     public private(set) var hasRemoteParent: Bool
     /// /Handler called when the span starts and ends.
@@ -219,7 +219,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
                 attributes.removeValueForKey(key: key)
             }
             totalAttributeCount += 1
-            if attributes[key] == nil && totalAttributeCount > maxNumberOfAttributes {
+            if attributes[key] == nil, totalAttributeCount > maxNumberOfAttributes {
                 return
             }
             attributes[key] = value
@@ -250,7 +250,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
         addTimedEvent(timedEvent: TimedEvent(epochNanos: clock.now, event: event))
     }
 
-    public func addEvent(event: TimedEvent){
+    public func addEvent(event: TimedEvent) {
         addTimedEvent(timedEvent: event)
     }
 

--- a/Tests/OpenTelemetryApiTests/Common/AttributeValueTests.swift
+++ b/Tests/OpenTelemetryApiTests/Common/AttributeValueTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 class AttributeValueTest: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Context/Propagation/B3PropagatorTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/Propagation/B3PropagatorTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 class B3PropagatorTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Context/Propagation/BinaryFormatTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/Propagation/BinaryFormatTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 class BinaryFormatTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/CorrelationContext/DefaultCorrelationContextManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/CorrelationContext/DefaultCorrelationContextManagerTests.swift
@@ -13,11 +13,11 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
-fileprivate let key = EntryKey(name: "key")!
-fileprivate let value = EntryValue(string: "value")!
+private let key = EntryKey(name: "key")!
+private let value = EntryValue(string: "value")!
 
 class TestCorrelationContext: CorrelationContext {
     static func contextBuilder() -> CorrelationContextBuilder {

--- a/Tests/OpenTelemetryApiTests/CorrelationContext/EntryMetadataTests.swift
+++ b/Tests/OpenTelemetryApiTests/CorrelationContext/EntryMetadataTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 class EntryMetadataTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/CorrelationContext/EntryTests.swift
+++ b/Tests/OpenTelemetryApiTests/CorrelationContext/EntryTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 class EntryTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Metrics/DefaultMeterProviderTests.swift
+++ b/Tests/OpenTelemetryApiTests/Metrics/DefaultMeterProviderTests.swift
@@ -22,11 +22,11 @@ final class DefaultMeterProviderTests: XCTestCase {
     }
 
     func testDefault() {
-        let defaultMeter =   DefaultMeterProvider.instance.get(instrumentationName: "", instrumentationVersion: nil)
+        let defaultMeter = DefaultMeterProvider.instance.get(instrumentationName: "", instrumentationVersion: nil)
         XCTAssert(defaultMeter is ProxyMeter)
-        let otherMeter =   DefaultMeterProvider.instance.get(instrumentationName: "named meter", instrumentationVersion: nil)
+        let otherMeter = DefaultMeterProvider.instance.get(instrumentationName: "named meter", instrumentationVersion: nil)
         XCTAssert(otherMeter is ProxyMeter)
-        XCTAssert(defaultMeter === otherMeter)
+        XCTAssert(defaultMeter is ProxyMeter)
 
         let counter = defaultMeter.createDoubleCounter(name: "ctr")
         XCTAssert(counter.internalCounter is NoopCounterMetric<Double>)
@@ -37,11 +37,11 @@ final class DefaultMeterProviderTests: XCTestCase {
         DefaultMeterProvider.setDefault(meterFactory: factory)
         XCTAssert(DefaultMeterProvider.initialized)
 
-        let defaultMeter =   DefaultMeterProvider.instance.get(instrumentationName: "", instrumentationVersion: nil)
+        let defaultMeter = DefaultMeterProvider.instance.get(instrumentationName: "", instrumentationVersion: nil)
         XCTAssert(defaultMeter is TestNoopMeter)
 
-        let otherMeter =   DefaultMeterProvider.instance.get(instrumentationName: "named meter", instrumentationVersion: nil)
-        XCTAssert(defaultMeter !== otherMeter)
+        let otherMeter = DefaultMeterProvider.instance.get(instrumentationName: "named meter", instrumentationVersion: nil)
+        XCTAssert(otherMeter is TestNoopMeter)
 
         let counter = defaultMeter.createIntCounter(name: "ctr")
         XCTAssert(counter.internalCounter is NoopCounterMetric<Int>)
@@ -58,16 +58,13 @@ final class DefaultMeterProviderTests: XCTestCase {
     }
 
     func testUpdateDefault_CachedTracer() {
-        let defaultMeter =   DefaultMeterProvider.instance.get(instrumentationName: "", instrumentationVersion: nil)
+        let defaultMeter = DefaultMeterProvider.instance.get(instrumentationName: "", instrumentationVersion: nil)
         let noOpCounter = defaultMeter.createDoubleCounter(name: "ctr")
         XCTAssert(noOpCounter.internalCounter is NoopCounterMetric<Double>)
 
         DefaultMeterProvider.setDefault(meterFactory: TestMeter())
         let counter = defaultMeter.createDoubleCounter(name: "ctr")
         XCTAssert(counter.internalCounter is NoopCounterMetric<Double>)
-
-        let newdefaultMeter =   DefaultMeterProvider.instance.get(instrumentationName: "", instrumentationVersion: nil)
-        XCTAssert(defaultMeter !== newdefaultMeter)
     }
 }
 

--- a/Tests/OpenTelemetryApiTests/Trace/DefaultSpanTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/DefaultSpanTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 final class TestEvent: Event {

--- a/Tests/OpenTelemetryApiTests/Trace/DefaultTracerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/DefaultTracerTests.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 final class DefaultTracerTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Trace/SpanBuilderTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/SpanBuilderTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 class SpanBuilderTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Trace/SpanContextTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/SpanContextTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 final class SpanContextTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Trace/SpanIdTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/SpanIdTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 final class SpanIdTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Trace/StatusTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/StatusTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 final class StatusTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Trace/TraceFlagsTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/TraceFlagsTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 final class TraceFlagsTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Trace/TraceIdTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/TraceIdTests.swift
@@ -13,14 +13,13 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 final class TraceIdTests: XCTestCase {
     let firstBytes: [UInt8] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, UInt8(ascii: "a")]
     let secondBytes: [UInt8] = [0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, UInt8(ascii: "A")]
     let shortBytes: [UInt8] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, UInt8(ascii: "b")]
-
 
     var first: TraceId!
     var second: TraceId!
@@ -65,7 +64,6 @@ final class TraceIdTests: XCTestCase {
         XCTAssertEqual(TraceId(fromHexString: "YY00000000000000000000000000000061AA", withOffset: 2), first)
         XCTAssertEqual(TraceId(fromHexString: "ZZff000000000000000000000000000041BB", withOffset: 2), second)
         XCTAssertEqual(TraceId(fromHexString: "ZZ0000000000000062AA", withOffset: 2), short)
-
     }
 
     func testToHexString() {
@@ -105,7 +103,6 @@ final class TraceIdTests: XCTestCase {
         XCTAssertTrue(first.description.contains("00000000000000000000000000000061"))
         XCTAssertTrue(second.description.contains("ff000000000000000000000000000041"))
         XCTAssertTrue(short.description.contains("0000000000000062"))
-
     }
 
     static var allTests = [

--- a/Tests/OpenTelemetryApiTests/Trace/TracestateTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/TracestateTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetryApi
+import OpenTelemetryApi
 import XCTest
 
 final class TraceStateTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/DistributedContext/DistributedContextManagerSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/DistributedContext/DistributedContextManagerSdkTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class CorrelationContextManagerSdkTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/DistributedContext/DistributedContextSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/DistributedContext/DistributedContextSdkTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class CorrelationContextSdkTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/DistributedContext/Mocks/DistributedContextMock.swift
+++ b/Tests/OpenTelemetrySdkTests/DistributedContext/Mocks/DistributedContextMock.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 
 class CorrelationContextMock: CorrelationContext {
     static func contextBuilder() -> CorrelationContextBuilder {

--- a/Tests/OpenTelemetrySdkTests/DistributedContext/ScopedDistributedContextTests.swift
+++ b/Tests/OpenTelemetrySdkTests/DistributedContext/ScopedDistributedContextTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class ScopedCorrelationContextTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Internal/MonotonicClockTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Internal/MonotonicClockTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class MonotonicClockTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Internal/TestClock.swift
+++ b/Tests/OpenTelemetrySdkTests/Internal/TestClock.swift
@@ -14,7 +14,7 @@
 //
 
 import Foundation
-import OpenTelemetryApi
+import OpenTelemetrySdk
 
 /// A mutable Clock that allows the time to be set for testing.
 class TestClock: Clock {

--- a/Tests/OpenTelemetrySdkTests/Internal/TestClockTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Internal/TestClockTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class TestClockTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Metrics/TestMetricExporter.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/TestMetricExporter.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class TestMetricExporter: MetricExporter {

--- a/Tests/OpenTelemetrySdkTests/Metrics/TestMetricProcessor.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/TestMetricProcessor.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class TestMetricProcessor: MetricProcessor {

--- a/Tests/OpenTelemetrySdkTests/Resource/ResourceTest.swift
+++ b/Tests/OpenTelemetrySdkTests/Resource/ResourceTest.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class ResourceTest: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Trace/Config/TraceConfigTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Config/TraceConfigTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class TraceConfigTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Trace/Export/BatchSpansProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Export/BatchSpansProcessorTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class BatchSpansProcessorTests: XCTestCase {
@@ -205,7 +205,6 @@ class BatchSpansProcessorTests: XCTestCase {
 }
 
 class BlockingSpanExporter: SpanExporter {
-    
     let cond = NSCondition()
 
     enum State {
@@ -235,13 +234,12 @@ class BlockingSpanExporter: SpanExporter {
         }
         cond.unlock()
     }
-    
+
     func flush() -> SpanExporterResultCode {
         return .success
     }
 
-    func shutdown() {
-    }
+    func shutdown() {}
 
     fileprivate func unblock() {
         cond.lock()
@@ -269,10 +267,10 @@ class WaitingSpanExporter: SpanExporter {
         while spanDataList.count < numberToWaitFor {
             cond.wait()
         }
-            ret = spanDataList
-            spanDataList.removeAll()
+        ret = spanDataList
+        spanDataList.removeAll()
 
-            return ret
+        return ret
     }
 
     func export(spans: [SpanData]) -> SpanExporterResultCode {
@@ -282,7 +280,7 @@ class WaitingSpanExporter: SpanExporter {
         cond.broadcast()
         return .success
     }
-    
+
     func flush() -> SpanExporterResultCode {
         return .success
     }

--- a/Tests/OpenTelemetrySdkTests/Trace/Export/MultiSpanExporterTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Export/MultiSpanExporterTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class MultiSpanExporterTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Trace/Export/SimpleSpansProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Export/SimpleSpansProcessorTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class SimpleSpansProcessorTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanExporterMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanExporterMock.swift
@@ -14,7 +14,7 @@
 //
 
 import Foundation
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 
 class SpanExporterMock: SpanExporter {
     var exportCalledTimes: Int = 0

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 
 class SpanMock: Span {
     var name: String = ""
@@ -30,29 +30,21 @@ class SpanMock: Span {
 
     var status: Status?
 
-    func updateName(name: String) {
-    }
+    func updateName(name: String) {}
 
-    func setAttribute(key: String, value: AttributeValue?) {
-    }
+    func setAttribute(key: String, value: AttributeValue?) {}
 
-    func addEvent(name: String) {
-    }
+    func addEvent(name: String) {}
 
-    func addEvent(name: String, attributes: [String: AttributeValue]) {
-    }
+    func addEvent(name: String, attributes: [String: AttributeValue]) {}
 
-    func addEvent<E>(event: E) where E: Event {
-    }
+    func addEvent<E>(event: E) where E: Event {}
 
-    func addEvent(name: String, timestamp: Date) {
-    }
+    func addEvent(name: String, timestamp: Date) {}
 
-    func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {
-    }
+    func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {}
 
-    func addEvent<E>(event: E, timestamp: Date) where E: Event {
-    }
+    func addEvent<E>(event: E, timestamp: Date) where E: Event {}
 
     var description: String = "SpanMock"
 }

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanProcessorMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanProcessorMock.swift
@@ -14,7 +14,7 @@
 //
 
 import Foundation
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 
 class SpanProcessorMock: SpanProcessor {
     var onStartCalledTimes = 0

--- a/Tests/OpenTelemetrySdkTests/Trace/MultiSpanProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/MultiSpanProcessorTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class MultiSpanProcessorTest: XCTestCase {
@@ -89,12 +89,12 @@ class MultiSpanProcessorTest: XCTestCase {
     func testTwoSpanProcessorDifferentRequirements() {
         spanProcessor1.isEndRequired = false
         spanProcessor2.isStartRequired = false
-        
+
         let multiSpanProcessor = MultiSpanProcessor(spanProcessors: [spanProcessor1, spanProcessor2])
 
         XCTAssertTrue(multiSpanProcessor.isStartRequired)
         XCTAssertTrue(multiSpanProcessor.isEndRequired)
-        
+
         multiSpanProcessor.onStart(span: readableSpan)
         XCTAssert(spanProcessor1.onStartCalledSpan === readableSpan)
         XCTAssertFalse(spanProcessor2.onStartCalled)

--- a/Tests/OpenTelemetrySdkTests/Trace/NoopSpanProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/NoopSpanProcessorTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class NoopSpanProcessorTest: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 import os.activity

--- a/Tests/OpenTelemetrySdkTests/Trace/TimedEventTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/TimedEventTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class TimedEventTests: XCTestCase {

--- a/Tests/OpenTelemetrySdkTests/Trace/TracerSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/TracerSdkTests.swift
@@ -14,7 +14,7 @@
 //
 
 import OpenTelemetryApi
-@testable import OpenTelemetrySdk
+import OpenTelemetrySdk
 import XCTest
 
 class TracerSdkTests: XCTestCase {


### PR DESCRIPTION
Review visibility of classes and methods, some of them could not be used properly outside of the library
Convert some Metrics classes to structs, since are not meant to be inherited
Modify tests import so only those files needing non public access import libraries as `@testable`
Code styling done to the modified files

It modifies many files all are them are minor changes