### PR TITLE
Make TracerSdkProvider initializer with parameters public

### DIFF
--- a/Sources/OpenTelemetrySdk/Internal/MillisClock.swift
+++ b/Sources/OpenTelemetrySdk/Internal/MillisClock.swift
@@ -16,11 +16,11 @@
 import Foundation
 import OpenTelemetryApi
 
-class MillisClock: Clock {
+public class MillisClock: Clock {
     ///  Returns a MillisClock
-    init() {}
+    public init() {}
 
-    var now: Date {
+    public var now: Date {
         return Date()
     }
 }

--- a/Sources/OpenTelemetrySdk/Trace/TracerSdkProvider.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TracerSdkProvider.swift
@@ -22,11 +22,9 @@ public class TracerSdkProvider: TracerProvider {
     private var sharedState: TracerSharedState
 
     /// Returns a new TracerSdkProvider with default Clock, IdsGenerator and Resource.
-    public convenience init() {
-        self.init(clock: MillisClock(), idsGenerator: RandomIdsGenerator(), resource: EnvVarResource.resource)
-    }
-
-    init(clock: Clock, idsGenerator: IdsGenerator, resource: Resource) {
+    public init(clock: Clock = MillisClock(),
+                idsGenerator: IdsGenerator =  RandomIdsGenerator(),
+                resource: Resource = EnvVarResource.resource) {
         sharedState = TracerSharedState(clock: clock, idsGenerator: idsGenerator, resource: resource)
     }
 


### PR DESCRIPTION
 and use default values  so user only needs to change what is needed

Relates to #105 