### PR TITLE
Modify SpanProcessor.onStart() to receive parent Context

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/Export/BatchSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/BatchSpanProcessor.swift
@@ -14,6 +14,7 @@
 //
 
 import Foundation
+import OpenTelemetryApi
 
 /// Implementation of the SpanProcessor that batches spans exported by the SDK then pushes
 /// to the exporter pipeline.
@@ -39,7 +40,7 @@ public struct BatchSpanProcessor: SpanProcessor {
     public let isStartRequired = false
     public let isEndRequired = true
 
-    public func onStart(span: ReadableSpan) {}
+    public func onStart(parentContext: SpanContext?, span: ReadableSpan) {}
 
     public func onEnd(span: ReadableSpan) {
         if sampled, !span.context.traceFlags.sampled {

--- a/Sources/OpenTelemetrySdk/Trace/Export/SimpleSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/SimpleSpanProcessor.swift
@@ -25,7 +25,7 @@ public struct SimpleSpanProcessor: SpanProcessor {
     public let isStartRequired = false
     public let isEndRequired = true
     
-    public func onStart(span: ReadableSpan) {
+    public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
     }
 
     public mutating func onEnd(span: ReadableSpan) {

--- a/Sources/OpenTelemetrySdk/Trace/MultiSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/MultiSpanProcessor.swift
@@ -14,6 +14,7 @@
 //
 
 import Foundation
+import OpenTelemetryApi
 
 /// Implementation of the SpanProcessor that simply forwards all received events to a list of
 /// SpanProcessors.
@@ -42,9 +43,9 @@ public struct MultiSpanProcessor: SpanProcessor {
         return spanProcessorsEnd.count > 0
     }
 
-    public func onStart(span: ReadableSpan) {
+    public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
         spanProcessorsStart.forEach {
-            $0.onStart(span: span)
+            $0.onStart(parentContext: parentContext, span: span)
         }
     }
 

--- a/Sources/OpenTelemetrySdk/Trace/NoopSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/NoopSpanProcessor.swift
@@ -14,6 +14,7 @@
 //
 
 import Foundation
+import OpenTelemetryApi
 
 public struct NoopSpanProcessor: SpanProcessor {
     public init() {}
@@ -21,7 +22,7 @@ public struct NoopSpanProcessor: SpanProcessor {
     public let isStartRequired = false
     public let isEndRequired = false
 
-    public func onStart(span: ReadableSpan) {}
+    public func onStart(parentContext: SpanContext?, span: ReadableSpan) {}
 
     public func onEnd(span: ReadableSpan) {}
 

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -33,7 +33,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
     /// Contains the identifiers associated with this Span.
     public private(set) var context: SpanContext
     /// The parent SpanId of this span. Invalid if this is a root span.
-    public private(set) var parentSpanId: SpanId?
+    public private(set) var parentContext: SpanContext?
     /// True if the parent is on a different process.
     public private(set) var hasRemoteParent: Bool
     /// /Handler called when the span starts and ends.
@@ -95,7 +95,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
                  name: String,
                  instrumentationLibraryInfo: InstrumentationLibraryInfo,
                  kind: SpanKind,
-                 parentSpanId: SpanId?,
+                 parentContext: SpanContext?,
                  hasRemoteParent: Bool,
                  traceConfig: TraceConfig,
                  spanProcessor: SpanProcessor,
@@ -108,7 +108,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
         self.context = context
         self.name = name
         self.instrumentationLibraryInfo = instrumentationLibraryInfo
-        self.parentSpanId = parentSpanId
+        self.parentContext = parentContext
         self.hasRemoteParent = hasRemoteParent
         self.traceConfig = traceConfig
         self.links = links
@@ -144,7 +144,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
                                  name: String,
                                  instrumentationLibraryInfo: InstrumentationLibraryInfo,
                                  kind: SpanKind,
-                                 parentSpanId: SpanId?,
+                                 parentContext: SpanContext?,
                                  hasRemoteParent: Bool,
                                  traceConfig: TraceConfig,
                                  spanProcessor: SpanProcessor,
@@ -157,7 +157,8 @@ public class RecordEventsReadableSpan: ReadableSpan {
         let span = RecordEventsReadableSpan(context: context,
                                             name: name,
                                             instrumentationLibraryInfo: instrumentationLibraryInfo,
-                                            kind: kind, parentSpanId: parentSpanId,
+                                            kind: kind,
+                                            parentContext: parentContext,
                                             hasRemoteParent: hasRemoteParent,
                                             traceConfig: traceConfig,
                                             spanProcessor: spanProcessor,
@@ -167,7 +168,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
                                             links: links,
                                             totalRecordedLinks: totalRecordedLinks,
                                             startTime: startTime)
-        spanProcessor.onStart(span: span)
+        spanProcessor.onStart(parentContext: parentContext, span: span)
         return span
     }
 
@@ -176,7 +177,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
                         spanId: context.spanId,
                         traceFlags: context.traceFlags,
                         traceState: context.traceState,
-                        parentSpanId: parentSpanId,
+                        parentSpanId: parentContext?.spanId,
                         resource: resource,
                         instrumentationLibraryInfo: instrumentationLibraryInfo,
                         name: name,

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSDK.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSDK.swift
@@ -152,7 +152,7 @@ public class SpanBuilderSdk: SpanBuilder {
                                                   name: spanName,
                                                   instrumentationLibraryInfo: instrumentationLibraryInfo,
                                                   kind: spanKind,
-                                                  parentSpanId: parentContext?.spanId,
+                                                  parentContext: parentContext,
                                                   hasRemoteParent: parentContext?.isRemote ?? false,
                                                   traceConfig: traceConfig,
                                                   spanProcessor: spanProcessor,

--- a/Sources/OpenTelemetrySdk/Trace/SpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanProcessor.swift
@@ -14,6 +14,7 @@
 //
 
 import Foundation
+import OpenTelemetryApi
 
 /// SpanProcessor is the interface TracerSdk uses to allow synchronous hooks for when a Span
 /// is started or when a Span is ended.
@@ -28,7 +29,7 @@ public protocol SpanProcessor {
     /// This method is called synchronously on the execution thread, should not throw or block the
     /// execution thread.
     /// - Parameter span: the ReadableSpan that just started
-    func onStart(span: ReadableSpan)
+    func onStart(parentContext: SpanContext?, span: ReadableSpan)
 
     /// Called when a Span is ended, if the Span.isRecording() is true.
     /// This method is called synchronously on the execution thread, should not throw or block the

--- a/Tests/ExportersTests/OpenTelemetryProtocol/SpanAdapterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/SpanAdapterTests.swift
@@ -36,7 +36,7 @@ class SpanAdapterTests: XCTestCase {
     func testToPRotoResourceSpans() {
         let libInfo = InstrumentationLibraryInfo(name: "testLibrary", version: "semver:0.0.1")
 
-        let event = RecordEventsReadableSpan.startSpan(context: spanContext, name: "GET /api/endpoint", instrumentationLibraryInfo: libInfo, kind: SpanKind.server, parentSpanId: nil, hasRemoteParent: false, traceConfig: TraceConfig(), spanProcessor: NoopSpanProcessor(), clock: MillisClock(), resource: Resource(), attributes: AttributesDictionary(capacity: 0), links: [], totalRecordedLinks: 0, startTime: Date())
+        let event = RecordEventsReadableSpan.startSpan(context: spanContext, name: "GET /api/endpoint", instrumentationLibraryInfo: libInfo, kind: SpanKind.server, parentContext: nil, hasRemoteParent: false, traceConfig: TraceConfig(), spanProcessor: NoopSpanProcessor(), clock: MillisClock(), resource: Resource(), attributes: AttributesDictionary(capacity: 0), links: [], totalRecordedLinks: 0, startTime: Date())
         
         let result = SpanAdapter.toProtoResourceSpans(spanDataList: [event.toSpanData()])
         

--- a/Tests/OpenTelemetrySdkTests/Trace/Export/SimpleSpansProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Export/SimpleSpansProcessorTests.swift
@@ -35,7 +35,7 @@ class SimpleSpansProcessorTests: XCTestCase {
     }
 
     func testOnStartSync() {
-        simpleSampledSpansProcessor.onStart(span: readableSpan)
+        simpleSampledSpansProcessor.onStart(parentContext: nil, span: readableSpan)
         XCTAssertTrue(spanExporter.exportCalledTimes == 0 && spanExporter.shutdownCalledTimes == 0)
     }
 

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanProcessorMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanProcessorMock.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 import OpenTelemetrySdk
+import OpenTelemetryApi
 
 class SpanProcessorMock: SpanProcessor {
     var onStartCalledTimes = 0
@@ -31,7 +32,7 @@ class SpanProcessorMock: SpanProcessor {
     var isStartRequired = true
     var isEndRequired = true
 
-    func onStart(span: ReadableSpan) {
+    func onStart(parentContext: SpanContext?, span: ReadableSpan) {
         onStartCalledTimes += 1
         onStartCalledSpan = span
     }

--- a/Tests/OpenTelemetrySdkTests/Trace/MultiSpanProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/MultiSpanProcessorTests.swift
@@ -14,6 +14,7 @@
 //
 
 import OpenTelemetrySdk
+import OpenTelemetryApi
 import XCTest
 
 class MultiSpanProcessorTest: XCTestCase {
@@ -30,14 +31,14 @@ class MultiSpanProcessorTest: XCTestCase {
 
     func testEmpty() {
         let multiSpanProcessor = MultiSpanProcessor(spanProcessors: [SpanProcessor]())
-        multiSpanProcessor.onStart(span: readableSpan)
+        multiSpanProcessor.onStart(parentContext: nil, span: readableSpan)
         multiSpanProcessor.onEnd(span: readableSpan)
         multiSpanProcessor.shutdown()
     }
 
     func testOneSpanProcessor() {
         let multiSpanProcessor = MultiSpanProcessor(spanProcessors: [spanProcessor1])
-        multiSpanProcessor.onStart(span: readableSpan)
+        multiSpanProcessor.onStart(parentContext: nil, span: readableSpan)
         XCTAssert(spanProcessor1.onStartCalledSpan === readableSpan)
         multiSpanProcessor.onEnd(span: readableSpan)
         XCTAssert(spanProcessor1.onEndCalledSpan === readableSpan)
@@ -51,12 +52,12 @@ class MultiSpanProcessorTest: XCTestCase {
         spanProcessor1.isStartRequired = false
         spanProcessor1.isEndRequired = false
         let multiSpanProcessor = MultiSpanProcessor(spanProcessors: [spanProcessor1])
-        multiSpanProcessor.onStart(span: readableSpan)
+        multiSpanProcessor.onStart(parentContext: nil, span: readableSpan)
 
         XCTAssertFalse(multiSpanProcessor.isStartRequired)
         XCTAssertFalse(multiSpanProcessor.isEndRequired)
 
-        multiSpanProcessor.onStart(span: readableSpan)
+        multiSpanProcessor.onStart(parentContext: nil, span: readableSpan)
         XCTAssertFalse(spanProcessor1.onStartCalled)
         multiSpanProcessor.onEnd(span: readableSpan)
         XCTAssertFalse(spanProcessor1.onEndCalled)
@@ -69,7 +70,7 @@ class MultiSpanProcessorTest: XCTestCase {
     func testTwoSpanProcessor() {
         let multiSpanProcessor = MultiSpanProcessor(spanProcessors: [spanProcessor1, spanProcessor2])
 
-        multiSpanProcessor.onStart(span: readableSpan)
+        multiSpanProcessor.onStart(parentContext: nil, span: readableSpan)
         XCTAssert(spanProcessor1.onStartCalledSpan === readableSpan)
         XCTAssert(spanProcessor2.onStartCalledSpan === readableSpan)
 
@@ -95,7 +96,7 @@ class MultiSpanProcessorTest: XCTestCase {
         XCTAssertTrue(multiSpanProcessor.isStartRequired)
         XCTAssertTrue(multiSpanProcessor.isEndRequired)
 
-        multiSpanProcessor.onStart(span: readableSpan)
+        multiSpanProcessor.onStart(parentContext: nil, span: readableSpan)
         XCTAssert(spanProcessor1.onStartCalledSpan === readableSpan)
         XCTAssertFalse(spanProcessor2.onStartCalled)
 

--- a/Tests/OpenTelemetrySdkTests/Trace/NoopSpanProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/NoopSpanProcessorTests.swift
@@ -21,7 +21,7 @@ class NoopSpanProcessorTest: XCTestCase {
 
     func testNoCrash() {
         let noopSpanProcessor = NoopSpanProcessor()
-        noopSpanProcessor.onStart(span: readableSpan)
+        noopSpanProcessor.onStart(parentContext: nil, span: readableSpan)
         XCTAssertFalse(noopSpanProcessor.isStartRequired)
         noopSpanProcessor.onEnd(span: readableSpan)
         XCTAssertFalse(noopSpanProcessor.isEndRequired)

--- a/Tests/OpenTelemetrySdkTests/Trace/RecordEventsReadableSpanTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/RecordEventsReadableSpanTests.swift
@@ -338,6 +338,10 @@ class RecordEventsReadableSpanTest: XCTestCase {
                                          spanId: spanId,
                                          traceFlags: TraceFlags(),
                                          traceState: TraceState())
+        let parentContext = SpanContext.create(traceId: traceId,
+                                         spanId: parentSpanId,
+                                         traceFlags: TraceFlags(),
+                                         traceState: TraceState())
         let link1 = SpanData.Link(context: context, attributes: TestUtils.generateRandomAttributes())
         let links = [link1]
 
@@ -345,7 +349,7 @@ class RecordEventsReadableSpanTest: XCTestCase {
                                                               name: name,
                                                               instrumentationLibraryInfo: instrumentationLibraryInfo,
                                                               kind: kind,
-                                                              parentSpanId: parentSpanId,
+                                                              parentContext: parentContext,
                                                               hasRemoteParent: false,
                                                               traceConfig: traceConfig,
                                                               spanProcessor: spanProcessor,
@@ -394,22 +398,26 @@ class RecordEventsReadableSpanTest: XCTestCase {
     }
 
     private func createTestRootSpan() -> RecordEventsReadableSpan {
-        return createTestSpan(kind: .internal, config: TraceConfig(), parentSpanId: nil, attributes: [String: AttributeValue]())
+        return createTestSpan(kind: .internal, config: TraceConfig(), parentContext: nil, attributes: [String: AttributeValue]())
     }
 
     private func createTestSpan(attributes: [String: AttributeValue]) -> RecordEventsReadableSpan {
-        return createTestSpan(kind: .internal, config: TraceConfig(), parentSpanId: nil, attributes: attributes)
+        return createTestSpan(kind: .internal, config: TraceConfig(), parentContext: nil, attributes: attributes)
     }
 
     private func createTestSpan(kind: SpanKind) -> RecordEventsReadableSpan {
-        return createTestSpan(kind: kind, config: TraceConfig(), parentSpanId: parentSpanId, attributes: [String: AttributeValue]())
+        let parentContext = SpanContext.create(traceId: traceId,
+                                               spanId: parentSpanId,
+                                               traceFlags: TraceFlags(),
+                                               traceState: TraceState())
+        return createTestSpan(kind: kind, config: TraceConfig(), parentContext: parentContext, attributes: [String: AttributeValue]())
     }
 
     private func createTestSpan(config: TraceConfig) -> RecordEventsReadableSpan {
-        return createTestSpan(kind: .internal, config: config, parentSpanId: nil, attributes: [String: AttributeValue]())
+        return createTestSpan(kind: .internal, config: config, parentContext: nil, attributes: [String: AttributeValue]())
     }
 
-    private func createTestSpan(kind: SpanKind, config: TraceConfig, parentSpanId: SpanId?, attributes: [String: AttributeValue]) -> RecordEventsReadableSpan {
+    private func createTestSpan(kind: SpanKind, config: TraceConfig, parentContext: SpanContext?, attributes: [String: AttributeValue]) -> RecordEventsReadableSpan {
         var attributesWithCapacity = AttributesDictionary(capacity: config.maxNumberOfAttributes)
         attributesWithCapacity.updateValues(attributes: attributes)
 
@@ -417,7 +425,7 @@ class RecordEventsReadableSpanTest: XCTestCase {
                                                       name: spanName,
                                                       instrumentationLibraryInfo: instrumentationLibraryInfo,
                                                       kind: kind,
-                                                      parentSpanId: parentSpanId,
+                                                      parentContext: parentContext,
                                                       hasRemoteParent: true,
                                                       traceConfig: config,
                                                       spanProcessor: spanProcessor,

--- a/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
@@ -211,7 +211,7 @@ class SpanBuilderSdkTest: XCTestCase {
         let parent = tracerSdk.spanBuilder(spanName: spanName).startSpan()
         let span = tracerSdk.spanBuilder(spanName: spanName).setNoParent().setParent(parent).startSpan() as! RecordEventsReadableSpan
         XCTAssertEqual(span.context.traceId, parent.context.traceId)
-        XCTAssertEqual(span.parentSpanId, parent.context.spanId)
+        XCTAssertEqual(span.parentContext?.spanId, parent.context.spanId)
         let span2 = tracerSdk.spanBuilder(spanName: spanName).setNoParent().setParent(parent.context).startSpan()
         XCTAssertEqual(span2.context.traceId, parent.context.traceId)
         span2.end()
@@ -223,7 +223,7 @@ class SpanBuilderSdkTest: XCTestCase {
         let parent = tracerSdk.spanBuilder(spanName: spanName).startSpan()
         let span = tracerSdk.spanBuilder(spanName: spanName).setNoParent().setParent(parent.context).startSpan() as! RecordEventsReadableSpan
         XCTAssertEqual(span.context.traceId, parent.context.traceId)
-        XCTAssertEqual(span.parentSpanId, parent.context.spanId)
+        XCTAssertEqual(span.parentContext?.spanId, parent.context.spanId)
         span.end()
         parent.end()
     }
@@ -233,7 +233,7 @@ class SpanBuilderSdkTest: XCTestCase {
         tracerSdk.setActive(parent)
         let span = tracerSdk.spanBuilder(spanName: spanName).startSpan() as! RecordEventsReadableSpan
         XCTAssertEqual(span.context.traceId, parent.context.traceId)
-        XCTAssertEqual(span.parentSpanId, parent.context.spanId)
+        XCTAssertEqual(span.parentContext?.spanId, parent.context.spanId)
         span.end()
         parent.end()
     }
@@ -242,7 +242,7 @@ class SpanBuilderSdkTest: XCTestCase {
         let parent = DefaultSpan()
         let span = tracerSdk.spanBuilder(spanName: spanName).setParent(parent.context).startSpan() as! RecordEventsReadableSpan
         XCTAssertNotEqual(span.context.traceId, parent.context.traceId)
-        XCTAssertNil(span.parentSpanId)
+        XCTAssertNil(span.parentContext?.spanId)
         span.end()
     }
 


### PR DESCRIPTION
Make SpanProcessor.onStart() receive parent Context, as per specification