### PR TITLE
Hide DefaultSpan and remove DefaultSpan.random()

### DIFF
--- a/Examples/Logging Tracer/LoggingTracer.swift
+++ b/Examples/Logging Tracer/LoggingTracer.swift
@@ -46,10 +46,14 @@ class LoggingTracer: Tracer {
         }
 
         func startSpan() -> Span {
-            if spanContext == nil && !isRootSpan {
+            if spanContext == nil, !isRootSpan {
                 spanContext = tracer.activeSpan?.context
             }
-            return spanContext != nil && spanContext != SpanContext.invalid ? LoggingSpan(name: name, kind: .client) : DefaultSpan.random()
+            if spanContext != nil, spanContext != SpanContext.invalid {
+                return LoggingSpan(name: name, kind: .client)
+            } else {
+                return DefaultTracer.instance.spanBuilder(spanName: name).startSpan()
+            }
         }
 
         func setParent(_ parent: Span) -> Self {
@@ -74,7 +78,7 @@ class LoggingTracer: Tracer {
         func addLink(spanContext: SpanContext, attributes: [String: AttributeValue]) -> Self {
             return self
         }
-        
+
         func setSpanKind(spanKind: SpanKind) -> Self {
             return self
         }

--- a/Sources/OpenTelemetryApi/Trace/DefaultTracer.swift
+++ b/Sources/OpenTelemetryApi/Trace/DefaultTracer.swift
@@ -19,8 +19,6 @@ import Foundation
 public class DefaultTracer: Tracer {
     public static var instance = DefaultTracer()
 
-    public init() {}
-
     public var activeSpan: Span? {
         return ContextUtils.getCurrentSpan()
     }
@@ -30,6 +28,6 @@ public class DefaultTracer: Tracer {
     }
 
     public func spanBuilder(spanName: String) -> SpanBuilder {
-        return DefaultSpanBuilder(tracer: self, spanName: spanName)
+        return PropagatedSpanBuilder(tracer: self, spanName: spanName)
     }
 }

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
@@ -15,34 +15,33 @@
 
 import Foundation
 
-/// The DefaultSpan is the default Span that is used when no Span
+/// The PropagatedSpan is the default Span that is used when no Span
 /// implementation is available. All operations are no-op except context propagation.
-/// Used also to stop tracing, see Tracer.withSpan()
-public class DefaultSpan: Span {
-    public var name: String = ""
+class PropagatedSpan: Span {
+    var name: String = ""
 
-    public var kind: SpanKind
+    var kind: SpanKind
 
-    public var context: SpanContext
+    var context: SpanContext
 
-    public var scope: Scope?
+    var scope: Scope?
 
-    public func end() {
+    func end() {
         scope?.close()
     }
 
-    public func end(time: Date) {
+    func end(time: Date) {
         end()
     }
 
     /// Returns a DefaultSpan with an invalid SpanContext.
-    public convenience init() {
+    convenience init() {
         self.init(context: SpanContext.invalid, kind: .client)
     }
 
     /// Creates an instance of this class with the SpanContext.
     /// - Parameter context: the SpanContext
-    public convenience init(context: SpanContext) {
+    convenience init(context: SpanContext) {
         self.init(context: context, kind: .client)
     }
 
@@ -50,43 +49,43 @@ public class DefaultSpan: Span {
     /// - Parameters:
     ///   - context: the SpanContext
     ///   - kind: the SpanKind
-    public init(context: SpanContext, kind: SpanKind) {
+    init(context: SpanContext, kind: SpanKind) {
         self.context = context
         self.kind = kind
     }
 
-    public static func random() -> DefaultSpan {
-        return DefaultSpan(context: SpanContext.create(traceId: TraceId.random(),
+    static func random() -> PropagatedSpan {
+        return PropagatedSpan(context: SpanContext.create(traceId: TraceId.random(),
                                                        spanId: SpanId.random(),
                                                        traceFlags: TraceFlags(),
                                                        traceState: TraceState()),
                            kind: .client)
     }
 
-    public var isRecording: Bool {
+    var isRecording: Bool {
         return false
     }
 
-    public var status: Status {
+    var status: Status {
         get {
             return Status.ok
         }
         set {}
     }
 
-    public var description: String {
-        return "DefaultSpan"
+    var description: String {
+        return "PropagatedSpan"
     }
 
-    public func updateName(name: String) {}
+    func updateName(name: String) {}
 
-    public func setAttribute(key: String, value: AttributeValue?) {}
+    func setAttribute(key: String, value: AttributeValue?) {}
 
-    public func addEvent(name: String) {}
+    func addEvent(name: String) {}
 
-    public func addEvent(name: String, timestamp: Date) {}
+    func addEvent(name: String, timestamp: Date) {}
 
-    public func addEvent(name: String, attributes: [String: AttributeValue]) {}
+    func addEvent(name: String, attributes: [String: AttributeValue]) {}
 
-    public func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {}
+    func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {}
 }

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
@@ -54,14 +54,6 @@ class PropagatedSpan: Span {
         self.kind = kind
     }
 
-    static func random() -> PropagatedSpan {
-        return PropagatedSpan(context: SpanContext.create(traceId: TraceId.random(),
-                                                       spanId: SpanId.random(),
-                                                       traceFlags: TraceFlags(),
-                                                       traceState: TraceState()),
-                           kind: .client)
-    }
-
     var isRecording: Bool {
         return false
     }

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 /// No-op implementation of the SpanBuilder
-public class DefaultSpanBuilder: SpanBuilder {
+class PropagatedSpanBuilder: SpanBuilder {
     private var tracer: Tracer
     private var isRootSpan: Bool = false
     private var spanContext: SpanContext?
@@ -29,7 +29,7 @@ public class DefaultSpanBuilder: SpanBuilder {
         if spanContext == nil, !isRootSpan {
             spanContext = tracer.activeSpan?.context
         }
-        return spanContext != nil && spanContext != SpanContext.invalid ? DefaultSpan(context: spanContext!, kind: .client) : DefaultSpan.random()
+        return spanContext != nil && spanContext != SpanContext.invalid ? PropagatedSpan(context: spanContext!, kind: .client) : PropagatedSpan.random()
     }
 
     @discardableResult public func setParent(_ parent: Span) -> Self {

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
@@ -29,7 +29,14 @@ class PropagatedSpanBuilder: SpanBuilder {
         if spanContext == nil, !isRootSpan {
             spanContext = tracer.activeSpan?.context
         }
-        return spanContext != nil && spanContext != SpanContext.invalid ? PropagatedSpan(context: spanContext!, kind: .client) : PropagatedSpan.random()
+        if spanContext != nil && spanContext != SpanContext.invalid {
+            return PropagatedSpan(context: spanContext!, kind: .client)
+        } else {
+            return PropagatedSpan(context: SpanContext.create(traceId: TraceId.random(),
+                                                              spanId: SpanId.random(),
+                                                              traceFlags: TraceFlags(),
+                                                              traceState: TraceState()))
+        }
     }
 
     @discardableResult public func setParent(_ parent: Span) -> Self {

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSDK.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSDK.swift
@@ -135,7 +135,7 @@ public class SpanBuilderSdk: SpanBuilder {
                                              traceState: traceState)
 
         if !samplingDecision.isSampled {
-            return DefaultSpan(context: spanContext, kind: spanKind)
+            return DefaultTracer.instance.spanBuilder(spanName: spanName).startSpan()
         }
 
         attributes.updateValues(attributes: samplingDecision.attributes)

--- a/Sources/OpenTelemetrySdk/Trace/TracerSdkProvider.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TracerSdkProvider.swift
@@ -31,7 +31,7 @@ public class TracerSdkProvider: TracerProvider {
 
     public func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Tracer {
         if sharedState.hasBeenShutdown {
-            return DefaultTracer()
+            return DefaultTracer.instance
         }
         let instrumentationLibraryInfo = InstrumentationLibraryInfo(name: instrumentationName, version: instrumentationVersion ?? "")
         if let tracer = tracerProvider[instrumentationLibraryInfo] {

--- a/Tests/OpenTelemetryApiTests/Context/Propagation/BinaryFormatTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/Propagation/BinaryFormatTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-import OpenTelemetryApi
+@testable import OpenTelemetryApi
 import XCTest
 
 class BinaryFormatTests: XCTestCase {
@@ -32,7 +32,7 @@ class BinaryFormatTests: XCTestCase {
         traceId = TraceId(fromBytes: traceId_bytes)
         spanId = SpanId(fromBytes: spanId_bytes)
         traceOptions = TraceFlags(fromByte: traceOptions_byte)
-        invalidSpanContext = DefaultSpan().context
+        invalidSpanContext = PropagatedSpan().context
     }
 
     private func testSpanContextConversion(spanContext: SpanContext) {

--- a/Tests/OpenTelemetryApiTests/Trace/DefaultSpanTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/DefaultSpanTests.swift
@@ -13,25 +13,25 @@
 // limitations under the License.
 //
 
-import OpenTelemetryApi
+@testable import OpenTelemetryApi
 import XCTest
 
 final class DefaultSpanTest: XCTestCase {
     func testHasInvalidContextAndDefaultSpanOptions() {
-        let context = DefaultSpan.random().context
+        let context = PropagatedSpan.random().context
         XCTAssertEqual(context.traceFlags, TraceFlags())
         XCTAssertEqual(context.traceState, TraceState())
     }
 
     func testHasUniqueTraceIdAndSpanId() {
-        let span1 = DefaultSpan.random()
-        let span2 = DefaultSpan.random()
+        let span1 = PropagatedSpan.random()
+        let span2 = PropagatedSpan.random()
         XCTAssertNotEqual(span1.context.traceId, span2.context.traceId)
         XCTAssertNotEqual(span1.context.spanId, span2.context.spanId)
     }
 
     func testDoNotCrash() {
-        let span = DefaultSpan.random()
+        let span = PropagatedSpan.random()
         span.setAttribute(key: "MyStringAttributeKey", value: AttributeValue.string("MyStringAttributeValue"))
         span.setAttribute(key: "MyBooleanAttributeKey", value: AttributeValue.bool(true))
         span.setAttribute(key: "MyLongAttributeKey", value: AttributeValue.int(123))
@@ -51,12 +51,12 @@ final class DefaultSpanTest: XCTestCase {
     }
 
     func testDefaultSpan_ToString() {
-        let span = DefaultSpan.random()
-        XCTAssertEqual(span.description, "DefaultSpan")
+        let span = PropagatedSpan.random()
+        XCTAssertEqual(span.description, "PropagatedSpan")
     }
 
     func testDefaultSpan_NilEndSpanOptions() {
-        let span = DefaultSpan()
+        let span = PropagatedSpan()
         span.end()
     }
 }

--- a/Tests/OpenTelemetryApiTests/Trace/DefaultTracerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/DefaultTracerTests.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-import OpenTelemetryApi
+@testable import OpenTelemetryApi
 import XCTest
 
 final class DefaultTracerTests: XCTestCase {
@@ -30,20 +30,20 @@ final class DefaultTracerTests: XCTestCase {
     }
 
     func testDefaultGetCurrentSpan() {
-        XCTAssert(defaultTracer.activeSpan is DefaultSpan?)
+        XCTAssert(defaultTracer.activeSpan is PropagatedSpan?)
     }
 
     func testGetCurrentSpan_WithSpan() {
         XCTAssert(defaultTracer.activeSpan == nil)
-        var ws = defaultTracer.setActive(DefaultSpan.random())
+        var ws = defaultTracer.setActive(PropagatedSpan.random())
         XCTAssert(defaultTracer.activeSpan != nil)
-        XCTAssert(defaultTracer.activeSpan is DefaultSpan)
+        XCTAssert(defaultTracer.activeSpan is PropagatedSpan)
         ws.close()
         XCTAssert(defaultTracer.activeSpan == nil)
     }
 
     func testDefaultSpanBuilderWithName() {
-        XCTAssert(defaultTracer.spanBuilder(spanName: spanName).startSpan() is DefaultSpan)
+        XCTAssert(defaultTracer.spanBuilder(spanName: spanName).startSpan() is PropagatedSpan)
     }
 
     func testTestInProcessContext() {
@@ -69,14 +69,14 @@ final class DefaultTracerTests: XCTestCase {
     }
 
     func testTestSpanContextPropagation() {
-        let parent = DefaultSpan(context: spanContext)
+        let parent = PropagatedSpan(context: spanContext)
 
         let span = defaultTracer.spanBuilder(spanName: spanName).setParent(parent).startSpan()
         XCTAssert(span.context === spanContext)
     }
 
     func testTestSpanContextPropagationCurrentSpan() {
-        let parent = DefaultSpan(context: spanContext)
+        let parent = PropagatedSpan(context: spanContext)
         var scope = defaultTracer.setActive(parent)
         let span = defaultTracer.spanBuilder(spanName: spanName).startSpan()
         XCTAssert(span.context === spanContext)

--- a/Tests/OpenTelemetryApiTests/Trace/DefaultTracerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/DefaultTracerTests.swift
@@ -18,6 +18,13 @@ import Foundation
 @testable import OpenTelemetryApi
 import XCTest
 
+fileprivate func createRandomPropagatedSpan() -> PropagatedSpan {
+    return PropagatedSpan(context: SpanContext.create(traceId: TraceId.random(),
+                                                      spanId: SpanId.random(),
+                                                      traceFlags: TraceFlags(),
+                                                      traceState: TraceState()))
+}
+
 final class DefaultTracerTests: XCTestCase {
     let defaultTracer = DefaultTracer.instance
     let spanName = "MySpanName"
@@ -35,7 +42,7 @@ final class DefaultTracerTests: XCTestCase {
 
     func testGetCurrentSpan_WithSpan() {
         XCTAssert(defaultTracer.activeSpan == nil)
-        var ws = defaultTracer.setActive(PropagatedSpan.random())
+        var ws = defaultTracer.setActive(createRandomPropagatedSpan())
         XCTAssert(defaultTracer.activeSpan != nil)
         XCTAssert(defaultTracer.activeSpan is PropagatedSpan)
         ws.close()

--- a/Tests/OpenTelemetryApiTests/Trace/PropagatedSpanTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/PropagatedSpanTests.swift
@@ -16,22 +16,29 @@
 @testable import OpenTelemetryApi
 import XCTest
 
-final class DefaultSpanTest: XCTestCase {
+fileprivate func createRandomPropagatedSpan() -> PropagatedSpan {
+    return PropagatedSpan(context: SpanContext.create(traceId: TraceId.random(),
+                                                      spanId: SpanId.random(),
+                                                      traceFlags: TraceFlags(),
+                                                      traceState: TraceState()))
+}
+
+final class PropagatedSpanTest: XCTestCase {
     func testHasInvalidContextAndDefaultSpanOptions() {
-        let context = PropagatedSpan.random().context
+        let context = createRandomPropagatedSpan().context
         XCTAssertEqual(context.traceFlags, TraceFlags())
         XCTAssertEqual(context.traceState, TraceState())
     }
 
     func testHasUniqueTraceIdAndSpanId() {
-        let span1 = PropagatedSpan.random()
-        let span2 = PropagatedSpan.random()
+        let span1 = createRandomPropagatedSpan()
+        let span2 = createRandomPropagatedSpan()
         XCTAssertNotEqual(span1.context.traceId, span2.context.traceId)
         XCTAssertNotEqual(span1.context.spanId, span2.context.spanId)
     }
 
     func testDoNotCrash() {
-        let span = PropagatedSpan.random()
+        let span = createRandomPropagatedSpan()
         span.setAttribute(key: "MyStringAttributeKey", value: AttributeValue.string("MyStringAttributeValue"))
         span.setAttribute(key: "MyBooleanAttributeKey", value: AttributeValue.bool(true))
         span.setAttribute(key: "MyLongAttributeKey", value: AttributeValue.int(123))
@@ -51,7 +58,7 @@ final class DefaultSpanTest: XCTestCase {
     }
 
     func testDefaultSpan_ToString() {
-        let span = PropagatedSpan.random()
+        let span = createRandomPropagatedSpan()
         XCTAssertEqual(span.description, "PropagatedSpan")
     }
 

--- a/Tests/OpenTelemetryApiTests/Trace/SpanBuilderTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/SpanBuilderTests.swift
@@ -16,18 +16,25 @@
 @testable import OpenTelemetryApi
 import XCTest
 
+fileprivate func createRandomPropagatedSpan() -> PropagatedSpan {
+    return PropagatedSpan(context: SpanContext.create(traceId: TraceId.random(),
+                                                      spanId: SpanId.random(),
+                                                      traceFlags: TraceFlags(),
+                                                      traceState: TraceState()))
+}
+
 class SpanBuilderTests: XCTestCase {
     let tracer = DefaultTracer.instance
 
     func testDoNotCrash_NoopImplementation() {
         let spanBuilder = tracer.spanBuilder(spanName: "MySpanName")
         spanBuilder.setSpanKind(spanKind: .server)
-        spanBuilder.setParent(PropagatedSpan.random())
-        spanBuilder.setParent(PropagatedSpan.random().context)
+        spanBuilder.setParent(createRandomPropagatedSpan())
+        spanBuilder.setParent(createRandomPropagatedSpan().context)
         spanBuilder.setNoParent()
-        spanBuilder.addLink(spanContext: PropagatedSpan.random().context)
-        spanBuilder.addLink(spanContext: PropagatedSpan.random().context, attributes: [String: AttributeValue]())
-        spanBuilder.addLink(spanContext: PropagatedSpan.random().context, attributes: [String: AttributeValue]())
+        spanBuilder.addLink(spanContext: createRandomPropagatedSpan().context)
+        spanBuilder.addLink(spanContext: createRandomPropagatedSpan().context, attributes: [String: AttributeValue]())
+        spanBuilder.addLink(spanContext: createRandomPropagatedSpan().context, attributes: [String: AttributeValue]())
         spanBuilder.setAttribute(key: "key", value: "value")
         spanBuilder.setAttribute(key: "key", value: 12345)
         spanBuilder.setAttribute(key: "key", value: 0.12345)

--- a/Tests/OpenTelemetryApiTests/Trace/SpanBuilderTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/SpanBuilderTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-import OpenTelemetryApi
+@testable import OpenTelemetryApi
 import XCTest
 
 class SpanBuilderTests: XCTestCase {
@@ -22,18 +22,18 @@ class SpanBuilderTests: XCTestCase {
     func testDoNotCrash_NoopImplementation() {
         let spanBuilder = tracer.spanBuilder(spanName: "MySpanName")
         spanBuilder.setSpanKind(spanKind: .server)
-        spanBuilder.setParent(DefaultSpan.random())
-        spanBuilder.setParent(DefaultSpan.random().context)
+        spanBuilder.setParent(PropagatedSpan.random())
+        spanBuilder.setParent(PropagatedSpan.random().context)
         spanBuilder.setNoParent()
-        spanBuilder.addLink(spanContext: DefaultSpan.random().context)
-        spanBuilder.addLink(spanContext: DefaultSpan.random().context, attributes: [String: AttributeValue]())
-        spanBuilder.addLink(spanContext: DefaultSpan.random().context, attributes: [String: AttributeValue]())
+        spanBuilder.addLink(spanContext: PropagatedSpan.random().context)
+        spanBuilder.addLink(spanContext: PropagatedSpan.random().context, attributes: [String: AttributeValue]())
+        spanBuilder.addLink(spanContext: PropagatedSpan.random().context, attributes: [String: AttributeValue]())
         spanBuilder.setAttribute(key: "key", value: "value")
         spanBuilder.setAttribute(key: "key", value: 12345)
         spanBuilder.setAttribute(key: "key", value: 0.12345)
         spanBuilder.setAttribute(key: "key", value: true)
         spanBuilder.setAttribute(key: "key", value: AttributeValue.string("value"))
         spanBuilder.setStartTime(time: Date())
-        XCTAssert(spanBuilder.startSpan() is DefaultSpan)
+        XCTAssert(spanBuilder.startSpan() is PropagatedSpan)
     }
 }

--- a/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-import OpenTelemetryApi
+@testable import OpenTelemetryApi
 import OpenTelemetrySdk
 import XCTest
 
@@ -43,9 +43,9 @@ class SpanBuilderSdkTest: XCTestCase {
     func testAddLink() {
         // Verify methods do not crash.
         let spanBuilder = tracerSdk.spanBuilder(spanName: spanName) as! SpanBuilderSdk
-        spanBuilder.addLink(SpanData.Link(context: DefaultSpan().context))
-        spanBuilder.addLink(spanContext: DefaultSpan().context)
-        spanBuilder.addLink(spanContext: DefaultSpan().context, attributes: [String: AttributeValue]())
+        spanBuilder.addLink(SpanData.Link(context: PropagatedSpan().context))
+        spanBuilder.addLink(spanContext: PropagatedSpan().context)
+        spanBuilder.addLink(spanContext: PropagatedSpan().context, attributes: [String: AttributeValue]())
         let span = spanBuilder.startSpan() as! RecordEventsReadableSpan
         XCTAssertEqual(span.toSpanData().links.count, 3)
         span.end()
@@ -242,7 +242,7 @@ class SpanBuilderSdkTest: XCTestCase {
     }
 
     func testParent_invalidContext() {
-        let parent = DefaultSpan()
+        let parent = PropagatedSpan()
         let span = tracerSdk.spanBuilder(spanName: spanName).setParent(parent.context).startSpan() as! RecordEventsReadableSpan
         XCTAssertNotEqual(span.context.traceId, parent.context.traceId)
         XCTAssertNil(span.parentContext?.spanId)

--- a/Tests/OpenTelemetrySdkTests/Trace/TracerSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/TracerSdkTests.swift
@@ -54,7 +54,7 @@ class TracerSdkTests: XCTestCase {
         // TODO: Check context bahaviour
 //        let origContext = ContextUtils.withSpan(span)
 //        XCTAssertTrue(tracer.currentSpan === span)
-//        XCTAssertTrue(tracer.currentSpan is DefaultSpan)
+//        XCTAssertTrue(tracer.currentSpan is PropagatedSpan)
     }
 
     func testGetCurrentSpan_WithSpan() {


### PR DESCRIPTION
Change DefaultSpan to PropagatedSpan and clean its public visibility, also rename DefaultSpanBuilder to PropagatedSpanBuilder and hide. These classes can only be now used for internal tests. Fixes #121
Remove PropagatedSpan.random(), it was only used once internally and in tests, so move the code where it is used. Fixes #122