### PR TITLE
Rework Span Status logic

### DIFF
--- a/Examples/Logging Tracer/LoggingSpan.swift
+++ b/Examples/Logging Tracer/LoggingSpan.swift
@@ -21,7 +21,7 @@ class LoggingSpan: Span {
     var kind: SpanKind
     var context: SpanContext = SpanContext.invalid
     var isRecording: Bool = true
-    var status: Status?
+    var status: Status = .unset
     var scope: Scope?
 
 

--- a/Sources/Exporters/DatadogExporter/Spans/SpanEncoder.swift
+++ b/Sources/Exporters/DatadogExporter/Spans/SpanEncoder.swift
@@ -95,14 +95,14 @@ internal struct DDSpan: Encodable {
         self.startTime = spanData.startEpochNanos
         self.duration = spanData.endEpochNanos - spanData.startEpochNanos
 
-        if spanData.status?.isOk ?? true {
+        if spanData.status.isOk {
             self.error = false
             self.errorMessage = nil
             self.errorType = nil
             self.errorStack = nil
         } else {
             self.error = true
-            self.errorType = spanData.attributes["error.type"]?.description ?? spanData.status?.description
+            self.errorType = spanData.attributes["error.type"]?.description ?? spanData.status.description
             self.errorMessage = spanData.attributes["error.message"]?.description
             self.errorStack = spanData.attributes["error.stack"]?.description
         }

--- a/Sources/Exporters/Jaeger/Adapter.swift
+++ b/Sources/Exporters/Jaeger/Adapter.swift
@@ -75,8 +75,8 @@ final class Adapter {
         }
 
         tags.append(Tag(key: Adapter.keySpanKind, vType: .string, vStr: span.kind.rawValue.uppercased(), vDouble: nil, vBool: nil, vLong: nil, vBinary: nil))
-        tags.append(Tag(key: Adapter.keySpanStatusMessage, vType: .string, vStr: span.status?.statusDescription ?? "", vDouble: nil, vBool: nil, vLong: nil, vBinary: nil))
-        tags.append(Tag(key: Adapter.keySpanStatusCode, vType: .long, vStr: nil, vDouble: nil, vBool: nil, vLong: Int64(span.status?.statusCode.rawValue ?? 0), vBinary: nil))
+        tags.append(Tag(key: Adapter.keySpanStatusMessage, vType: .string, vStr: span.status.statusDescription ?? "", vDouble: nil, vBool: nil, vLong: nil, vBinary: nil))
+        tags.append(Tag(key: Adapter.keySpanStatusCode, vType: .long, vStr: nil, vDouble: nil, vBool: nil, vLong: Int64(span.status.statusCode.rawValue ?? 0), vBinary: nil))
 
         if span.status != .ok {
             tags.append(Tag(key: keyError, vType: .bool, vStr: nil, vDouble: nil, vBool: true, vLong: nil, vBinary: nil))

--- a/Sources/Exporters/Zipkin/Implementation/ZipkinConversionExtension.swift
+++ b/Sources/Exporters/Zipkin/Implementation/ZipkinConversionExtension.swift
@@ -76,10 +76,10 @@ struct ZipkinConversionExtension {
 
         let status = otelSpan.status
 
-        if status?.isOk ?? false {
-            attributeEnumerationState.tags[statusCode] = "\(status!.statusCode)".capitalized
-            if status?.statusDescription != nil {
-                attributeEnumerationState.tags[statusDescription] = status!.description
+        if status.isOk {
+            attributeEnumerationState.tags[statusCode] = "\(status.statusCode)".capitalized
+            if status.statusDescription != nil {
+                attributeEnumerationState.tags[statusDescription] = status.statusDescription
             }
         }
 

--- a/Sources/OpenTelemetryApi/Trace/DefaultSpan.swift
+++ b/Sources/OpenTelemetryApi/Trace/DefaultSpan.swift
@@ -60,7 +60,7 @@ public class DefaultSpan: Span {
         return false
     }
 
-    public var status: Status? {
+    public var status: Status {
         get {
             return Status.ok
         }

--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -30,7 +30,7 @@ public protocol Span: AnyObject, CustomStringConvertible {
     var isRecording: Bool { get }
 
     /// The status of the span execution.
-    var status: Status? { get set }
+    var status: Status { get set }
 
     /// The name of the Span.
     /// If changed, this will override the name provided via StartSpan method overload.

--- a/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
@@ -59,7 +59,7 @@ public struct SpanData: Equatable {
     public private(set) var links = [Link]()
 
     /// The Status.
-    public private(set) var status: Status?
+    public private(set) var status: Status = .unset
 
     /// The end epoch timestamp in nanos of this Span
     public private(set) var endEpochNanos: UInt64
@@ -172,7 +172,7 @@ public struct SpanData: Equatable {
         return self
     }
 
-    @discardableResult public mutating func settingTimedEvents(_ events: [Event]) -> SpanData {
+    @discardableResult public mutating func settingEvents(_ events: [Event]) -> SpanData {
         self.events = events
         return self
     }

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -67,9 +67,9 @@ public class RecordEventsReadableSpan: ReadableSpan {
     /// Number of events recorded.
     public private(set) var totalRecordedEvents = 0
     /// The status of the span.
-    public var status: Status? = Status.ok {
+    public var status: Status = Status.unset {
         didSet {
-            if hasEnded || status == nil {
+            if hasEnded {
                 status = oldValue
             }
         }
@@ -275,10 +275,6 @@ public class RecordEventsReadableSpan: ReadableSpan {
         spanProcessor.onEnd(span: self)
         isRecording = false
         scope?.close()
-    }
-
-    private func getStatusWithDefault() -> Status {
-        return status ?? Status.ok
     }
 
     public var description: String {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/SpanAdapterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/SpanAdapterTests.swift
@@ -38,7 +38,7 @@ class SpanAdapterTests: XCTestCase {
         testData.settingHasEnded(false)
         testData.settingAttributes(["key": AttributeValue.bool(true)])
         testData.settingTotalAttributeCount(2)
-        testData.settingTimedEvents([SpanData.Event(name: "my_event", epochNanos: 12347)])
+        testData.settingEvents([SpanData.Event(name: "my_event", epochNanos: 12347)])
         testData.settingTotalRecordedEvents(3)
         testData.settingLinks([SpanData.Link(context: spanContext)])
         testData.settingTotalRecordedLinks(2)

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/ReadableSpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/ReadableSpanMock.swift
@@ -52,7 +52,7 @@ class ReadableSpanMock: ReadableSpan {
 
     var isRecording: Bool = false
 
-    var status: Status?
+    var status: Status = .unset
 
     var scope: Scope?
 

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
@@ -28,7 +28,7 @@ class SpanMock: Span {
 
     var isRecording: Bool = false
 
-    var status: Status?
+    var status: Status = .unset
 
     var scope: Scope?
 


### PR DESCRIPTION
Rework Span Status logic following the spec, now unset is the default status.

Avoid using an optional for storage, now that default is unset.