### PR TITLE
added optional URLSessionInstrumentation config to customize span name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,127 +47,102 @@ let package = Package(
     ],
     targets: [
         .target(name: "OpenTelemetryApi",
-                dependencies: []
-        ),
+                dependencies: []),
         .target(name: "OpenTelemetrySdk",
                 dependencies: ["OpenTelemetryApi",
-                               .product(name: "Atomics", package: "swift-atomics")]
-        ),
+                               .product(name: "Atomics", package: "swift-atomics")]),
         .target(name: "URLSessionInstrumentation",
                 dependencies: ["OpenTelemetrySdk"],
-                path: "Sources/Instrumentation/URLSession"
-
-        ),
+                path: "Sources/Instrumentation/URLSession"),
         .target(name: "OpenTracingShim",
                 dependencies: ["OpenTelemetrySdk",
-                               "Opentracing"]
-        ),
+                               "Opentracing"]),
         .target(name: "SwiftMetricsShim",
                 dependencies: ["OpenTelemetrySdk",
                                .product(name: "NIO", package: "swift-nio"),
-                               .product(name: "CoreMetrics", package: "swift-metrics")]
-        ),
+                               .product(name: "CoreMetrics", package: "swift-metrics")]),
         .target(name: "JaegerExporter",
                 dependencies: ["OpenTelemetrySdk",
                                .product(name: "Thrift", package: "Thrift")],
-                path: "Sources/Exporters/Jaeger"
-        ),
+                path: "Sources/Exporters/Jaeger"),
         .target(name: "ZipkinExporter",
                 dependencies: ["OpenTelemetrySdk"],
-                path: "Sources/Exporters/Zipkin"
-        ),
+                path: "Sources/Exporters/Zipkin"),
         .target(name: "PrometheusExporter",
                 dependencies: ["OpenTelemetrySdk",
                                .product(name: "NIO", package: "swift-nio"),
                                .product(name: "NIOHTTP1", package: "swift-nio")],
-                path: "Sources/Exporters/Prometheus"
-        ),
+                path: "Sources/Exporters/Prometheus"),
         .target(name: "OpenTelemetryProtocolExporter",
                 dependencies: ["OpenTelemetrySdk",
                                .product(name: "GRPC", package: "grpc-swift")],
-                path: "Sources/Exporters/OpenTelemetryProtocol"
-        ),
+                path: "Sources/Exporters/OpenTelemetryProtocol"),
         .target(name: "StdoutExporter",
                 dependencies: ["OpenTelemetrySdk"],
-                path: "Sources/Exporters/Stdout"
-        ),
+                path: "Sources/Exporters/Stdout"),
         .target(name: "InMemoryExporter",
                 dependencies: ["OpenTelemetrySdk"],
-                path: "Sources/Exporters/InMemory"
-        ),
+                path: "Sources/Exporters/InMemory"),
         .target(name: "DatadogExporter",
                 dependencies: ["OpenTelemetrySdk"],
                 path: "Sources/Exporters/DatadogExporter",
-                exclude: ["NOTICE", "README.md"]
-        ),
+                exclude: ["NOTICE", "README.md"]),
         .testTarget(name: "OpenTelemetryApiTests",
                     dependencies: ["OpenTelemetryApi"],
-                    path: "Tests/OpenTelemetryApiTests"
-        ),
+                    path: "Tests/OpenTelemetryApiTests"),
         .testTarget(name: "OpenTracingShimTests",
                     dependencies: ["OpenTracingShim",
                                    "OpenTelemetrySdk"],
-                    path: "Tests/OpenTracingShim"
-        ),
+                    path: "Tests/OpenTracingShim"),
+        .testTarget(name: "URLSessionInstrumentationTests",
+                    dependencies: ["URLSessionInstrumentation"],
+                    path: "Tests/InstrumentationTests/URLSessionTests"),
         .testTarget(name: "SwiftMetricsShimTests",
                     dependencies: ["SwiftMetricsShim",
                                    "OpenTelemetrySdk"],
-                    path: "Tests/SwiftMetricsShim"
-        ),
+                    path: "Tests/SwiftMetricsShim"),
         .testTarget(name: "OpenTelemetrySdkTests",
                     dependencies: ["OpenTelemetryApi",
                                    "OpenTelemetrySdk"],
-                    path: "Tests/OpenTelemetrySdkTests"
-        ),
+                    path: "Tests/OpenTelemetrySdkTests"),
         .testTarget(name: "JaegerExporterTests",
                     dependencies: ["JaegerExporter"],
-                    path: "Tests/ExportersTests/Jaeger"
-        ),
+                    path: "Tests/ExportersTests/Jaeger"),
         .testTarget(name: "ZipkinExporterTests",
                     dependencies: ["ZipkinExporter"],
-                    path: "Tests/ExportersTests/Zipkin"
-        ),
+                    path: "Tests/ExportersTests/Zipkin"),
         .testTarget(name: "PrometheusExporterTests",
                     dependencies: ["PrometheusExporter"],
-                    path: "Tests/ExportersTests/Prometheus"
-        ),
+                    path: "Tests/ExportersTests/Prometheus"),
         .testTarget(name: "OpenTelemetryProtocolExporterTests",
                     dependencies: ["OpenTelemetryProtocolExporter"],
-                    path: "Tests/ExportersTests/OpenTelemetryProtocol"
-        ),
+                    path: "Tests/ExportersTests/OpenTelemetryProtocol"),
         .testTarget(name: "InMemoryExporterTests",
                     dependencies: ["InMemoryExporter"],
-                    path: "Tests/ExportersTests/InMemory"
-        ),
+                    path: "Tests/ExportersTests/InMemory"),
         .testTarget(name: "DatadogExporterTests",
                     dependencies: ["DatadogExporter",
                                    .product(name: "NIO", package: "swift-nio"),
                                    .product(name: "NIOHTTP1", package: "swift-nio")],
-                    path: "Tests/ExportersTests/DatadogExporter"
-        ),
+                    path: "Tests/ExportersTests/DatadogExporter"),
         .target(name: "LoggingTracer",
                 dependencies: ["OpenTelemetryApi"],
-                path: "Examples/Logging Tracer"
-        ),
+                path: "Examples/Logging Tracer"),
         .target(name: "SimpleExporter",
                 dependencies: ["OpenTelemetrySdk", "JaegerExporter", "StdoutExporter", "ZipkinExporter"],
                 path: "Examples/Simple Exporter",
-                exclude: ["README.md"]
-        ),
+                exclude: ["README.md"]),
         .target(name: "PrometheusSample",
                 dependencies: ["OpenTelemetrySdk", "PrometheusExporter"],
                 path: "Examples/Prometheus Sample",
-                exclude: ["README.md"]
-        ),
+                exclude: ["README.md"]),
         .target(name: "DatadogSample",
                 dependencies: ["DatadogExporter"],
                 path: "Examples/Datadog Sample",
-                exclude: ["README.md"]
-        ),
+                exclude: ["README.md"]),
         .target(name: "NetworkSample",
                 dependencies: ["URLSessionInstrumentation", "StdoutExporter"],
                 path: "Examples/Network Sample",
-                exclude: ["README.md"]
-        ),
+                exclude: ["README.md"]),
     ]
 )

