### PR TITLE
move URLSession Config `requestCreated` call to before the span is cr…

### DIFF
--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -61,6 +61,8 @@ class URLSessionLogger {
             spanBuilder.setAttribute(key: $0.key, value: $0.value)
         }
 
+        instrumentation.configuration.createdRequest?(request, spanBuilder)
+        
         let span = spanBuilder.startSpan()
         runningSpansQueue.sync {
             runningSpans[sessionTaskId] = span
@@ -70,8 +72,6 @@ class URLSessionLogger {
         if shouldInjectHeaders {
             returnRequest = instrumentedRequest(for: request, span: span, instrumentation: instrumentation)
         }
-
-        instrumentation.configuration.createdRequest?(returnRequest ?? request, spanBuilder)
 
         return returnRequest ?? request
     }


### PR DESCRIPTION
…eated

The config describes this callback as a means to customize the span builder before
the span is started, but it was getting called after `spanBuilder.startSpan()` was called.


Though, now, the request hasn't been "created" since `createdRequest` is called before `instrumentedRequest`.  Maybe this configuration should be called "customizeSpanBuilder"?