### PR TITLE
Instrumentation for URLSession 

### DIFF
--- a/Examples/Network Sample/main.swift
+++ b/Examples/Network Sample/main.swift
@@ -1,0 +1,46 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetrySdk
+import StdoutExporter
+import URLSessionInstrumentation
+
+
+func simpleNetworkCall() {
+    let url = URL(string: "http://httpbin.org/get")!
+    let request = URLRequest(url: url)
+    let semaphore = DispatchSemaphore(value: 0)
+
+    let task = URLSession.shared.dataTask(with: request) { data, _, _ in
+        if let data = data {
+            let string = String(data: data, encoding: .utf8)
+            print(string ?? "")
+        }
+        semaphore.signal()
+    }
+    task.resume()
+
+    semaphore.wait()
+}
+
+let spanProcessor = SimpleSpanProcessor(spanExporter: StdoutExporter(isDebug: true))
+OpenTelemetrySDK.instance.tracerProvider.addSpanProcessor(spanProcessor)
+
+let networkInstrumentation = URLSessionInstrumentation(configuration: URLSessionConfiguration())
+
+simpleNetworkCall()
+sleep(1)
+

--- a/Examples/Network Sample/main.swift
+++ b/Examples/Network Sample/main.swift
@@ -1,4 +1,4 @@
-// Copyright 2020, OpenTelemetry Authors
+// Copyright 2021, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,4 +43,3 @@ let networkInstrumentation = URLSessionInstrumentation(configuration: URLSession
 
 simpleNetworkCall()
 sleep(1)
