### PR TITLE
Make B3Propagator extract headers fro both formats

### DIFF
--- a/Examples/Logging Tracer/LoggingBinaryFormat.swift
+++ b/Examples/Logging Tracer/LoggingBinaryFormat.swift
@@ -19,7 +19,7 @@ import OpenTelemetryApi
 struct LoggingBinaryFormat: BinaryFormattable {
     func fromByteArray(bytes: [UInt8]) -> SpanContext? {
         Logger.log("LoggingBinaryFormat.FromByteArray(...)")
-        return SpanContext.invalid
+        return nil
     }
 
     func toByteArray(spanContext: SpanContext) -> [UInt8] {

--- a/Examples/Logging Tracer/LoggingSpan.swift
+++ b/Examples/Logging Tracer/LoggingSpan.swift
@@ -19,15 +19,18 @@ import OpenTelemetryApi
 class LoggingSpan: Span {
     var name: String
     var kind: SpanKind
-    var context: SpanContext = SpanContext.invalid
+    var context: SpanContext
     var isRecording: Bool = true
     var status: Status = .unset
     var scope: Scope?
 
-
     public init(name: String, kind: SpanKind) {
         self.name = name
         self.kind = kind
+        self.context = SpanContext.create(traceId: TraceId.random(),
+                                          spanId: SpanId.random(),
+                                          traceFlags: TraceFlags(),
+                                          traceState: TraceState())
     }
 
     public var description: String {

--- a/Examples/Logging Tracer/LoggingTracer.swift
+++ b/Examples/Logging Tracer/LoggingTracer.swift
@@ -29,11 +29,6 @@ class LoggingTracer: Tracer {
         return LoggingSpanBuilder(tracer: self, spanName: spanName)
     }
 
-    @discardableResult func setActive(_ span: Span) -> Scope {
-        Logger.log("\(tracerName).WithSpan")
-        return OpenTelemetryContext.setActiveSpan(span)
-    }
-
     class LoggingSpanBuilder: SpanBuilder {
         private var tracer: Tracer
         private var isRootSpan: Bool = false
@@ -49,7 +44,7 @@ class LoggingTracer: Tracer {
             if spanContext == nil, !isRootSpan {
                 spanContext = OpenTelemetryContext.activeSpan?.context
             }
-            if spanContext != nil, spanContext != SpanContext.invalid {
+            if spanContext != nil {
                 return LoggingSpan(name: name, kind: .client)
             } else {
                 return DefaultTracer.instance.spanBuilder(spanName: name).startSpan()

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
@@ -36,7 +36,11 @@ class PropagatedSpan: Span {
 
     /// Returns a DefaultSpan with an invalid SpanContext.
     convenience init() {
-        self.init(context: SpanContext.invalid, kind: .client)
+        let invalidContext = SpanContext.create(traceId: TraceId(),
+                           spanId: SpanId(),
+                           traceFlags: TraceFlags(),
+                           traceState: TraceState())
+        self.init(context: invalidContext, kind: .client)
     }
 
     /// Creates an instance of this class with the SpanContext.

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
@@ -29,14 +29,10 @@ class PropagatedSpanBuilder: SpanBuilder {
         if spanContext == nil, !isRootSpan {
             spanContext = OpenTelemetryContext.activeSpan?.context
         }
-        if spanContext != nil && spanContext != SpanContext.invalid {
-            return PropagatedSpan(context: spanContext!, kind: .client)
-        } else {
-            return PropagatedSpan(context: SpanContext.create(traceId: TraceId.random(),
-                                                              spanId: SpanId.random(),
-                                                              traceFlags: TraceFlags(),
-                                                              traceState: TraceState()))
-        }
+        return PropagatedSpan(context: spanContext ?? SpanContext.create(traceId: TraceId.random(),
+                                                                         spanId: SpanId.random(),
+                                                                         traceFlags: TraceFlags(),
+                                                                         traceState: TraceState()))
     }
 
     @discardableResult public func setParent(_ parent: Span) -> Self {

--- a/Sources/OpenTelemetryApi/Trace/Propagation/B3Propagator.swift
+++ b/Sources/OpenTelemetryApi/Trace/Propagation/B3Propagator.swift
@@ -27,31 +27,31 @@ public class B3Propagator: TextMapPropagator {
     public static let falseInt = "0"
     public static let combinedHeader = "b3"
     public static let combinedHeaderDelimiter = "-"
-    
+
     public let fields: Set<String> = [traceIdHeader, spanIdHeader, sampledHeader]
-    
+
     private static let maxTraceIdLength = 2 * TraceId.size
     private static let maxSpanIdLength = 2 * SpanId.size
-    private static let sampledFlags: TraceFlags = TraceFlags().settingIsSampled(true)
-    private static let notSampledFlags: TraceFlags = TraceFlags().settingIsSampled(false)
-    
-    private var singleHeader: Bool
-    
+    private static let sampledFlags = TraceFlags().settingIsSampled(true)
+    private static let notSampledFlags = TraceFlags().settingIsSampled(false)
+
+    private var singleHeaderInjection: Bool
+
     /// Creates a new instance of B3Propagator. Default to use multiple headers.
     public init() {
-        self.singleHeader = false
+        self.singleHeaderInjection = false
     }
-    
+
     /// Creates a new instance of B3Propagator
     /// - Parameters:
     ///     - singleHeader: whether to use single or multiple headers
-    public init(_ singleHeader: Bool) {
-        self.singleHeader = singleHeader
+    public init(_ singleHeaderInjection: Bool) {
+        self.singleHeaderInjection = singleHeaderInjection
     }
-    
+
     public func inject<S>(spanContext: SpanContext, carrier: inout [String: String], setter: S) where S: Setter {
         let sampled = spanContext.traceFlags.sampled ? B3Propagator.trueInt : B3Propagator.falseInt
-        if singleHeader {
+        if singleHeaderInjection {
             setter.set(carrier: &carrier, key: B3Propagator.combinedHeader, value: "\(spanContext.traceId.hexString)\(B3Propagator.combinedHeaderDelimiter)\(spanContext.spanId.hexString)\(B3Propagator.combinedHeaderDelimiter)\(sampled)")
         } else {
             setter.set(carrier: &carrier, key: B3Propagator.traceIdHeader, value: spanContext.traceId.hexString)
@@ -59,87 +59,83 @@ public class B3Propagator: TextMapPropagator {
             setter.set(carrier: &carrier, key: B3Propagator.sampledHeader, value: sampled)
         }
     }
-    
+
     public func extract<G>(carrier: [String: String], getter: G) -> SpanContext? where G: Getter {
         var spanContext: SpanContext?
-        
-        if singleHeader {
-            spanContext = getSpanContextFromSingleHeader(carrier: carrier, getter: getter)
-        } else {
+
+        spanContext = getSpanContextFromSingleHeader(carrier: carrier, getter: getter)
+        if spanContext == nil {
             spanContext = getSpanContextFromMultipleHeaders(carrier: carrier, getter: getter)
         }
-        
+        if spanContext == nil {
+            print("Invalid SpanId in B3 header. Returning no span context.")
+        }
+
         return spanContext
     }
-    
+
     private func getSpanContextFromSingleHeader<G>(carrier: [String: String], getter: G) -> SpanContext? where G: Getter {
         guard let value = getter.get(carrier: carrier, key: B3Propagator.combinedHeader), value.count >= 1 else {
-            print("Missing or empty combined header: \(B3Propagator.combinedHeader). Returning INVALID span context.")
-            return SpanContext.invalid
+            return nil
         }
-        
+
         let parts: [String] = value[0].split(separator: "-").map { String($0) }
-        
+
         //  must have between 2 and 4 hyphen delimited parts:
         //  traceId-spanId-sampled-parentSpanId (last two are optional)
         if parts.count < 2 || parts.count > 4 {
-            print("Invalid combined header '\(B3Propagator.combinedHeader)'. Returning INVALID span Context")
-            return SpanContext.invalid
+            return nil
         }
-        
+
         let traceId = parts[0]
         if !isTraceIdValid(traceId) {
-            print("Invalid TraceId in B3 header: \(B3Propagator.combinedHeader). Returning INVALID span context.")
-            return SpanContext.invalid
+            return nil
         }
-        
+
         let spanId = parts[1]
         if !isSpanIdValid(spanId) {
-            print("Invalid SpanId in B3 header: \(B3Propagator.combinedHeader). Returning INVALID span context.")
-            return SpanContext.invalid
+            return nil
         }
-        
+
         let sampled: String? = parts.count >= 3 ? parts[2] : nil
-        
+
         return buildSpanContext(traceId: traceId, spanId: spanId, sampled: sampled)
     }
-    
+
     private func getSpanContextFromMultipleHeaders<G>(carrier: [String: String], getter: G) -> SpanContext? where G: Getter {
         guard let traceIdCollection = getter.get(carrier: carrier, key: B3Propagator.traceIdHeader), traceIdCollection.count >= 1, isTraceIdValid(traceIdCollection[0]) else {
-            print("Invalid TraceId in B3 header: \(B3Propagator.combinedHeader). Returning INVALID span context.")
-            return SpanContext.invalid
+            return nil
         }
-        
+
         let traceId = traceIdCollection[0]
-        
+
         guard let spanIdCollection = getter.get(carrier: carrier, key: B3Propagator.spanIdHeader), spanIdCollection.count >= 0, isSpanIdValid(spanIdCollection[0]) else {
-            print("Invalid SpanId in B3 header: \(B3Propagator.combinedHeader). Returning INVALID span context.")
-            return SpanContext.invalid
+            return nil
         }
-        
+
         let spanId = spanIdCollection[0]
-        
+
         guard let sampledCollection = getter.get(carrier: carrier, key: B3Propagator.sampledHeader), sampledCollection.count >= 1 else {
             return buildSpanContext(traceId: traceId, spanId: spanId, sampled: nil)
         }
-        
+
         return buildSpanContext(traceId: traceId, spanId: spanId, sampled: sampledCollection.first)
     }
-    
-    private func buildSpanContext(traceId: String, spanId: String, sampled: String?) -> SpanContext {
+
+    private func buildSpanContext(traceId: String, spanId: String, sampled: String?) -> SpanContext? {
         if let sampled = sampled {
             let traceFlags = (sampled == B3Propagator.trueInt || sampled == "true") ? B3Propagator.sampledFlags : B3Propagator.notSampledFlags
-            return SpanContext.createFromRemoteParent(traceId: TraceId(fromHexString: traceId), spanId: SpanId(fromHexString: spanId), traceFlags: traceFlags, traceState: TraceState())
+            let returnContext = SpanContext.createFromRemoteParent(traceId: TraceId(fromHexString: traceId), spanId: SpanId(fromHexString: spanId), traceFlags: traceFlags, traceState: TraceState())
+            return returnContext.isValid ? returnContext : nil
         } else {
-            print("Error parsing B3 header. Returning INVALID span content.")
-            return SpanContext.invalid
+            return nil
         }
     }
-    
+
     private func isTraceIdValid(_ traceId: String) -> Bool {
         return !(traceId.isEmpty || traceId.count > B3Propagator.maxTraceIdLength)
     }
-    
+
     private func isSpanIdValid(_ spanId: String) -> Bool {
         return !(spanId.isEmpty || spanId.count > B3Propagator.maxSpanIdLength)
     }

--- a/Sources/OpenTelemetryApi/Trace/SpanContext.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanContext.swift
@@ -18,7 +18,7 @@ import Foundation
 /// A class that represents a span context. A span context contains the state that must propagate to
 /// child Spans and across process boundaries. It contains the identifiers race_id and span_id
 /// associated with the Span and a set of options.
-public final class SpanContext: Equatable, CustomStringConvertible, Hashable {
+public struct SpanContext: Equatable, CustomStringConvertible, Hashable {
     /// The trace identifier associated with this SpanContext
     public private(set) var traceId: TraceId
 
@@ -33,12 +33,6 @@ public final class SpanContext: Equatable, CustomStringConvertible, Hashable {
 
     /// The traceState associated with this SpanContext
     public let isRemote: Bool
-
-    /// The invalid SpanContext that can be used for no-op operations.
-    public static let invalid = SpanContext(traceId: TraceId.invalid,
-                                            spanId: SpanId.invalid,
-                                            traceFlags: TraceFlags(),
-                                            traceState: TraceState(), isRemote: false)
 
     private init(traceId: TraceId, spanId: SpanId, traceFlags: TraceFlags, traceState: TraceState, isRemote: Bool) {
         self.traceId = traceId

--- a/Tests/OpenTelemetryApiTests/Context/Propagation/B3PropagatorTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/Propagation/B3PropagatorTests.swift
@@ -120,7 +120,7 @@ class B3PropagatorTests: XCTestCase {
         invalidHeaders[B3Propagator.spanIdHeader] = spanIdHexString
         invalidHeaders[B3Propagator.sampledHeader] = B3Propagator.trueInt
 
-        XCTAssertFalse(b3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(b3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_InvalidTraceId_Size() {
@@ -129,7 +129,7 @@ class B3PropagatorTests: XCTestCase {
         invalidHeaders[B3Propagator.spanIdHeader] = spanIdHexString
         invalidHeaders[B3Propagator.sampledHeader] = B3Propagator.trueInt
 
-        XCTAssertFalse(b3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(b3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_InvalidSpanId() {
@@ -138,7 +138,7 @@ class B3PropagatorTests: XCTestCase {
         invalidHeaders[B3Propagator.spanIdHeader] = "abcdefghijklmnop"
         invalidHeaders[B3Propagator.sampledHeader] = B3Propagator.trueInt
 
-        XCTAssertFalse(b3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(b3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_InvalidSpanId_Size() {
@@ -147,7 +147,7 @@ class B3PropagatorTests: XCTestCase {
         invalidHeaders[B3Propagator.spanIdHeader] = spanIdHexString + "00"
         invalidHeaders[B3Propagator.sampledHeader] = B3Propagator.trueInt
 
-        XCTAssertFalse(b3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(b3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testInject_SampledContext_SingleHeader() {
@@ -195,42 +195,42 @@ class B3PropagatorTests: XCTestCase {
     func testExtract_Empty_SingleHeader() {
         var invalidHeaders = [String: String]()
         invalidHeaders[B3Propagator.combinedHeader] = ""
-        XCTAssertFalse(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_InvalidTraceId_SingleHeader() {
         var invalidHeaders = [String: String]()
         invalidHeaders[B3Propagator.combinedHeader] = "abcdefghijklmnopabcdefghijklmnop-\(spanIdHexString)-\(B3Propagator.falseInt)"
-        XCTAssertFalse(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_InvalidTraceId_Size_SingleHeader() {
         var invalidHeaders = [String: String]()
         invalidHeaders[B3Propagator.combinedHeader] = "\(traceIdHexString)00-\(spanIdHexString)-\(B3Propagator.falseInt)"
-        XCTAssertFalse(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_InvalidSpanId_SingleHeader() {
         var invalidHeaders = [String: String]()
         invalidHeaders[B3Propagator.combinedHeader] = "\(traceIdHexString)-abcdefghijklmnop-\(B3Propagator.falseInt)"
-        XCTAssertFalse(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_InvalidSpanId_Size_SingleHeader() {
         var invalidHeaders = [String: String]()
         invalidHeaders[B3Propagator.combinedHeader] = "\(traceIdHexString)-\(spanIdHexString)00-\(B3Propagator.falseInt)"
-        XCTAssertFalse(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_TooFewParts_SingleHeader() {
         var invalidHeaders = [String: String]()
         invalidHeaders[B3Propagator.combinedHeader] = traceIdHexString
-        XCTAssertFalse(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 
     func testExtract_TooManyParts_SingleHeader() {
         var invalidHeaders = [String: String]()
         invalidHeaders[B3Propagator.combinedHeader] = "\(traceIdHexString)-\(spanIdHexString)-\(B3Propagator.falseInt)-extra-extra"
-        XCTAssertFalse(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter)!.isValid)
+        XCTAssertNil(singleHeaderB3Propagator.extract(carrier: invalidHeaders, getter: getter))
     }
 }

--- a/Tests/OpenTelemetryApiTests/Context/Propagation/W3CTraceContextPropagatorTest.swift
+++ b/Tests/OpenTelemetryApiTests/Context/Propagation/W3CTraceContextPropagatorTest.swift
@@ -59,7 +59,11 @@ class W3CTraceContextPropagatorTest: XCTestCase {
 
     func testInject_Nothing() {
         var carrier = [String: String]()
-        httpTraceContext.inject(spanContext: SpanContext.invalid, carrier: &carrier, setter: setter)
+        let invalidContext = SpanContext.create(traceId: TraceId(),
+                                                spanId: SpanId(),
+                                                traceFlags: TraceFlags(),
+                                                traceState: TraceState())
+        httpTraceContext.inject(spanContext: invalidContext, carrier: &carrier, setter: setter)
         XCTAssertEqual(carrier.count, 0)
     }
 

--- a/Tests/OpenTelemetryApiTests/Trace/DefaultTracerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/DefaultTracerTests.swift
@@ -72,21 +72,21 @@ final class DefaultTracerTests: XCTestCase {
 
     func testTestSpanContextPropagationExplicitParent() {
         let span = defaultTracer.spanBuilder(spanName: spanName).setParent(spanContext).startSpan()
-        XCTAssert(span.context === spanContext)
+        XCTAssert(span.context == spanContext)
     }
 
     func testTestSpanContextPropagation() {
         let parent = PropagatedSpan(context: spanContext)
 
         let span = defaultTracer.spanBuilder(spanName: spanName).setParent(parent).startSpan()
-        XCTAssert(span.context === spanContext)
+        XCTAssert(span.context == spanContext)
     }
 
     func testTestSpanContextPropagationCurrentSpan() {
         let parent = PropagatedSpan(context: spanContext)
         var scope = OpenTelemetryContext.setActiveSpan(parent)
         let span = defaultTracer.spanBuilder(spanName: spanName).startSpan()
-        XCTAssert(span.context === spanContext)
+        XCTAssert(span.context == spanContext)
         scope.close()
     }
 }

--- a/Tests/OpenTelemetryApiTests/Trace/SpanContextTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/SpanContextTests.swift
@@ -40,14 +40,7 @@ final class SpanContextTests: XCTestCase {
         remote = SpanContext.createFromRemoteParent(traceId: TraceId(fromBytes: secondTraceIdBytes), spanId: SpanId(fromBytes: secondSpanIdBytes), traceFlags: TraceFlags().settingIsSampled(true), traceState: emptyTraceState)
     }
 
-    func testInvalidSpanContext() {
-        XCTAssertEqual(SpanContext.invalid.traceId, TraceId.invalid)
-        XCTAssertEqual(SpanContext.invalid.spanId, SpanId.invalid)
-        XCTAssertEqual(SpanContext.invalid.traceFlags, TraceFlags())
-    }
-
     func testIsValid() {
-        XCTAssertFalse(SpanContext.invalid.isValid)
         XCTAssertFalse(SpanContext.create(traceId: TraceId(fromBytes: firstTraceIdBytes), spanId: SpanId.invalid, traceFlags: TraceFlags(), traceState: emptyTraceState).isValid)
         XCTAssertFalse(SpanContext.create(traceId: TraceId.invalid, spanId: SpanId.invalid, traceFlags: TraceFlags(), traceState: emptyTraceState).isValid)
         XCTAssertFalse(SpanContext.create(traceId: TraceId.invalid, spanId: SpanId(fromBytes: firstSpanIdBytes), traceFlags: TraceFlags(), traceState: emptyTraceState).isValid)


### PR DESCRIPTION
B3Propagator configuration is only for header injection, for extraction it should always try with single format first and use multiple headers if single fails.
Fixes #129