### PR TITLE
pinned GRPC to 1.0.0-alpha.12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         .package(name: "Opentracing", url: "https://github.com/undefinedlabs/opentracing-objc", from: "0.5.2"),
         .package(name: "Thrift", url: "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1"),
         .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-        .package(name: "grpc-swift", url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.12"),
+        .package(name: "grpc-swift", url: "https://github.com/grpc/grpc-swift.git", .exact("1.0.0-alpha.12")),
         .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0")
     ],
     targets: [


### PR DESCRIPTION
I was running into issues where GRPC-swift package was loading as 1.0.0-alpha.22 causing build errors: 

```
/Users/brycebuchanan/Library/Developer/Xcode/DerivedData/ios-integration-testing-gkpdnhglypnaamcidrafzbctcayl/SourcePackages/checkouts/opentelemetry-swift/Sources/Exporters/OpenTelemetryProtocol/proto/logs_service.grpc.swift:92:75: warning: 'GRPCProtobufPayload' is deprecated: This protocol is longer required. Please regenerate your code.
extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: GRPCProtobufPayload {}
                                                                          ^
/Users/brycebuchanan/Library/Developer/Xcode/DerivedData/ios-integration-testing-gkpdnhglypnaamcidrafzbctcayl/SourcePackages/checkouts/opentelemetry-swift/Sources/Exporters/OpenTelemetryProtocol/proto/logs_service.grpc.swift:93:76: warning: 'GRPCProtobufPayload' is deprecated: This protocol is longer required. Please regenerate your code.
extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: GRPCProtobufPayload {}
                                                                           ^
/Users/brycebuchanan/Library/Developer/Xcode/DerivedData/ios-integration-testing-gkpdnhglypnaamcidrafzbctcayl/SourcePackages/checkouts/opentelemetry-swift/Sources/Exporters/OpenTelemetryProtocol/proto/logs_service.grpc.swift:79:14: error: type of expression is ambiguous without more context
      return UnaryCallHandler(callHandlerContext: callHandlerContext) { context in
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Pinning GRPC-swift to the version defined in the package.swift resolves the issue. 

It may be worthwhile to create a new issue to upgrade this project to use the latest version of GRPC-swift, but this pr provides a decent stop-gap in the mean time. 