### PR TITLE
Print events in StdoutExporter debug log

### DIFF
--- a/Sources/Exporters/Stdout/StdoutExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutExporter.swift
@@ -39,6 +39,13 @@ public class StdoutExporter: SpanExporter {
                 print("Start: \(span.startTime.timeIntervalSince1970.toNanoseconds)")
                 print("Duration: \(span.endTime.timeIntervalSince(span.startTime).toNanoseconds) nanoseconds")
                 print("Attributes: \(span.attributes)")
+                if !span.events.isEmpty {
+                    print("Events:")
+                    for event in span.events {
+                        let ts = event.timestamp.timeIntervalSince(span.startTime).toNanoseconds
+                        print("  \(event.name) Time: +\(ts) Attributes: \(event.attributes)")
+                    }
+                }
                 print("------------------\n")
             } else {
                 do {


### PR DESCRIPTION
I'm using the StdoutExporter as a debug aide and found that it was missing the span events.