-

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,8 @@ let package = Package(
         .library(name: "libOpenTelemetryApi", type: .static, targets: ["OpenTelemetryApi"]),
         .library(name: "OpenTelemetrySdk", type: .dynamic, targets: ["OpenTelemetrySdk"]),
         .library(name: "libOpenTelemetrySdk", type: .static, targets: ["OpenTelemetrySdk"]),
+        .library(name: "URLSessionInstrumentation", type: .dynamic, targets: ["URLSessionInstrumentation"]),
+        .library(name: "libURLSessionInstrumentation", type: .static, targets: ["URLSessionInstrumentation"]),
         .library(name: "OpenTracingShim", type: .dynamic, targets: ["OpenTracingShim"]),
         .library(name: "libOpenTracingShim", type: .static, targets: ["OpenTracingShim"]),
         .library(name: "JaegerExporter", type: .dynamic, targets: ["JaegerExporter"]),
@@ -47,6 +49,11 @@ let package = Package(
         .target(name: "OpenTelemetrySdk",
                 dependencies: ["OpenTelemetryApi",
                                .product(name: "Atomics", package: "swift-atomics")]
+        ),
+        .target(name: "URLSessionInstrumentation",
+                dependencies: ["OpenTelemetrySdk"],
+                path: "Sources/Instrumentation/URLSession"
+
         ),
         .target(name: "OpenTracingShim",
                 dependencies: ["OpenTelemetrySdk",
@@ -142,6 +149,11 @@ let package = Package(
         .target(name: "DatadogSample",
                 dependencies: ["DatadogExporter"],
                 path: "Examples/Datadog Sample",
+                exclude: ["README.md"]
+        ),
+        .target(name: "NetworkSample",
+                dependencies: ["URLSessionInstrumentation", "StdoutExporter"],
+                path: "Examples/Network Sample",
                 exclude: ["README.md"]
         ),
     ]

--- a/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
+++ b/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
@@ -1,0 +1,61 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+enum InstrumentationUtils {
+    static func objc_getClassList() -> [AnyClass] {
+        let expectedClassCount = ObjectiveC.objc_getClassList(nil, 0)
+        let allClasses = UnsafeMutablePointer<AnyClass>.allocate(capacity: Int(expectedClassCount))
+        let autoreleasingAllClasses = AutoreleasingUnsafeMutablePointer<AnyClass>(allClasses)
+        let actualClassCount: Int32 = ObjectiveC.objc_getClassList(autoreleasingAllClasses, expectedClassCount)
+
+        var classes = [AnyClass]()
+        for i in 0 ..< actualClassCount {
+            classes.append(allClasses[Int(i)])
+        }
+        allClasses.deallocate()
+        return classes
+    }
+
+    static func instanceRespondsAndImplements(cls: AnyClass, selector: Selector) -> Bool {
+        var implements = false
+        if cls.instancesRespond(to: selector) {
+            var methodCount: UInt32 = 0
+            let methodList = class_copyMethodList(cls, &methodCount)
+            defer {
+                free(methodList)
+            }
+            if let methodList = methodList, methodCount > 0 {
+                enumerateCArray(array: methodList, count: methodCount) { _, m in
+                    let sel = method_getName(m)
+                    if sel == selector {
+                        implements = true
+                        return
+                    }
+                }
+            }
+        }
+        return implements
+    }
+
+    private static func enumerateCArray<T>(array: UnsafePointer<T>, count: UInt32, f: (UInt32, T) -> Void) {
+        var ptr = array
+        for i in 0 ..< count {
+            f(i, ptr.pointee)
+            ptr = ptr.successor()
+        }
+    }
+}

--- a/Sources/Instrumentation/URLSession/URLSessionConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionConfiguration.swift
@@ -1,0 +1,62 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+public typealias DataOrFile = Any
+public typealias SessionTaskId = String
+public typealias HTTPStatus = Int
+
+public struct URLSessionConfiguration {
+    public init(shouldRecordPayload: ((URLSession) -> (Bool)?)? = nil,
+                shouldInstrument: ((URLRequest) -> (Bool)?)? = nil,
+                shouldInjectTracingHeaders: ((inout URLRequest) -> (Bool)?)? = nil,
+                createdRequest: ((URLRequest, SpanBuilder) -> ())? = nil,
+                receivedResponse: ((URLResponse, DataOrFile?, Span) -> ())? = nil,
+                receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> ())? = nil)
+    {
+        self.shouldRecordPayload = shouldRecordPayload
+        self.shouldInstrument = shouldInstrument
+        self.shouldInjectTracingHeaders = shouldInjectTracingHeaders
+        self.createdRequest = createdRequest
+        self.receivedResponse = receivedResponse
+        self.receivedError = receivedError
+    }
+
+    // Instrumentation Callbacks
+
+    /// Implement this callback to filter wich requests you want to instrument, all by default
+    public var shouldInstrument: ((URLRequest) -> (Bool)?)?
+
+    /// Implement this callback if you want the session to record payload data, false by default
+    public var shouldRecordPayload: ((URLSession) -> (Bool)?)?
+
+    /// Implement this callback to filter wich requests you want to inject headers to follow the trace,
+    /// you can also modify the request or add other headers in this method.
+    /// Instruments all requests by default
+    public var shouldInjectTracingHeaders: ((inout URLRequest) -> (Bool)?)?
+
+    ///  Called before the span is created, it allows to add extra information to the Span through the builder
+    public var createdRequest: ((URLRequest, SpanBuilder) -> ())?
+
+
+    ///  Called before the span is ended, it allows to add extra information to the Span
+    public var receivedResponse: ((URLResponse, DataOrFile?, Span) -> ())?
+
+    ///  Called before the span is ended, it allows to add extra information to the Span
+    public var receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> ())?
+}

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -1,0 +1,509 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+struct NetworkRequestState {
+    var request: URLRequest?
+    var dataProcessed: Data?
+}
+
+private var idKey: Void?
+
+public class URLSessionInstrumentation {
+    private var requestMap = [String: NetworkRequestState]()
+
+    
+
+    var configuration: URLSessionConfiguration
+
+    private let queue = DispatchQueue(label: "com.datadoghq.ddnetworkinstrumentation")
+
+    static var instrumentedKey = "com.datadoghq.instrumentedCall"
+
+    public private(set) var tracer: TracerSdk
+
+    public init(configuration: URLSessionConfiguration) {
+        self.configuration = configuration
+        tracer = OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: "NSURLSession", instrumentationVersion: "0.0.1") as! TracerSdk
+        self.injectInNSURLClasses()
+    }
+
+    private func injectInNSURLClasses() {
+        let selectors = [
+            #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:)),
+            #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:completionHandler:)),
+            #selector(URLSessionDataDelegate.urlSession(_:task:didCompleteWithError:)),
+            #selector(URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)! as (URLSessionDataDelegate) -> (URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void),
+            #selector(URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)! as (URLSessionDataDelegate) -> (URLSession, URLSessionDataTask, URLSessionStreamTask) -> Void)
+        ]
+
+        let classes = InstrumentationUtils.objc_getClassList()
+        classes.forEach {
+            guard $0 != Self.self else { return }
+            var selectorFound = false
+            var methodCount: UInt32 = 0
+            guard let methodList = class_copyMethodList($0, &methodCount) else { return }
+
+            for i in 0..<Int(methodCount) {
+                for j in 0..<selectors.count {
+                    if method_getName(methodList[i]) == selectors[j] {
+                        selectorFound = true
+                        injectIntoDelegateClass(cls: $0)
+                        break
+                    }
+                }
+                if selectorFound {
+                    break
+                }
+            }
+        }
+        injectIntoNSURLSessionCreateTaskMethods()
+        injectIntoNSURLSessionCreateTaskWithParameterMethods()
+        injectIntoNSURLSessionAsyncDataAndDownloadTaskMethods()
+        injectIntoNSURLSessionAsyncUploadTaskMethods()
+    }
+
+    private func injectIntoDelegateClass(cls: AnyClass) {
+        // Sessions
+        injectTaskDidReceiveDataIntoDelegateClass(cls: cls)
+        injectTaskDidReceiveResponseIntoDelegateClass(cls: cls)
+        injectTaskDidCompleteWithErrorIntoDelegateClass(cls: cls)
+        injectRespondsToSelectorIntoDelegateClass(cls: cls)
+
+        // Data tasks
+        injectDataTaskDidBecomeDownloadTaskIntoDelegateClass(cls: cls)
+    }
+
+    private func injectIntoNSURLSessionCreateTaskMethods() {
+        let cls = URLSession.self
+        [
+            #selector(URLSession.dataTask(with:) as (URLSession) -> (URLRequest) -> URLSessionDataTask),
+            #selector(URLSession.dataTask(with:) as (URLSession) -> (URL) -> URLSessionDataTask),
+            #selector(URLSession.uploadTask(withStreamedRequest:)),
+            #selector(URLSession.downloadTask(with:) as (URLSession) -> (URLRequest) -> URLSessionDownloadTask),
+            #selector(URLSession.downloadTask(with:) as (URLSession) -> (URL) -> URLSessionDownloadTask),
+            #selector(URLSession.downloadTask(withResumeData:))
+        ].forEach {
+            let selector = $0
+            guard let original = class_getInstanceMethod(cls, selector) else {
+                print("injectInto \(selector.description) failed")
+                return
+            }
+            var originalIMP: IMP?
+            let sessionTaskId = UUID().uuidString
+
+            let block: @convention(block) (URLSession, AnyObject) -> URLSessionTask = { session, argument in
+                if let url = argument as? URL {
+                    var request = URLRequest(url: url)
+                    if self.configuration.shouldInjectTracingHeaders?(&request) ?? true {
+                        if selector == #selector(URLSession.dataTask(with:) as (URLSession) -> (URL) -> URLSessionDataTask) {
+                            return session.dataTask(with: request)
+                        } else {
+                            return session.downloadTask(with: request)
+                        }
+                    }
+                }
+
+                let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (URLSession, Selector, Any) -> URLSessionDataTask).self)
+                var task: URLSessionTask
+
+                if let request = argument as? URLRequest, objc_getAssociatedObject(argument, &idKey) == nil {
+                    let instrumentedRequest = self.instrumentedRequest(for: request)
+                    task = castedIMP(session, selector, instrumentedRequest)
+                    URLSessionLogger.logRequest(instrumentedRequest, instrumentation: self, sessionTaskId: sessionTaskId)
+                } else {
+                    task = castedIMP(session, selector, argument)
+                    if objc_getAssociatedObject(argument, &idKey) == nil,
+                       let currentRequest = task.currentRequest
+                    {
+                        URLSessionLogger.logRequest(currentRequest, instrumentation: self, sessionTaskId: sessionTaskId)
+                    }
+                }
+                self.setIdKey(value: sessionTaskId, for: task)
+                return task
+            }
+            let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+            originalIMP = method_setImplementation(original, swizzledIMP)
+        }
+    }
+
+    private func injectIntoNSURLSessionCreateTaskWithParameterMethods() {
+        let cls = URLSession.self
+        [
+            #selector(URLSession.uploadTask(with:from:)),
+            #selector(URLSession.uploadTask(with:fromFile:))
+        ].forEach {
+            let selector = $0
+            guard let original = class_getInstanceMethod(cls, selector) else {
+                print("injectInto \(selector.description) failed")
+                return
+            }
+            var originalIMP: IMP?
+            let sessionTaskId = UUID().uuidString
+
+            let block: @convention(block) (URLSession, URLRequest, AnyObject) -> URLSessionTask = { session, request, argument in
+                let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (URLSession, Selector, URLRequest, AnyObject) -> URLSessionDataTask).self)
+                let instrumentedRequest = self.instrumentedRequest(for: request)
+                let task = castedIMP(session, selector, instrumentedRequest, argument)
+                URLSessionLogger.logRequest(instrumentedRequest, instrumentation: self, sessionTaskId: sessionTaskId)
+                self.setIdKey(value: sessionTaskId, for: task)
+                return task
+            }
+            let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+            originalIMP = method_setImplementation(original, swizzledIMP)
+        }
+    }
+
+    private func injectIntoNSURLSessionAsyncDataAndDownloadTaskMethods() {
+        let cls = URLSession.self
+        [
+            #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask),
+            #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask),
+            #selector(URLSession.downloadTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask),
+            #selector(URLSession.downloadTask(with:completionHandler:) as (URLSession) -> (URL, @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask),
+            #selector(URLSession.downloadTask(withResumeData:completionHandler:))
+        ].forEach {
+            let selector = $0
+            guard let original = class_getInstanceMethod(cls, selector) else {
+                print("injectInto \(selector.description) failed")
+                return
+            }
+            var originalIMP: IMP?
+            let sessionTaskId = UUID().uuidString
+
+            let block: @convention(block) (URLSession, AnyObject, ((Any?, URLResponse?, Error?) -> Void)?) -> URLSessionTask = { session, argument, completion in
+
+                if let url = argument as? URL {
+                    var request = URLRequest(url: url)
+
+                    if self.configuration.shouldInjectTracingHeaders?(&request) ?? true {
+                        if selector == #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask) {
+                            if let completion = completion {
+                                return session.dataTask(with: request, completionHandler: completion)
+                            } else {
+                                return session.dataTask(with: request)
+                            }
+                        } else {
+                            if let completion = completion {
+                                return session.downloadTask(with: request, completionHandler: completion)
+                            } else {
+                                return session.downloadTask(with: request)
+                            }
+                        }
+                    }
+                }
+
+                let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (URLSession, Selector, Any, ((Any?, URLResponse?, Error?) -> Void)?) -> URLSessionDataTask).self)
+                var task: URLSessionTask!
+
+                var completionBlock = completion
+                if objc_getAssociatedObject(argument, &idKey) == nil {
+                    let completionWrapper: (Any?, URLResponse?, Error?) -> Void = { object, response, error in
+                        if error != nil {
+                            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                            URLSessionLogger.logError(error!, dataOrFile: object, statusCode: status, instrumentation: self, sessionTaskId: sessionTaskId)
+                        } else {
+                            if let response = response {
+                                URLSessionLogger.logResponse(response, dataOrFile: object, instrumentation: self, sessionTaskId: sessionTaskId)
+                            }
+                        }
+                        if let completion = completion {
+                            completion(object, response, error)
+                        } else {
+                            (session.delegate as? URLSessionTaskDelegate)?.urlSession?(session, task: task, didCompleteWithError: error)
+                        }
+                    }
+                    completionBlock = completionWrapper
+                }
+
+                if let request = argument as? URLRequest, objc_getAssociatedObject(argument, &idKey) == nil {
+                    let instrumentedRequest = self.instrumentedRequest(for: request)
+                    task = castedIMP(session, selector, instrumentedRequest, completionBlock)
+                    URLSessionLogger.logRequest(instrumentedRequest, instrumentation: self, sessionTaskId: sessionTaskId)
+                } else {
+                    task = castedIMP(session, selector, argument, completionBlock)
+                    if objc_getAssociatedObject(argument, &idKey) == nil,
+                       let currentRequest = task.currentRequest
+                    {
+                        URLSessionLogger.logRequest(currentRequest, instrumentation: self, sessionTaskId: sessionTaskId)
+                    }
+                }
+                self.setIdKey(value: sessionTaskId, for: task)
+                return task
+            }
+            let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+            originalIMP = method_setImplementation(original, swizzledIMP)
+        }
+    }
+
+    private func injectIntoNSURLSessionAsyncUploadTaskMethods() {
+        let cls = URLSession.self
+        [
+            #selector(URLSession.uploadTask(with:from:completionHandler:)),
+            #selector(URLSession.uploadTask(with:fromFile:completionHandler:))
+        ].forEach {
+            let selector = $0
+            guard let original = class_getInstanceMethod(cls, selector) else {
+                print("injectInto \(selector.description) failed")
+                return
+            }
+            var originalIMP: IMP?
+            let sessionTaskId = UUID().uuidString
+
+            let block: @convention(block) (URLSession, URLRequest, AnyObject, ((Any?, URLResponse?, Error?) -> Void)?) -> URLSessionTask = { session, request, argument, completion in
+
+                let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (URLSession, Selector, URLRequest, AnyObject, ((Any?, URLResponse?, Error?) -> Void)?) -> URLSessionDataTask).self)
+
+                var task: URLSessionTask!
+                var completionBlock = completion
+                if objc_getAssociatedObject(argument, &idKey) == nil {
+                    let completionWrapper: (Any?, URLResponse?, Error?) -> Void = { object, response, error in
+                        if error != nil {
+                            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                            URLSessionLogger.logError(error!, dataOrFile: object, statusCode: status, instrumentation: self, sessionTaskId: sessionTaskId)
+                        } else {
+                            if let response = response {
+                                URLSessionLogger.logResponse(response, dataOrFile: object, instrumentation: self, sessionTaskId: sessionTaskId)
+                            }
+                        }
+                        if let completion = completion {
+                            completion(object, response, error)
+                        } else {
+                            (session.delegate as? URLSessionTaskDelegate)?.urlSession?(session, task: task, didCompleteWithError: error)
+                        }
+                    }
+                    completionBlock = completionWrapper
+                }
+
+                let instrumentedRequest = self.instrumentedRequest(for: request)
+                task = castedIMP(session, selector, instrumentedRequest, argument, completionBlock)
+                URLSessionLogger.logRequest(instrumentedRequest, instrumentation: self, sessionTaskId: sessionTaskId)
+
+                self.setIdKey(value: sessionTaskId, for: task)
+                return task
+            }
+            let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+            originalIMP = method_setImplementation(original, swizzledIMP)
+        }
+    }
+
+    // Delegate methods
+    private func injectTaskDidReceiveDataIntoDelegateClass(cls: AnyClass) {
+        let selector = #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:))
+        guard let original = class_getInstanceMethod(cls, selector) else {
+            return
+        }
+        var originalIMP: IMP?
+        let block: @convention(block) (Any, URLSession, URLSessionDataTask, Data) -> Void = { object, session, dataTask, data in
+            if objc_getAssociatedObject(session, &idKey) == nil {
+                self.urlSession(session, dataTask: dataTask, didReceive: data)
+            }
+            let key = String(selector.hashValue)
+            objc_setAssociatedObject(session, key, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (Any, Selector, URLSession, URLSessionDataTask, Data) -> Void).self)
+            castedIMP(object, selector, session, dataTask, data)
+            objc_setAssociatedObject(session, key, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+        let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+        originalIMP = method_setImplementation(original, swizzledIMP)
+    }
+
+    private func injectTaskDidReceiveResponseIntoDelegateClass(cls: AnyClass) {
+        let selector = #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:completionHandler:))
+        guard let original = class_getInstanceMethod(cls, selector) else {
+            return
+        }
+        var originalIMP: IMP?
+        let block: @convention(block) (Any, URLSession, URLSessionDataTask, URLResponse, @escaping (URLSession.ResponseDisposition) -> Void) -> Void = { object, session, dataTask, response, completion in
+            if objc_getAssociatedObject(session, &idKey) == nil {
+                self.urlSession(session, dataTask: dataTask, didReceive: response, completionHandler: completion)
+                completion(.allow)
+            }
+            let key = String(selector.hashValue)
+            objc_setAssociatedObject(session, key, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (Any, Selector, URLSession, URLSessionDataTask, URLResponse, @escaping (URLSession.ResponseDisposition) -> Void) -> Void).self)
+            castedIMP(object, selector, session, dataTask, response, completion)
+            objc_setAssociatedObject(session, key, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+        let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+        originalIMP = method_setImplementation(original, swizzledIMP)
+    }
+
+    private func injectTaskDidCompleteWithErrorIntoDelegateClass(cls: AnyClass) {
+        let selector = #selector(URLSessionDataDelegate.urlSession(_:task:didCompleteWithError:))
+        guard let original = class_getInstanceMethod(cls, selector) else {
+            return
+        }
+        var originalIMP: IMP?
+        let block: @convention(block) (Any, URLSession, URLSessionTask, Error?) -> Void = { object, session, task, error in
+            if objc_getAssociatedObject(session, &idKey) == nil {
+                self.urlSession(session, task: task, didCompleteWithError: error)
+            }
+            let key = String(selector.hashValue)
+            objc_setAssociatedObject(session, key, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (Any, Selector, URLSession, URLSessionTask, Error?) -> Void).self)
+            castedIMP(object, selector, session, task, error)
+            objc_setAssociatedObject(session, key, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+        let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+        originalIMP = method_setImplementation(original, swizzledIMP)
+    }
+
+    func injectRespondsToSelectorIntoDelegateClass(cls: AnyClass) {
+        let selector = #selector(NSObject.responds(to:))
+        guard let original = class_getInstanceMethod(cls, selector),
+              InstrumentationUtils.instanceRespondsAndImplements(cls: cls, selector: selector)
+        else {
+            return
+        }
+
+        var originalIMP: IMP?
+        let block: @convention(block) (Any, Selector) -> Bool = { object, respondsTo in
+            if respondsTo == #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:completionHandler:)) {
+                return true
+            }
+            let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (Any, Selector, Selector) -> Bool).self)
+            return castedIMP(object, selector, respondsTo)
+        }
+        let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+        originalIMP = method_setImplementation(original, swizzledIMP)
+    }
+
+    private func injectDataTaskDidBecomeDownloadTaskIntoDelegateClass(cls: AnyClass) {
+        let selector = #selector(URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)! as (URLSessionDataDelegate) -> (URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void)
+        guard let original = class_getInstanceMethod(cls, selector) else {
+            return
+        }
+        var originalIMP: IMP?
+        let block: @convention(block) (Any, URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void = { object, session, dataTask, downloadTask in
+            if objc_getAssociatedObject(session, &idKey) == nil {
+                self.urlSession(session, dataTask: dataTask, didBecome: downloadTask)
+            }
+            let key = String(selector.hashValue)
+            objc_setAssociatedObject(session, key, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            let castedIMP = unsafeBitCast(originalIMP, to: (@convention(c) (Any, Selector, URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void).self)
+            castedIMP(object, selector, session, dataTask, downloadTask)
+            objc_setAssociatedObject(session, key, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+        let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
+        originalIMP = method_setImplementation(original, swizzledIMP)
+    }
+
+    // URLSessionTask methods
+    private func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        guard configuration.shouldRecordPayload?(session) ?? false else { return }
+        let dataCopy = data
+        queue.async {
+            let taskId = self.idKeyForTask(dataTask)
+            if (self.requestMap[taskId]?.request) != nil {
+                var requestState = self.requestState(for: taskId)
+                requestState.dataProcessed?.append(dataCopy)
+            }
+        }
+    }
+
+    private func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        guard configuration.shouldRecordPayload?(session) ?? false else { return }
+        queue.async {
+            let taskId = self.idKeyForTask(dataTask)
+            if (self.requestMap[taskId]?.request) != nil {
+                var requestState = self.requestState(for: taskId)
+                if response.expectedContentLength < 0 {
+                    requestState.dataProcessed = Data()
+                } else {
+                    requestState.dataProcessed = Data(capacity: Int(response.expectedContentLength))
+                }
+            }
+        }
+    }
+
+    private func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        let taskId = self.idKeyForTask(task)
+        if (self.requestMap[taskId]?.request) != nil {
+            let requestState = self.requestState(for: taskId)
+            if let error = error {
+                let status = (task.response as? HTTPURLResponse)?.statusCode ?? 0
+                URLSessionLogger.logError(error, dataOrFile: requestState.dataProcessed, statusCode: status, instrumentation: self, sessionTaskId: taskId)
+            } else if let response = task.response {
+                URLSessionLogger.logResponse(response, dataOrFile: requestState.dataProcessed, instrumentation: self, sessionTaskId: taskId)
+            }
+        }
+    }
+
+    private func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didBecome downloadTask: URLSessionDownloadTask) {
+        queue.async {
+            let id = self.idKeyForTask(dataTask)
+            self.setIdKey(value: id, for: downloadTask)
+        }
+    }
+
+    // Helpers
+    private func idKeyForTask(_ task: URLSessionTask) -> String {
+        var id = objc_getAssociatedObject(task, &idKey) as? String
+        if id == nil {
+            id = UUID().uuidString
+            objc_setAssociatedObject(task, &idKey, id, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+        return id!
+    }
+
+    private func setIdKey(value: String, for task: URLSessionTask) {
+        objc_setAssociatedObject(task, &idKey, value, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    private func requestState(for id: String) -> NetworkRequestState {
+        var state = requestMap[id]
+        if state == nil {
+            state = NetworkRequestState()
+            requestMap[id] = state
+        }
+        return state!
+    }
+
+    private func instrumentedRequest(for request: URLRequest) -> URLRequest {
+        var request = request
+        guard configuration.shouldInjectTracingHeaders?(&request) ?? true
+        else {
+            return request
+        }
+        var instrumentedRequest = request
+        objc_setAssociatedObject(instrumentedRequest, &URLSessionInstrumentation.instrumentedKey, true, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+        var traceHeaders = tracePropagationHTTPHeaders()
+        if let originalHeaders = request.allHTTPHeaderFields {
+            traceHeaders.merge(originalHeaders) { _, new in new }
+        }
+        instrumentedRequest.allHTTPHeaderFields = traceHeaders
+        return instrumentedRequest
+    }
+
+    private func tracePropagationHTTPHeaders() -> [String: String] {
+        var headers = [String: String]()
+
+        struct HeaderSetter: Setter {
+            func set(carrier: inout [String: String], key: String, value: String) {
+                carrier[key] = value
+            }
+        }
+
+        guard let currentSpan = tracer.activeSpan else {
+            return headers
+        }
+        tracer.textFormat.inject(spanContext: currentSpan.context, carrier: &headers, setter: HeaderSetter())
+        return headers
+    }
+}

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -1,0 +1,102 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+class URLSessionLogger {
+    static var runningSpans = [String: Span]()
+    static var runningSpansQueue = DispatchQueue(label: "org.opentelemetry.URLSessionLogger")
+
+    static func logRequest(_ request: URLRequest, instrumentation: URLSessionInstrumentation, sessionTaskId: String) {
+        guard instrumentation.configuration.shouldInstrument?(request) ?? true else {
+            return
+        }
+
+        var attributes: [String: String]
+
+        attributes = [
+            SemanticAttributes.httpMethod.rawValue: request.httpMethod ?? "unknown_method",
+            SemanticAttributes.httpURL.rawValue: request.url?.absoluteString ?? "unknown_url",
+            SemanticAttributes.httpScheme.rawValue: request.url?.scheme ?? "unknown_scheme",
+        ]
+
+        if let host = request.url?.host {
+            attributes[SemanticAttributes.netPeerName.rawValue] = host
+        }
+
+        if let port = request.url?.port {
+            attributes[SemanticAttributes.netPeerPort.rawValue] = String(port)
+        }
+
+        let spanName = "HTTP " + (request.httpMethod ?? "")
+        let spanBuilder = instrumentation.tracer.spanBuilder(spanName: spanName)
+        spanBuilder.setSpanKind(spanKind: .client)
+        attributes.forEach {
+            spanBuilder.setAttribute(key: $0.key, value: $0.value)
+        }
+
+        instrumentation.configuration.createdRequest?(request, spanBuilder)
+
+        let span = spanBuilder.startSpan()
+        runningSpansQueue.sync {
+            runningSpans[sessionTaskId] = span
+        }
+    }
+
+    static func logResponse(_ response: URLResponse, dataOrFile: Any?, instrumentation: URLSessionInstrumentation, sessionTaskId: String) {
+        var span: Span!
+        runningSpansQueue.sync {
+            span = runningSpans.removeValue(forKey: sessionTaskId)
+        }
+        guard span != nil,
+              let httpResponse = response as? HTTPURLResponse
+        else {
+            return
+        }
+
+        let statusCode = httpResponse.statusCode
+        span.setAttribute(key: SemanticAttributes.httpStatusCode.rawValue, value: AttributeValue.string(String(statusCode)))
+        span.status = statusForStatusCode(code: statusCode)
+
+        instrumentation.configuration.receivedResponse?(response, dataOrFile, span)
+        span.end()
+    }
+
+    static func logError(_ error: Error, dataOrFile: Any?, statusCode: Int, instrumentation: URLSessionInstrumentation, sessionTaskId: String) {
+        var span: Span!
+        runningSpansQueue.sync {
+            span = runningSpans.removeValue(forKey: sessionTaskId)
+        }
+        guard span != nil else {
+            return
+        }
+        span.setAttribute(key: SemanticAttributes.httpStatusCode.rawValue, value: AttributeValue.string(String(statusCode)))
+        span.status = URLSessionLogger.statusForStatusCode(code: statusCode)
+        instrumentation.configuration.receivedError?(error, dataOrFile, statusCode, span)
+
+        span.end()
+    }
+
+    static func statusForStatusCode(code: Int) -> Status {
+        switch code {
+            case 200 ... 399:
+                return .ok
+            default:
+                return .error(description: String(code))
+        }
+    }
+}


### PR DESCRIPTION
This is my proposal for URLSession instrumentation:
* It works just by initializing `URLSessionInstrumentation`, for any code or library based on URLSession, no changes for the user code or third party libraries.
* User can implement any extra behaviour by setting the callbacks in `URLSessionConfiguration`. e.g. exclude URL's for instrumentation or header injection, report extra tags, inject extra headers...

Added a very simple example that can be used for experimenting
Missing tests for the code