--- a/Sources/Instrumentation/URLSession/URLSessionConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionConfiguration.swift
@@ -24,14 +24,16 @@ public typealias HTTPStatus = Int
 public struct URLSessionConfiguration {
     public init(shouldRecordPayload: ((URLSession) -> (Bool)?)? = nil,
                 shouldInstrument: ((URLRequest) -> (Bool)?)? = nil,
+                nameSpan: ((URLRequest) -> (String)?)? = nil,
                 shouldInjectTracingHeaders: ((inout URLRequest) -> (Bool)?)? = nil,
-                createdRequest: ((URLRequest, SpanBuilder) -> ())? = nil,
-                receivedResponse: ((URLResponse, DataOrFile?, Span) -> ())? = nil,
-                receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> ())? = nil)
+                createdRequest: ((URLRequest, SpanBuilder) -> Void)? = nil,
+                receivedResponse: ((URLResponse, DataOrFile?, Span) -> Void)? = nil,
+                receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)? = nil)
     {
         self.shouldRecordPayload = shouldRecordPayload
         self.shouldInstrument = shouldInstrument
         self.shouldInjectTracingHeaders = shouldInjectTracingHeaders
+        self.nameSpan = nameSpan
         self.createdRequest = createdRequest
         self.receivedResponse = receivedResponse
         self.receivedError = receivedError
@@ -39,24 +41,27 @@ public struct URLSessionConfiguration {
 
     // Instrumentation Callbacks
 
-    /// Implement this callback to filter wich requests you want to instrument, all by default
+    /// Implement this callback to filter which requests you want to instrument, all by default
     public var shouldInstrument: ((URLRequest) -> (Bool)?)?
 
     /// Implement this callback if you want the session to record payload data, false by default
     public var shouldRecordPayload: ((URLSession) -> (Bool)?)?
 
-    /// Implement this callback to filter wich requests you want to inject headers to follow the trace,
+    /// Implement this callback to filter which requests you want to inject headers to follow the trace,
     /// you can also modify the request or add other headers in this method.
     /// Instruments all requests by default
     public var shouldInjectTracingHeaders: ((inout URLRequest) -> (Bool)?)?
 
+    /// Implement this callback to override the default span name for a given request, return nil to use default.
+    /// default name: `HTTP {method}` e.g. `HTTP PUT`
+    public var nameSpan: ((URLRequest) -> (String)?)?
+
     ///  Called before the span is created, it allows to add extra information to the Span through the builder
-    public var createdRequest: ((URLRequest, SpanBuilder) -> ())?
-
-
-    ///  Called before the span is ended, it allows to add extra information to the Span
-    public var receivedResponse: ((URLResponse, DataOrFile?, Span) -> ())?
+    public var createdRequest: ((URLRequest, SpanBuilder) -> Void)?
 
     ///  Called before the span is ended, it allows to add extra information to the Span
-    public var receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> ())?
+    public var receivedResponse: ((URLResponse, DataOrFile?, Span) -> Void)?
+
+    ///  Called before the span is ended, it allows to add extra information to the Span
+    public var receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)?
 }

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -1,4 +1,4 @@
-// Copyright 2020, OpenTelemetry Authors
+// Copyright 2021, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,7 +51,10 @@ class URLSessionLogger {
             attributes[SemanticAttributes.netPeerPort.rawValue] = String(port)
         }
 
