### PR TITLE
Add startTimestamp to MetricData

### DIFF
--- a/Sources/Exporters/Prometheus/PrometheusMetric.swift
+++ b/Sources/Exporters/Prometheus/PrometheusMetric.swift
@@ -49,7 +49,7 @@ struct PrometheusMetric {
         }
 
         values.forEach { value in
-            output += value.name ?? name
+            output += value.name != nil ? PrometheusMetric.getSafeMetricName(name: value.name!) : name
 
             if value.labels.count > 0 {
                 output += "{"

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/Aggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/Aggregator.swift
@@ -15,40 +15,51 @@
 
 import Foundation
 
-protocol Aggregator: AnyObject {
-    associatedtype T
-    func update(value: T)
-    func checkpoint()
-    func toMetricData() -> MetricData
-    func getAggregationType() -> AggregationType
+public class Aggregator<T> {
+    var lastStart: Date = Date.distantFuture
+    var lastEnd: Date = Date()
+
+    public func update(value: T) {}
+    public func checkpoint() {
+        lastStart = lastEnd
+        lastEnd = Date()
+    }
+
+    public func toMetricData() -> MetricData {
+        return NoopMetricData()
+    }
+    public func getAggregationType() -> AggregationType {
+        return .intSum
+    }
+
 }
 
-public class AnyAggregator<T>: Aggregator {
-    private let _update: (T) -> Void
-    private let _checkpoint: () -> Void
-    private let _toMetricData: () -> MetricData
-    private let _getAggregationType: () -> AggregationType
-
-    init<U: Aggregator>(_ aggregable: U) where U.T == T {
-        _update = aggregable.update
-        _checkpoint = aggregable.checkpoint
-        _toMetricData = aggregable.toMetricData
-        _getAggregationType = aggregable.getAggregationType
-    }
-
-    func update(value: T) {
-        _update(value)
-    }
-
-    func checkpoint() {
-        _checkpoint()
-    }
-
-    func toMetricData() -> MetricData {
-        return _toMetricData()
-    }
-
-    func getAggregationType() -> AggregationType {
-        return _getAggregationType()
-    }
-}
+// public class AnyAggregator<T>: Aggregator {
+//    private let _update: (T) -> Void
+//    private let _checkpoint: () -> Void
+//    private let _toMetricData: () -> MetricData
+//    private let _getAggregationType: () -> AggregationType
+//
+//    init<U: Aggregator>(_ aggregable: U) where U.T == T {
+//        _update = aggregable.update
+//        _checkpoint = aggregable.checkpoint
+//        _toMetricData = aggregable.toMetricData
+//        _getAggregationType = aggregable.getAggregationType
+//    }
+//
+//    func update(value: T) {
+//        _update(value)
+//    }
+//
+//    func checkpoint() {
+//        _checkpoint()
+//    }
+//
+//    func toMetricData() -> MetricData {
+//        return _toMetricData()
+//    }
+//
+//    func getAggregationType() -> AggregationType {
+//        return _getAggregationType()
+//    }
+// }

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/Aggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/Aggregator.swift
@@ -28,38 +28,8 @@ public class Aggregator<T> {
     public func toMetricData() -> MetricData {
         return NoopMetricData()
     }
+
     public func getAggregationType() -> AggregationType {
         return .intSum
     }
-
 }
-
-// public class AnyAggregator<T>: Aggregator {
-//    private let _update: (T) -> Void
-//    private let _checkpoint: () -> Void
-//    private let _toMetricData: () -> MetricData
-//    private let _getAggregationType: () -> AggregationType
-//
-//    init<U: Aggregator>(_ aggregable: U) where U.T == T {
-//        _update = aggregable.update
-//        _checkpoint = aggregable.checkpoint
-//        _toMetricData = aggregable.toMetricData
-//        _getAggregationType = aggregable.getAggregationType
-//    }
-//
-//    func update(value: T) {
-//        _update(value)
-//    }
-//
-//    func checkpoint() {
-//        _checkpoint()
-//    }
-//
-//    func toMetricData() -> MetricData {
-//        return _toMetricData()
-//    }
-//
-//    func getAggregationType() -> AggregationType {
-//        return _getAggregationType()
-//    }
-// }

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/CounterSumAggregator.swift
@@ -16,29 +16,30 @@
 import Foundation
 
 /// Basic aggregator which calculates a Sum from individual measurements.
-public class CounterSumAggregator<T: SignedNumeric>: Aggregator {
+public class CounterSumAggregator<T: SignedNumeric>: Aggregator<T> {
     var sum: T = 0
     var pointCheck: T = 0
     private let lock = Lock()
 
-    func update(value: T) {
+    override public func update(value: T) {
         lock.withLockVoid {
             sum += value
         }
     }
 
-    func checkpoint() {
+    override public func checkpoint() {
         lock.withLockVoid {
+            super.checkpoint()
             pointCheck = sum
             sum = 0
         }
     }
 
-    func toMetricData() -> MetricData {
-        return SumData<T>(timestamp: Date(), sum: pointCheck)
+    public override func toMetricData() -> MetricData {
+        return SumData<T>(startTimestamp: lastStart, timestamp: lastEnd , sum: pointCheck)
     }
 
-    func getAggregationType() -> AggregationType {
+    public override func getAggregationType() -> AggregationType {
         if T.self == Double.Type.self {
             return .doubleSum
         } else {

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/LastValueAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/LastValueAggregator.swift
@@ -16,29 +16,30 @@
 import Foundation
 
 /// Simple aggregator that only keeps the last value.
-public class LastValueAggregator<T: SignedNumeric>: Aggregator {
+public class LastValueAggregator<T: SignedNumeric>: Aggregator<T> {
     var value: T = 0
     var pointCheck: T = 0
 
     private let lock = Lock()
 
-    func update(value: T) {
+    public override func update(value: T) {
         lock.withLockVoid {
             self.value = value
         }
     }
 
-    func checkpoint() {
+    public override func checkpoint() {
         lock.withLockVoid {
+            super.checkpoint()
             self.pointCheck = self.value
         }
     }
 
-    func toMetricData() -> MetricData {
-        return SumData<T>(timestamp: Date(), sum: pointCheck)
+    public override func toMetricData() -> MetricData {
+        return SumData<T>(startTimestamp: lastStart, timestamp: lastEnd, sum: pointCheck)
     }
 
-    func getAggregationType() -> AggregationType {
+    public override func getAggregationType() -> AggregationType {
         if T.self == Double.Type.self {
             return .doubleSum
         } else {

--- a/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdk.swift
@@ -27,7 +27,7 @@ class BoundCounterMetricSdk<T: SignedNumeric>: BoundCounterMetricSdkBase<T> {
         sumAggregator.update(value: value)
     }
 
-    override func getAggregator() -> AnyAggregator<T> {
-        return AnyAggregator<T>(sumAggregator)
+    override func getAggregator() -> CounterSumAggregator<T> {
+        return sumAggregator
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundCounterMetricSdkBase.swift
@@ -25,7 +25,7 @@ class BoundCounterMetricSdkBase<T>: BoundCounterMetric<T> {
         super.init()
     }
 
-    func getAggregator() -> AnyAggregator<T> {
+    func getAggregator() -> Aggregator<T> {
         fatalError()
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdk.swift
@@ -27,7 +27,7 @@ internal class BoundMeasureMetricSdk<T: SignedNumeric & Comparable>: BoundMeasur
         measureAggregator.update(value: value)
     }
 
-    override func getAggregator() -> AnyAggregator<T> {
-        return AnyAggregator<T>(measureAggregator)
+    override func getAggregator() -> MeasureMinMaxSumCountAggregator<T> {
+        return measureAggregator
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundMeasureMetricSdkBase.swift
@@ -21,7 +21,7 @@ class BoundMeasureMetricSdkBase<T>: BoundMeasureMetric<T> {
         super.init()
     }
 
-    func getAggregator() -> AnyAggregator<T> {
+    func getAggregator() -> Aggregator<T> {
         fatalError()
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Export/MetricData.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/MetricData.swift
@@ -16,17 +16,26 @@
 import Foundation
 
 public protocol MetricData {
+    var startTimestamp: Date { get set }
     var timestamp: Date { get set }
     var labels: [String: String] { get set }
 }
 
+public struct NoopMetricData: MetricData {
+    public var startTimestamp =  Date.distantPast
+    public var timestamp =  Date.distantPast
+    public var labels = [String: String]()
+}
+
 public struct SumData<T>: MetricData {
+    public var startTimestamp: Date
     public var timestamp: Date
     public var labels: [String: String] = [String: String]()
     public var sum: T
 }
 
 public struct SummaryData<T>: MetricData {
+    public var startTimestamp: Date
     public var timestamp: Date
     public var labels: [String: String] = [String: String]()
     public var count: Int

--- a/Sources/OpenTelemetrySdk/Metrics/LabelSetSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/LabelSetSdk.swift
@@ -36,7 +36,6 @@ class LabelSetSdk: LabelSet {
             output += $0
             isFirstLabel = false
         }
-
         return output
     }
 }


### PR DESCRIPTION
Add startTimestamp to MetricData, so we can support time ranges.
It implies changing Aggregator from protocol to class.
Minor fix in Prometheus exporter