### PR TITLE
Added `additionalHeaders` property to ZipkinExporterOptions

### DIFF
--- a/Sources/Exporters/Zipkin/ZipkinTraceExporter.swift
+++ b/Sources/Exporters/Zipkin/ZipkinTraceExporter.swift
@@ -17,7 +17,7 @@ import Foundation
 import OpenTelemetrySdk
 
 public class ZipkinTraceExporter: SpanExporter {
-    public private(set) var options: ZipkinTraceExporterOptions
+    public var options: ZipkinTraceExporterOptions
     var localEndPoint: ZipkinEndpoint
 
     public init(options: ZipkinTraceExporterOptions) {
@@ -31,6 +31,9 @@ public class ZipkinTraceExporter: SpanExporter {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        options.additionalHeaders.forEach {
+            request.addValue($0.value, forHTTPHeaderField: $0.key)
+        }
 
         let spans = encodeSpans(spans: spans)
         do {

--- a/Sources/Exporters/Zipkin/ZipkinTraceExporterOptions.swift
+++ b/Sources/Exporters/Zipkin/ZipkinTraceExporterOptions.swift
@@ -20,16 +20,19 @@ public struct ZipkinTraceExporterOptions {
     let timeoutSeconds: TimeInterval
     let serviceName: String
     let useShortTraceIds: Bool
+    let additionalHeaders: [String:String]
 
     public init(endpoint: String = "http://localhost:9411/api/v2/spans",
                 serviceName: String = "Open Telemetry Exporter",
                 timeoutSeconds: TimeInterval = 10.0,
-                useShortTraceIds: Bool = false) {
+                useShortTraceIds: Bool = false,
+                additionalHeaders: [String:String] = [String:String]()) {
 
         self.endpoint = endpoint
         self.serviceName = serviceName
         self.timeoutSeconds = timeoutSeconds
         self.useShortTraceIds = useShortTraceIds
+        self.additionalHeaders = additionalHeaders
     }
 }
 


### PR DESCRIPTION
Made `options` public in ZipkinTraceExporter; Adding the additional headers in `option.additionalHeaders` to the request in the `export(spans:)` method of ZipkinTraceExporter

This would enable a user to add custom header to the zipkin export calls like authorisation headers.