### PR TITLE
Allow configuration on the TraceProviderSDK

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/Propagation/W3CTraceContextPropagator.swift
+++ b/Sources/OpenTelemetryApi/Trace/Propagation/W3CTraceContextPropagator.swift
@@ -33,7 +33,7 @@ public struct W3CTraceContextPropagator: TextMapPropagator {
     private static let traceparentLengthV0 = versionAndTraceIdAndSpanIdLength + optionsLength
 
     static let traceparent = "traceparent"
-    static let traceState = "traceState"
+    static let traceState = "tracestate"
 
     public init() {}
 

--- a/Sources/OpenTelemetrySdk/Trace/MultiSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/MultiSpanProcessor.swift
@@ -18,12 +18,12 @@ import OpenTelemetryApi
 
 /// Implementation of the SpanProcessor that simply forwards all received events to a list of
 /// SpanProcessors.
-public struct MultiSpanProcessor: SpanProcessor {
+ struct MultiSpanProcessor: SpanProcessor {
     var spanProcessorsStart = [SpanProcessor]()
     var spanProcessorsEnd = [SpanProcessor]()
     var spanProcessorsAll = [SpanProcessor]()
 
-    public init(spanProcessors: [SpanProcessor]) {
+     init(spanProcessors: [SpanProcessor]) {
         spanProcessorsAll = spanProcessors
         spanProcessorsAll.forEach {
             if $0.isStartRequired {
@@ -35,33 +35,33 @@ public struct MultiSpanProcessor: SpanProcessor {
         }
     }
 
-    public var isStartRequired: Bool {
+     var isStartRequired: Bool {
         return spanProcessorsStart.count > 0
     }
 
-    public var isEndRequired: Bool {
+     var isEndRequired: Bool {
         return spanProcessorsEnd.count > 0
     }
 
-    public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
+     func onStart(parentContext: SpanContext?, span: ReadableSpan) {
         spanProcessorsStart.forEach {
             $0.onStart(parentContext: parentContext, span: span)
         }
     }
 
-    public func onEnd(span: ReadableSpan) {
+     func onEnd(span: ReadableSpan) {
         for var processor in spanProcessorsEnd {
             processor.onEnd(span: span)
         }
     }
 
-    public func shutdown() {
+     func shutdown() {
         for var processor in spanProcessorsAll {
             processor.shutdown()
         }
     }
 
-    public func forceFlush() {
+     func forceFlush() {
         spanProcessorsAll.forEach {
             $0.forceFlush()
         }

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -1,0 +1,45 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+/**
+ * Implementation of a EnvironmentContextPropagation propagation, using W3CTraceContextPropagator
+ */
+
+public struct EnvironmentContextPropagator: TextMapPropagator {
+    static let traceParent = "OTEL_TRACE_PARENT"
+    static let traceState = "OTEL_TRACE_STATE"
+    let w3cPropagator = W3CTraceContextPropagator()
+
+    public let fields: Set<String> = [traceState, traceParent]
+
+    public init() {}
+
+    public func inject<S>(spanContext: SpanContext, carrier: inout [String: String], setter: S) where S: Setter {
+        var auxCarrier = [String: String]()
+        w3cPropagator.inject(spanContext: spanContext, carrier: &auxCarrier, setter: setter)
+        carrier[EnvironmentContextPropagator.traceParent] = auxCarrier["traceparent"]
+        carrier[EnvironmentContextPropagator.traceState] = auxCarrier["tracestate"]
+    }
+
+    public func extract<G>(carrier: [String: String], getter: G) -> SpanContext? where G: Getter {
+        var auxCarrier = [String: String]()
+        auxCarrier["traceparent"] = carrier[EnvironmentContextPropagator.traceParent]
+        auxCarrier["tracestate"] = carrier[EnvironmentContextPropagator.traceState]
+        return w3cPropagator.extract(carrier: auxCarrier, getter: getter)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
@@ -166,16 +166,20 @@ class SpanBuilderSdk: SpanBuilder {
 
     private func getParentContext(parentType: ParentType, explicitParent: Span?, remoteParent: SpanContext?) -> SpanContext? {
         let currentSpan = OpenTelemetry.instance.contextProvider.activeSpan
+
+        var parentContext: SpanContext?
         switch parentType {
         case .noParent:
-            return nil
+            parentContext = nil
         case .currentSpan:
-            return currentSpan?.context
+            parentContext = currentSpan?.context
         case .explicitParent:
-            return explicitParent?.context
+            parentContext = explicitParent?.context
         case .explicitRemoteParent:
-            return remoteParent
+            parentContext = remoteParent
         }
+
+        return parentContext ?? tracerSharedState.launchEnvironmentContext
     }
 
     private static func getParentSpan(parentType: ParentType, explicitParent: Span?) -> Span? {

--- a/Sources/OpenTelemetrySdk/Trace/TracerProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TracerProviderSdk.swift
@@ -16,7 +16,6 @@
 import Foundation
 import OpenTelemetryApi
 
-/// This class is not intended to be used in application code and it is used only by OpenTelemetry.
 public class TracerProviderSdk: TracerProvider {
     private var tracerProvider = [InstrumentationLibraryInfo: TracerSdk]()
     internal var sharedState: TracerSharedState
@@ -66,14 +65,59 @@ public class TracerProviderSdk: TracerProvider {
         }
     }
 
+    /// Returns the active Clock.
+    public func getActiveClock() -> Clock {
+        return sharedState.clock
+    }
+
+    /// Updates the active Clock.
+    public func updateActiveClock(_ newClock: Clock) {
+        sharedState.clock = newClock
+    }
+
+    /// Returns the active IdGenerator.
+    public func getActiveIdGenerator() -> IdGenerator {
+        return sharedState.idGenerator
+    }
+
+    /// Updates the active IdGenerator.
+    public func updateActiveIdGenerator(_ newGenerator: IdGenerator) {
+        sharedState.idGenerator = newGenerator
+    }
+
+    /// Returns the active Resource.
+    public func getActiveResource() -> Resource {
+        return sharedState.resource
+    }
+
+    /// Updates the active Resource.
+    public func updateActiveResource(_ newResource: Resource) {
+        sharedState.resource = newResource
+    }
+
     /// Returns the active SpanLimits.
     public func getActiveSpanLimits() -> SpanLimits {
-        sharedState.activeSpanLimits
+        return sharedState.activeSpanLimits
     }
 
     /// Updates the active SpanLimits.
     public func updateActiveSpanLimits(_ spanLimits: SpanLimits) {
         sharedState.setActiveSpanLimits(spanLimits)
+    }
+
+    /// Returns the active Sampler.
+    public func getActiveSampler() -> Sampler {
+        return sharedState.sampler
+    }
+
+    /// Updates the active Sampler.
+    public func updateActiveSampler(_ newSampler: Sampler) {
+        sharedState.setSampler(newSampler)
+    }
+
+    /// Returns the active SpanProcessor.
+    public func getActiveSpanProcessor() -> SpanProcessor {
+        sharedState.activeSpanProcessor
     }
 
     /// Adds a new SpanProcessor to this Tracer.

--- a/Sources/OpenTelemetrySdk/Trace/TracerProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TracerProviderSdk.swift
@@ -115,17 +115,26 @@ public class TracerProviderSdk: TracerProvider {
         sharedState.setSampler(newSampler)
     }
 
-    /// Returns the active SpanProcessor.
-    public func getActiveSpanProcessor() -> SpanProcessor {
-        sharedState.activeSpanProcessor
+    /// Returns the active SpanProcessors.
+    public func getActiveSpanProcessors() -> [SpanProcessor] {
+        if let processor = sharedState.activeSpanProcessor as? MultiSpanProcessor {
+            return processor.spanProcessorsAll
+        } else {
+            return [sharedState.activeSpanProcessor]
+        }
     }
 
-    /// Adds a new SpanProcessor to this Tracer.
+    /// Adds a new SpanProcessor to this TracerProvider.
     /// Any registered processor cause overhead, consider to use an async/batch processor especially
     /// for span exporting, and export to multiple backends using the MultiSpanExporter
     /// - Parameter spanProcessor: the new SpanProcessor to be added.
     public func addSpanProcessor(_ spanProcessor: SpanProcessor) {
         sharedState.addSpanProcessor(spanProcessor)
+    }
+
+    /// Removes all SpanProcessors from this provider
+    public func resetSpanProcessors() {
+        sharedState.activeSpanProcessor = NoopSpanProcessor()
     }
 
     /// Attempts to stop all the activity for this Tracer. Calls SpanProcessor.shutdown()

--- a/Tests/OpenTelemetryApiTests/Trace/Propagation/W3CTraceContextPropagatorTest.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/Propagation/W3CTraceContextPropagatorTest.swift
@@ -187,7 +187,7 @@ class W3CTraceContextPropagatorTest: XCTestCase {
 
     func testHeaderNames() {
         XCTAssertEqual(W3CTraceContextPropagator.traceparent, "traceparent")
-        XCTAssertEqual(W3CTraceContextPropagator.traceState, "traceState")
+        XCTAssertEqual(W3CTraceContextPropagator.traceState, "tracestate")
     }
 
     func testExtract_EmptyCarrier() {

--- a/Tests/OpenTelemetrySdkTests/Trace/MultiSpanProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/MultiSpanProcessorTests.swift
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 
-import OpenTelemetrySdk
 import OpenTelemetryApi
+@testable import OpenTelemetrySdk
 import XCTest
 
 class MultiSpanProcessorTest: XCTestCase {


### PR DESCRIPTION
Allow configuration on the TraceProviderSDK, after hiding the SharedState from public access, configuration of some fields was not possible anymore. 