### PR TITLE
Fix excessive memory usage in PushMetricController and BatchSpanProcessor

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -27,7 +27,10 @@ class PushMetricController {
         self.metricProcessor = metricProcessor
         self.metricExporter = metricExporter
         self.pushInterval = pushInterval
-        pushMetricQueue.asyncAfter(deadline: .now() + pushInterval) {
+        pushMetricQueue.asyncAfter(deadline: .now() + pushInterval) { [weak self] in
+            guard let self = self else {
+                return
+            }
             while !(shouldCancel?() ?? false) {
                 autoreleasepool {
                     let start = Date()

--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -29,19 +29,21 @@ class PushMetricController {
         self.pushInterval = pushInterval
         pushMetricQueue.asyncAfter(deadline: .now() + pushInterval) {
             while !(shouldCancel?() ?? false) {
-                let start = Date()
-                let values = self.meterProvider.getMeters().values
-                for index in values.indices {
-                    values[index].collect()
-                }
+                autoreleasepool {
+                    let start = Date()
+                    let values = self.meterProvider.getMeters().values
+                    for index in values.indices {
+                        values[index].collect()
+                    }
 
-                let metricToExport = self.metricProcessor.finishCollectionCycle()
+                    let metricToExport = self.metricProcessor.finishCollectionCycle()
 
-                _ = metricExporter.export(metrics: metricToExport, shouldCancel: shouldCancel)
-                let timeInterval = Date().timeIntervalSince(start)
-                let remainingWait = pushInterval - timeInterval
-                if remainingWait > 0 {
-                    usleep(UInt32(remainingWait * 1000000))
+                    _ = metricExporter.export(metrics: metricToExport, shouldCancel: shouldCancel)
+                    let timeInterval = Date().timeIntervalSince(start)
+                    let remainingWait = pushInterval - timeInterval
+                    if remainingWait > 0 {
+                        usleep(UInt32(remainingWait * 1000000))
+                    }
                 }
             }
         }

--- a/Sources/OpenTelemetrySdk/Trace/Export/BatchSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/BatchSpanProcessor.swift
@@ -98,17 +98,19 @@ private class BatchWorker: Thread {
 
     override func main() {
         repeat {
-            var spansCopy: [ReadableSpan]
-            cond.lock()
-            if spanList.count < maxExportBatchSize {
-                repeat {
-                    cond.wait(until: Date().addingTimeInterval(scheduleDelay))
-                } while spanList.isEmpty
+            autoreleasepool {
+                var spansCopy: [ReadableSpan]
+                cond.lock()
+                if spanList.count < maxExportBatchSize {
+                    repeat {
+                        cond.wait(until: Date().addingTimeInterval(scheduleDelay))
+                    } while spanList.isEmpty
+                }
+                spansCopy = spanList
+                spanList.removeAll()
+                cond.unlock()
+                exportBatches(spanList: spansCopy)
             }
-            spansCopy = spanList
-            spanList.removeAll()
-            cond.unlock()
-            exportBatches(spanList: spansCopy)
         } while true
     }
 

--- a/Tests/OpenTelemetrySdkTests/Metrics/PushControllerTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/PushControllerTests.swift
@@ -53,7 +53,7 @@ final class PushControllerTests: XCTestCase {
 
         let pushInterval = controllerPushIntervalInSec
 
-        _ = PushMetricController(meterProvider: meterProvider, metricProcessor: testProcessor, metricExporter: testExporter, pushInterval: pushInterval)
+        let controller = PushMetricController(meterProvider: meterProvider, metricProcessor: testProcessor, metricExporter: testExporter, pushInterval: pushInterval)
 
         // Validate that collect is called on Meter1, Meter2.
         validateMeterCollect(meterCollectCount: &meter1CollectCount, expectedMeterCollectCount: collectionCountExpectedMin, meterName: "meter1", timeout: maxWaitInSec)
@@ -63,6 +63,7 @@ final class PushControllerTests: XCTestCase {
         lock.withLockVoid {
             XCTAssertTrue(exportCalledCount >= collectionCountExpectedMin)
         }
+        XCTAssertEqual(controller.pushInterval, pushInterval)
     }
 
     func validateMeterCollect(meterCollectCount: inout Int, expectedMeterCollectCount: Int, meterName: String, timeout: TimeInterval) {


### PR DESCRIPTION
As their job is done in an infinite loop, wrap each execution in an autoreleasepool so memory can be recovered in a timely manner, if not memory continue growing until stopped.