### PR TITLE
Introduce SwiftMetrics Shim

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "swift-metrics",
+        "repositoryURL": "https://github.com/apple/swift-metrics.git",
+        "state": {
+          "branch": null,
+          "revision": "e382458581b05839a571c578e90060fff499f101",
+          "version": "2.1.1"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,8 @@ let package = Package(
         .library(name: "libOpenTelemetrySdk", type: .static, targets: ["OpenTelemetrySdk"]),
         .library(name: "OpenTracingShim", type: .dynamic, targets: ["OpenTracingShim"]),
         .library(name: "libOpenTracingShim", type: .static, targets: ["OpenTracingShim"]),
+        .library(name: "SwiftMetricsShim", type: .dynamic, targets: ["SwiftMetricsShim"]),
+        .library(name: "libSwiftMetricsShim", type: .static, targets: ["SwiftMetricsShim"]),
         .library(name: "JaegerExporter", type: .dynamic, targets: ["JaegerExporter"]),
         .library(name: "libJaegerExporter", type: .static, targets: ["JaegerExporter"]),
         .library(name: "ZipkinExporter", type: .dynamic, targets: ["ZipkinExporter"]),
@@ -38,7 +40,8 @@ let package = Package(
         .package(name: "Thrift", url: "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1"),
         .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(name: "grpc-swift", url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),
-        .package(name: "swift-atomics", url: "https://github.com/apple/swift-atomics.git", from: "0.0.1")
+        .package(name: "swift-atomics", url: "https://github.com/apple/swift-atomics.git", from: "0.0.1"),
+        .package(name: "swift-metrics", url: "https://github.com/apple/swift-metrics.git", from: "2.1.1"),
     ],
     targets: [
         .target(name: "OpenTelemetryApi",
@@ -51,6 +54,11 @@ let package = Package(
         .target(name: "OpenTracingShim",
                 dependencies: ["OpenTelemetrySdk",
                                "Opentracing"]
+        ),
+        .target(name: "SwiftMetricsShim",
+                dependencies: ["OpenTelemetrySdk",
+                               .product(name: "NIO", package: "swift-nio"),
+                               .product(name: "CoreMetrics", package: "swift-metrics")]
         ),
         .target(name: "JaegerExporter",
                 dependencies: ["OpenTelemetrySdk",
@@ -93,6 +101,11 @@ let package = Package(
                     dependencies: ["OpenTracingShim",
                                    "OpenTelemetrySdk"],
                     path: "Tests/OpenTracingShim"
+        ),
+        .testTarget(name: "SwiftMetricsShimTests",
+                    dependencies: ["SwiftMetricsShim",
+                                   "OpenTelemetrySdk"],
+                    path: "Tests/SwiftMetricsShim"
         ),
         .testTarget(name: "OpenTelemetrySdkTests",
                     dependencies: ["OpenTelemetryApi",

--- a/Sources/SwiftMetricsShim/Extensions.swift
+++ b/Sources/SwiftMetricsShim/Extensions.swift
@@ -1,0 +1,23 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import CoreMetrics
+
+extension Array where Element == (String, String) {
+    var dictionary: [String: String] {
+        Dictionary(self, uniquingKeysWith: { lhs, rhs in lhs })
+    }
+}

--- a/Sources/SwiftMetricsShim/MetricHandlers.swift
+++ b/Sources/SwiftMetricsShim/MetricHandlers.swift
@@ -1,0 +1,123 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CoreMetrics
+import OpenTelemetryApi
+
+class SwiftCounterMetric: CounterHandler, SwiftMetric {
+    
+    var metricName: String
+    var metricType: MetricType = .counter
+    let counter: AnyCounterMetric<Int>
+    let labels: [String: String]
+    
+    required init(name: String, labels: [String: String], meter: Meter) {
+        metricName = name
+        counter = meter.createIntCounter(name: name, monotonic: true)
+        self.labels = labels
+    }
+    
+    func increment(by: Int64) {
+        counter.add(value: Int(by), labels: labels)
+    }
+    
+    func reset() {
+        
+    }
+    
+}
+
+class SwiftGaugeMetric: RecorderHandler, SwiftMetric {
+    
+    var metricName: String
+    var metricType: MetricType = .gauge
+    let counter: AnyCounterMetric<Double>
+    let labels: [String: String]
+    
+    required init(name: String, labels: [String: String], meter: Meter) {
+        metricName = name
+        counter = meter.createDoubleCounter(name: name, monotonic: false)
+        self.labels = labels
+    }
+    
+    func record(_ value: Int64) {
+        counter.add(value: Double(value), labels: labels)
+    }
+    
+    func record(_ value: Double) {
+        counter.add(value: value, labels: labels)
+    }
+    
+}
+
+class SwiftHistogramMetric: RecorderHandler, SwiftMetric {
+    
+    var metricName: String
+    var metricType: MetricType = .histogram
+    let measure: AnyMeasureMetric<Double>
+    let labels: [String: String]
+    
+    required init(name: String, labels: [String: String], meter: Meter) {
+        metricName = name
+        measure = meter.createDoubleMeasure(name: name)
+        self.labels = labels
+    }
+    
+    func record(_ value: Int64) {
+        measure.record(value: Double(value), labels: labels)
+    }
+    
+    func record(_ value: Double) {
+        measure.record(value: value, labels: labels)
+    }
+    
+}
+
+class SwiftSummaryMetric: TimerHandler, SwiftMetric {
+    
+    var metricName: String
+    var metricType: MetricType = .summary
+    let measure: AnyMeasureMetric<Double>
+    let labels: [String: String]
+    
+    required init(name: String, labels: [String: String], meter: Meter) {
+        metricName = name
+        measure = meter.createDoubleMeasure(name: name)
+        self.labels = labels
+    }
+    
+    func recordNanoseconds(_ duration: Int64) {
+        measure.record(value: Double(duration), labels: labels)
+    }
+    
+}
+
+protocol SwiftMetric {
+    var metricName: String { get }
+    var metricType: MetricType { get }
+    init(name: String, labels: [String: String], meter: Meter)
+}
+
+enum MetricType: String {
+    case counter
+    case histogram
+    case gauge
+    case summary
+}
+
+struct MetricKey: Hashable {
+    let name: String
+    let type: MetricType
+}

--- a/Sources/SwiftMetricsShim/SwiftMetricsShim.swift
+++ b/Sources/SwiftMetricsShim/SwiftMetricsShim.swift
@@ -1,0 +1,103 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CoreMetrics
+import NIOConcurrencyHelpers
+import OpenTelemetryApi
+
+public class OpenTelemetrySwiftMetrics: MetricsFactory {
+    
+    internal let meter: Meter
+    internal var metrics = [MetricKey: SwiftMetric]()
+    
+    public init(meter: Meter) {
+        self.meter = meter
+    }
+    
+    // MARK: - Make
+    
+    /// Counter: A counter is a cumulative metric that represents a single monotonically increasing counter whose value can only increase or be reset to zero on
+    /// restart. For example, you can use a counter to represent the number of requests served, tasks completed, or errors.
+    public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+        if let existing = metrics[.init(name: label, type: .counter)] {
+            return existing as! CounterHandler
+        }
+        
+        let metric = SwiftCounterMetric(name: label, labels: dimensions.dictionary, meter: meter)
+        
+        storeMetric(metric)
+        return metric
+    }
+    
+    /// Recorder: A recorder collects observations within a time window (usually things like response sizes) and can provide aggregated information about the
+    /// data sample, for example count, sum, min, max and various quantiles.
+    ///
+    /// Gauge: A Gauge is a metric that represents a single numerical value that can arbitrarily go up and down. Gauges are typically used for measured values
+    /// like temperatures or current memory usage, but also "counts" that can go up and down, like the number of active threads. Gauges are modeled as a
+    /// Recorder with a sample size of 1 that does not perform any aggregation.
+    public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
+        if let existing = metrics[.init(name: label, type: .histogram)] {
+            return existing as! RecorderHandler
+        }
+        
+        if let existing = metrics[.init(name: label, type: .gauge)] {
+            return existing as! RecorderHandler
+        }
+        
+        let metric: SwiftMetric & RecorderHandler = aggregate ?
+            SwiftHistogramMetric(name: label, labels: dimensions.dictionary, meter: meter) :
+            SwiftGaugeMetric(name: label, labels: dimensions.dictionary, meter: meter)
+        
+        storeMetric(metric)
+        return metric
+    }
+    
+    /// Timer: A timer collects observations within a time window (usually things like request duration) and provides aggregated information about the data sample,
+    /// for example min, max and various quantiles. It is similar to a Recorder but specialized for values that represent durations.
+    public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
+        if let existing = metrics[.init(name: label, type: .summary)] {
+            return existing as! TimerHandler
+        }
+        
+        let metric = SwiftSummaryMetric(name: label, labels: dimensions.dictionary, meter: meter)
+        
+        storeMetric(metric)
+        return metric
+    }
+    
+    private func storeMetric(_ metric: SwiftMetric) {
+        metrics[.init(name: metric.metricName, type: metric.metricType)] = metric
+    }
+    
+    // MARK: - Destroy
+    
+    public func destroyCounter(_ handler: CounterHandler) {
+        destroyMetric(handler as? SwiftMetric)
+    }
+    
+    public func destroyRecorder(_ handler: RecorderHandler) {
+        destroyMetric(handler as? SwiftMetric)
+    }
+    
+    public func destroyTimer(_ handler: TimerHandler) {
+        destroyMetric(handler as? SwiftMetric)
+    }
+    
+    private func destroyMetric(_ metric: SwiftMetric?) {
+        if let name = metric?.metricName, let type = metric?.metricType {
+            metrics.removeValue(forKey: .init(name: name, type: type))
+        }
+    }
+}

--- a/Tests/SwiftMetricsShim/SwiftMetricsShimTests.swift
+++ b/Tests/SwiftMetricsShim/SwiftMetricsShimTests.swift
@@ -1,0 +1,129 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+@testable import CoreMetrics
+@testable import SwiftMetricsShim
+import XCTest
+
+class SwiftMetricsShimTests: XCTestCase {
+    var testProcessor = TestMetricProcessor()
+    let provider = MeterSdkProvider()
+    var meter: MeterSdk!
+    var metrics: OpenTelemetrySwiftMetrics!
+
+    override func setUp() {
+        super.setUp()
+        testProcessor = TestMetricProcessor()
+        
+        meter = MeterSdkProvider(
+            metricProcessor: testProcessor,
+            metricExporter: NoopMetricExporter()
+        ).get(instrumentationName: "SwiftMetricsShimTest") as? MeterSdk
+        
+        metrics = .init(meter: meter)
+        MetricsSystem.bootstrapInternal(metrics)
+    }
+    
+    // MARK: - Test Lifecycle
+    
+    func testDestroy() {
+        let handler = metrics.makeCounter(label: "my_label", dimensions: [])
+        XCTAssertEqual(metrics.metrics.count, 1)
+        
+        metrics.destroyCounter(handler)
+        XCTAssertEqual(metrics.metrics.count, 0)
+    }
+    
+    // MARK: - Test Metric: Counter
+    
+    func testCounter() throws {
+        let counter = Counter(label: "my_counter")
+        counter.increment()
+        
+        meter.collect()
+        
+        let metric = testProcessor.metrics[0]
+        let data = try XCTUnwrap(metric.data.last as? SumData<Int>)
+        XCTAssertEqual(metric.name, "my_counter")
+        XCTAssertEqual(metric.aggregationType, .intSum)
+        XCTAssertEqual(data.sum, 1)
+        XCTAssertNil(data.labels["label_one"])
+    }
+    
+    func testCounter_withLabels() throws {
+        let counter = Counter(label: "my_counter", dimensions: [("label_one", "value")])
+        counter.increment(by: 5)
+        
+        meter.collect()
+        
+        let metric = testProcessor.metrics[0]
+        let data = try XCTUnwrap(metric.data.last as? SumData<Int>)
+        XCTAssertEqual(metric.name, "my_counter")
+        XCTAssertEqual(metric.aggregationType, .intSum)
+        XCTAssertEqual(data.sum, 5)
+        XCTAssertEqual(data.labels["label_one"], "value")
+    }
+    
+    // MARK: - Test Metric: Gauge
+    
+    func testGauge() throws {
+        let gauge = Gauge(label: "my_gauge")
+        gauge.record(100)
+        
+        meter.collect()
+        
+        let metric = testProcessor.metrics[0]
+        let data = try XCTUnwrap(metric.data.last as? SumData<Double>)
+        XCTAssertEqual(metric.name, "my_gauge")
+        XCTAssertEqual(metric.aggregationType, .doubleSum)
+        XCTAssertEqual(data.sum, 100)
+        XCTAssertNil(data.labels["label_one"])
+    }
+    
+    // MARK: - Test Metric: Histogram
+    
+    func testHistogram() throws {
+        let histogram = Gauge(label: "my_histogram", dimensions: [], aggregate: true)
+        histogram.record(100)
+        
+        meter.collect()
+        
+        let metric = testProcessor.metrics[0]
+        let data = try XCTUnwrap(metric.data.last as? SummaryData<Double>)
+        XCTAssertEqual(metric.name, "my_histogram")
+        XCTAssertEqual(metric.aggregationType, .doubleSummary)
+        XCTAssertEqual(data.sum, 100)
+        XCTAssertNil(data.labels["label_one"])
+    }
+    
+    // MARK: - Test Metric: Summary
+    
+    func testSummary() throws {
+        let timer = CoreMetrics.Timer(label: "my_timer")
+        timer.recordSeconds(1)
+        
+        meter.collect()
+        
+        let metric = testProcessor.metrics[0]
+        let data = try XCTUnwrap(metric.data.last as? SummaryData<Double>)
+        XCTAssertEqual(metric.name, "my_timer")
+        XCTAssertEqual(metric.aggregationType, .doubleSummary)
+        XCTAssertEqual(data.sum, 1000000000)
+        XCTAssertNil(data.labels["label_one"])
+    }
+
+}

--- a/Tests/SwiftMetricsShim/TestMetricProcessor.swift
+++ b/Tests/SwiftMetricsShim/TestMetricProcessor.swift
@@ -1,0 +1,30 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import OpenTelemetrySdk
+
+class TestMetricProcessor: MetricProcessor {
+    var metrics = [Metric]()
+    
+    func finishCollectionCycle() -> [Metric] {
+        let metrics = self.metrics
+        self.metrics = [Metric]()
+        return metrics
+    }
+
+    func process(metric: Metric) {
+        metrics.append(metric)
+    }
+}


### PR DESCRIPTION
Hey folks 👋 

Was going to raise an issue but thought this would work best as a contribution! (Hopefully the first of many 👀)

Apple have created their own [metrics API](https://github.com/apple/swift-metrics) which has been adopted by a number of other packages including, but not limited to, Vapor - a prominent Server Side Swift platform.

I thought an ideal feature would be to enable OpenTelemetry clients to bootstrap Swift Metrics with a shim package. This shim essentially redirects the data to the OpenTelemetry API functions.

```swift
let meter: Meter = // ... Your existing code to create a meter
let metrics = OpenTelemetrySwiftMetrics(meter: meter)
MetricsSystem.bootstrap(metrics)
```

If this is adopted, we may wish to add OpenTelemetry to the README of their package alongside SwiftPrometheus and StatsD. That would be a PR on their repo.

Tried to follow similar patterns to other products, but let me know if you need things changing!

Potentially this could be renamed/re-homed to an "Importers" directory to follow more closely with the "Exporters" systems. This would demonstrate a clear route forward for future bridges such as a `swift-log` product once we add support for logs.