-        let spanName = "HTTP " + (request.httpMethod ?? "")
+        var spanName = "HTTP " + (request.httpMethod ?? "")
+        if let customSpanName = instrumentation.configuration.nameSpan?(request) {
+            spanName = customSpanName
+        }
         let spanBuilder = instrumentation.tracer.spanBuilder(spanName: spanName)
         spanBuilder.setSpanKind(spanKind: .client)
         attributes.forEach {
@@ -111,10 +114,10 @@ class URLSessionLogger {
 
     private static func statusForStatusCode(code: Int) -> Status {
         switch code {
-            case 100 ... 399:
-                return .unset
-            default:
-                return .error(description: String(code))
+        case 100 ... 399:
+            return .unset
+        default:
+            return .error(description: String(code))
         }
     }
 

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionConfigurationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionConfigurationTests.swift
@@ -50,8 +50,10 @@ final class URLSessionConfigurationTests: XCTestCase {
         XCTAssertEqual(true, checker.nameSpanCalled)
 
         XCTAssertEqual(1, URLSessionLogger.runningSpans.count)
-        let span = URLSessionLogger.runningSpans["id"]!
-        XCTAssertEqual("new name", span.name)
+        XCTAssertNotNil(URLSessionLogger.runningSpans["id"])
+        if let span = URLSessionLogger.runningSpans["id"] {
+            XCTAssertEqual("new name", span.name)
+        }
     }
 
     public func testDefaultSpanName() {
@@ -68,8 +70,10 @@ final class URLSessionConfigurationTests: XCTestCase {
         URLSessionLogger.processAndLogRequest(request, sessionTaskId: "id", instrumentation: instrumentation, shouldInjectHeaders: true)
 
         XCTAssertEqual(1, URLSessionLogger.runningSpans.count)
-        let span = URLSessionLogger.runningSpans["id"]!
-        XCTAssertEqual("HTTP GET", span.name)
+        XCTAssertNotNil(URLSessionLogger.runningSpans["id"])
+        if let span = URLSessionLogger.runningSpans["id"] {
+            XCTAssertEqual("HTTP GET", span.name)
+        }
     }
 
     public func testDefaultSpanWithNameClosure() {
@@ -100,7 +104,9 @@ final class URLSessionConfigurationTests: XCTestCase {
         XCTAssertEqual(true, checker.nameSpanCalled)
 
         XCTAssertEqual(1, URLSessionLogger.runningSpans.count)
-        let span = URLSessionLogger.runningSpans["id"]!
-        XCTAssertEqual("HTTP GET", span.name)
+        XCTAssertNotNil(URLSessionLogger.runningSpans["id"])
+        if let span = URLSessionLogger.runningSpans["id"] {
+            XCTAssertEqual("HTTP GET", span.name)
+        }
     }
 }

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionConfigurationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionConfigurationTests.swift
@@ -1,0 +1,106 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+@testable import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+@testable import URLSessionInstrumentation
+import XCTest
+
+final class URLSessionConfigurationTests: XCTestCase {
+    override public func setUp() {}
+
+    public func testOverrideSpanName() {
+        let request = URLRequest(url: URL(string: "http://google.com")!)
+        class Check {
+            public var shouldRecordPayloadCalled: Bool = false
+            public var shouldInstrumentCalled: Bool = false
+            public var nameSpanCalled: Bool = false
+            public var shouldInjectTracingHeadersCalled: Bool = false
+            public var createdRequestCalled: Bool = false
+        }
+
+        let checker = Check()
+
+        let instrumentation = URLSessionInstrumentation(configuration: URLSessionConfiguration(shouldRecordPayload:nil,
+            shouldInstrument: nil,
+            nameSpan: { [weak checker] _ in
+                checker?.nameSpanCalled = true
+                return "new name"
+            },
+            shouldInjectTracingHeaders: nil,
+            createdRequest: nil,
+            receivedResponse: nil,
+            receivedError: nil))
+
+        URLSessionLogger.processAndLogRequest(request, sessionTaskId: "id", instrumentation: instrumentation, shouldInjectHeaders: true)
+
+        XCTAssertEqual(true, checker.nameSpanCalled)
+
+        XCTAssertEqual(1, URLSessionLogger.runningSpans.count)
+        let span = URLSessionLogger.runningSpans["id"]!
+        XCTAssertEqual("new name", span.name)
+    }
+
+    public func testDefaultSpanName() {
+        let request = URLRequest(url: URL(string: "http://google.com")!)
+
+        let instrumentation = URLSessionInstrumentation(configuration: URLSessionConfiguration(shouldRecordPayload:nil,
+            shouldInstrument: nil,
+            nameSpan: nil,
+            shouldInjectTracingHeaders: nil,
+            createdRequest: nil,
+            receivedResponse: nil,
+            receivedError: nil))
+
+        URLSessionLogger.processAndLogRequest(request, sessionTaskId: "id", instrumentation: instrumentation, shouldInjectHeaders: true)
+
+        XCTAssertEqual(1, URLSessionLogger.runningSpans.count)
+        let span = URLSessionLogger.runningSpans["id"]!
+        XCTAssertEqual("HTTP GET", span.name)
+    }
+
+    public func testDefaultSpanWithNameClosure() {
+        let request = URLRequest(url: URL(string: "http://google.com")!)
+        class Check {
+            public var shouldRecordPayloadCalled: Bool = false
+            public var shouldInstrumentCalled: Bool = false
+            public var nameSpanCalled: Bool = false
+            public var shouldInjectTracingHeadersCalled: Bool = false
+            public var createdRequestCalled: Bool = false
+        }
+
+        let checker = Check()
+
+        let instrumentation = URLSessionInstrumentation(configuration: URLSessionConfiguration(shouldRecordPayload:nil,
+            shouldInstrument: nil,
+            nameSpan: { [weak checker] _ in
+                checker?.nameSpanCalled = true
+                return nil
+            },
+            shouldInjectTracingHeaders: nil,
+            createdRequest: nil,
+            receivedResponse: nil,
+            receivedError: nil))
+
+        URLSessionLogger.processAndLogRequest(request, sessionTaskId: "id", instrumentation: instrumentation, shouldInjectHeaders: true)
+
+        XCTAssertEqual(true, checker.nameSpanCalled)
+
+        XCTAssertEqual(1, URLSessionLogger.runningSpans.count)
+        let span = URLSessionLogger.runningSpans["id"]!
+        XCTAssertEqual("HTTP GET", span.name)
+    }
+}


### PR DESCRIPTION
I've added an optional config to allow customization of the span name in the URLSession instrumentation which is allowed per the spec : 
```Therefore, HTTP client spans SHOULD be using conservative, low cardinality names formed from the available parameters of an HTTP request, such as "HTTP {METHOD_NAME}". Instrumentation MUST NOT default to using URI path as span name, but MAY provide hooks to allow custom logic to override the default span name.``` 

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md

also added some tests to verify the new addition operates as expected
some of the other changes are results of running swiftformat