### PR TITLE
Several minor improvements including:

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": null,
-          "revision": "399cfe1cfec19d8dc37dcd945a389e6eaae3ea43",
-          "version": "1.0.0-alpha.14"
+          "revision": "b83ee1ee2caa0660eb02444977b9b6e353c2adbf",
+          "version": "1.0.0-alpha.12"
         }
       },
       {
@@ -17,6 +17,15 @@
           "branch": null,
           "revision": "18c1a35ca966236cee0c5a714a51a73ff33384c1",
           "version": "0.5.2"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "26e346cd64f6b92d4089e7fafe2f8e82f60ddb8c",
+          "version": "0.0.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -38,14 +38,16 @@ let package = Package(
         .package(name: "Thrift", url: "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1"),
         .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(name: "grpc-swift", url: "https://github.com/grpc/grpc-swift.git", .exact("1.0.0-alpha.12")),
-        .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0")
+        .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
+        .package(name: "swift-atomics", url: "https://github.com/apple/swift-atomics.git", from: "0.0.1")
     ],
     targets: [
         .target(name: "OpenTelemetryApi",
                 dependencies: []
         ),
         .target(name: "OpenTelemetrySdk",
-                dependencies: ["OpenTelemetryApi"]
+                dependencies: ["OpenTelemetryApi",
+                               .product(name: "Atomics", package: "swift-atomics")]
         ),
         .target(name: "OpenTracingShim",
                 dependencies: ["OpenTelemetrySdk",

--- a/Sources/Exporters/DatadogExporter/Spans/SpanEncoder.swift
+++ b/Sources/Exporters/DatadogExporter/Spans/SpanEncoder.swift
@@ -95,16 +95,16 @@ internal struct DDSpan: Encodable {
         self.startTime = spanData.startTime.timeIntervalSince1970.toNanoseconds
         self.duration = spanData.endTime.timeIntervalSince(spanData.startTime).toNanoseconds
 
-        if spanData.status.isOk {
-            self.error = false
-            self.errorMessage = nil
-            self.errorType = nil
-            self.errorStack = nil
-        } else {
+        if spanData.status.isError {
             self.error = true
             self.errorType = spanData.attributes["error.type"]?.description ?? spanData.status.description
             self.errorMessage = spanData.attributes["error.message"]?.description
             self.errorStack = spanData.attributes["error.stack"]?.description
+        } else {
+            self.error = false
+            self.errorMessage = nil
+            self.errorType = nil
+            self.errorStack = nil
         }
 
         let spanType = spanData.attributes["type"] ?? spanData.attributes["db.type"]

--- a/Sources/OpenTelemetryApi/Trace/Status.swift
+++ b/Sources/OpenTelemetryApi/Trace/Status.swift
@@ -58,9 +58,14 @@ public struct Status: Equatable {
         return Status(statusCode: statusCode, description: description)
     }
 
-    /// True if this Status is OK, i.e., not an error.
+    /// True if this Status is OK
     public var isOk: Bool {
         return StatusCode.ok == statusCode
+    }
+
+    /// True if this Status is an Error
+    public var isError: Bool {
+        return StatusCode.error == statusCode
     }
 }
 

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -87,11 +87,8 @@ public class RecordEventsReadableSpan: ReadableSpan {
     /// The end time of the span.
     public private(set) var endTime: Date?
     /// True if the span is ended.
-    private var endAtomic = ManagedAtomic<Bool>(false)
-    public private(set) var hasEnded: Bool {
-        set {
-            self.endAtomic.store(newValue, ordering: .relaxed)
-        }
+    fileprivate var endAtomic = ManagedAtomic<Bool>(false)
+    public var hasEnded: Bool {
         get {
             return self.endAtomic.load(ordering: .relaxed)
         }
@@ -222,11 +219,10 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
 
     public func setAttribute(key: String, value: AttributeValue?) {
-        if hasEnded {
-            return
-        }
-
         attributesSyncLock.withLockVoid {
+            if !isRecording {
+                return
+            }
             if value == nil {
                 attributes.removeValueForKey(key: key)
             }
@@ -259,10 +255,10 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
 
     private func addEvent(event: SpanData.Event) {
-        if hasEnded {
-            return
-        }
         eventsSyncLock.withLockVoid {
+            if !isRecording {
+                return
+            }
             events.append(event)
             totalRecordedEvents += 1
         }
@@ -273,13 +269,16 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
 
     public func end(time: Date) {
-        if hasEnded {
+        if endAtomic.exchange(true, ordering: .relaxed) {
             return
         }
+        eventsSyncLock.withLockVoid{
+            attributesSyncLock.withLockVoid{
+                isRecording = false
+            }
+        }
         endTime = time
-        hasEnded = true
         spanProcessor.onEnd(span: self)
-        isRecording = false
         scope?.close()
     }
 

--- a/Tests/OpenTelemetryApiTests/Baggage/DefaultBaggageTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/DefaultBaggageTests.swift
@@ -14,7 +14,6 @@
 //
 
 import OpenTelemetryApi
-import OpenTelemetrySdk
 import XCTest
 
 class BaggageSdkTests: XCTestCase {

--- a/Tests/OpenTelemetryApiTests/Baggage/Mocks/BaggageMock.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Mocks/BaggageMock.swift
@@ -15,7 +15,6 @@
 
 import Foundation
 import OpenTelemetryApi
-import OpenTelemetrySdk
 
 class BaggageMock: Baggage {
     static func baggageBuilder() -> BaggageBuilder {


### PR DESCRIPTION
Several minor improvements including:
* Import "swift-atomics" library and use it to protect hasEnded attribute in RecordEventsReadableSpan
* Provide a isError attribute to Status so it can easily be checked, now that unset is the default
* Datadog exporter: Fix reporting unset as error, using previous attribute
* Clean some api tests (previously in sdk) that were incorrectly importing OpenTelemetrySdk