### PR TITLE
The Resource created here should be overwritten with new data

### DIFF
--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
@@ -21,15 +21,7 @@ public class TelemetryDataSource: ITelemetryDataSource {
     }
 
     public var name: String {
-        #if os(tvOS)
-            return "tvOS"
-        #elseif os(watchOS)
-            return "watchOS"
-        #elseif os(macOS)
-            return "macOS"
-        #else
-            return "iOS"
-        #endif
+        "opentelemetry"
     }
 
     public var version: String? {

--- a/Sources/Instrumentation/SDKResourceExtension/DefaultResources.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DefaultResources.swift
@@ -31,7 +31,7 @@ public class DefaultResources {
         let mirror = Mirror(reflecting: self)
         for children in mirror.children {
             if let provider = children.value as? ResourceProvider {
-                resource.merge(other: provider.create())
+                resource = provider.create().merging(other: resource)
             }
         }
         return resource

--- a/Tests/InstrumentationTests/sdk-resource-extension-tests/ResourcePropogationTests.swift
+++ b/Tests/InstrumentationTests/sdk-resource-extension-tests/ResourcePropogationTests.swift
@@ -1,0 +1,42 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+import Foundation
+
+import OpenTelemetryApi
+import OpenTelemetrySdk
+@testable import ResourceExtension
+import XCTest
+
+class ResourcePropogationTests : XCTestCase {
+    func testPropogation() {
+        let defaultResource = Resource()
+        let appProvider = ApplicationResourceProvider(source: ApplicationDataSource())
+        let telemetryProvider = TelemetryResourceProvider(source: TelemetryDataSource())
+        let resultResource = DefaultResources().get()
+        
+        let defaultValue = defaultResource.attributes[ResourceAttributes.serviceName.rawValue]?.description
+        let resultValue = resultResource.attributes[ResourceAttributes.serviceName.rawValue]?.description
+        let applicationName = appProvider.attributes[ResourceAttributes.serviceName.rawValue]?.description
+        
+        
+        XCTAssertNotNil(defaultValue)
+        XCTAssertNotNil(resultValue)
+        XCTAssertNotNil(applicationName)
+        XCTAssertEqual(resultValue, applicationName)
+        XCTAssertNotEqual(resultValue, defaultValue)
+        
+        
+    }
+}


### PR DESCRIPTION
the current implementation behaves by preserving the default values.

e.g.: `unknown_service:{process.executable.name}` is preserved in `service.name` as opposed to the new value presented in the application resource provider.