### PR TITLE
Use numbered version of opentracing-objc library

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Opentracing",
         "repositoryURL": "https://github.com/undefinedlabs/opentracing-objc",
         "state": {
-          "branch": "spm-support",
-          "revision": "c3a60aa19668e48f647c2e9d9ce7e364f69bc496",
-          "version": null
+          "branch": null,
+          "revision": "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+          "version": "0.5.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .executable(name: "loggingTracer", targets: ["LoggingTracer"]),
     ],
     dependencies: [
-        .package(url:  "https://github.com/undefinedlabs/opentracing-objc", .branch("spm-support")), // Need custom fork because of SPM
+        .package(url:  "https://github.com/undefinedlabs/opentracing-objc",  from: "0.5.2"), // Need custom fork because of SPM
         .package(url:  "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1"), // Need custom fork because of SPM
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.12"),


### PR DESCRIPTION
Swift Package manager forces to use a numbered version of opentracing-objc library, so our library can also be used with a numbered version