### PR TITLE
Add basic README files to those libraries that dont include one

### DIFF
--- a/Examples/Network Sample/README.md
+++ b/Examples/Network Sample/README.md
@@ -1,0 +1,4 @@
+### Network sample
+
+This example shows the URLSessionInstrumentation in action. 
+It only shows the minimum configuration: Just by initializing the class, all network request that happen after it will be captured by Opentelemetry as Spans. Check URLSessionInstrumentation README for more information.

--- a/Examples/Network Sample/README.md
+++ b/Examples/Network Sample/README.md
@@ -1,4 +1,4 @@
 ### Network sample
 
-This example shows the URLSessionInstrumentation in action. 
-It only shows the minimum configuration: Just by initializing the class, all network request that happen after it will be captured by Opentelemetry as Spans. Check URLSessionInstrumentation README for more information.
+This example shows the `URLSessionInstrumentation` in action. 
+It only shows the minimum configuration: Just by initializing the class, all network request that happen after it will be captured by Opentelemetry as Spans. Check [`URLSessionInstrumentation` README](Sources/Instrumentation/URLSession/README.md) for more information.

--- a/Sources/Importers/OpenTracingShim/README.md
+++ b/Sources/Importers/OpenTracingShim/README.md
@@ -1,0 +1,4 @@
+### OpenTracingShim
+
+An OpenTracing implementation that delegates to the OpenTelemetry SDK. Use OpenTracingShim to create tracers using this implementation.
+

--- a/Sources/Importers/SwiftMetricsShim/README.md
+++ b/Sources/Importers/SwiftMetricsShim/README.md
@@ -1,0 +1,17 @@
+### SwiftMetricsShim
+
+Apple have created their own metrics API which has been adopted by a number of other packages including, but not limited to, Vapor - a prominent Server Side Swift platform.
+
+This shim essentially redirects the data to the OpenTelemetry API functions.
+
+ ```
+let meter: Meter = // ... Your existing code to create a meter
+let metrics = OpenTelemetrySwiftMetrics(meter: meter)
+MetricsSystem.bootstrap(metrics)
+```
+
+If this is adopted, we may wish to add OpenTelemetry to the README of their package alongside SwiftPrometheus and StatsD. That would be a PR on their repo.
+
+Tried to follow similar patterns to other products, but let me know if you need things changing!
+
+Potentially this could be renamed/re-homed to an "Importers" directory to follow more closely with the "Exporters" systems. This would demonstrate a clear route forward for future bridges such as a swift-log product once we add support for logs.

--- a/Sources/Importers/SwiftMetricsShim/README.md
+++ b/Sources/Importers/SwiftMetricsShim/README.md
@@ -9,9 +9,3 @@ let meter: Meter = // ... Your existing code to create a meter
 let metrics = OpenTelemetrySwiftMetrics(meter: meter)
 MetricsSystem.bootstrap(metrics)
 ```
-
-If this is adopted, we may wish to add OpenTelemetry to the README of their package alongside SwiftPrometheus and StatsD. That would be a PR on their repo.
-
-Tried to follow similar patterns to other products, but let me know if you need things changing!
-
-Potentially this could be renamed/re-homed to an "Importers" directory to follow more closely with the "Exporters" systems. This would demonstrate a clear route forward for future bridges such as a swift-log product once we add support for logs.

--- a/Sources/Instrumentation/SDKResourceExtension/README.md
+++ b/Sources/Instrumentation/SDKResourceExtension/README.md
@@ -1,6 +1,6 @@
-# iOS Resource extension
+# SDK Resource extension
 
-This package captures a number of key data points of an iOS application and generates a Resource object that can be passed to a `TracerProvider`
+This package captures a number of key data points of an application and generates a Resource object that can be passed to a `TracerProvider`
 
 
 ## Usage 

--- a/Sources/Instrumentation/URLSession/README.md
+++ b/Sources/Instrumentation/URLSession/README.md
@@ -1,0 +1,26 @@
+# URL Session instrumentation
+
+This package captures the network calls produced by URLSession. Just by initializing the cl
+
+
+## Usage 
+
+Initialize the class with  `URLSessionInstrumentation(configuration: URLSessionInstrumentationConfiguration())` to automatically capture all network calls.
+
+This behaviour can be modified or augmented by using the optional callbacks defined in `URLSessionInstrumentationConfiguration` :
+
+`shouldInstrument: ((URLRequest) -> (Bool)?)?` :  Filter which requests you want to instrument, all by default
+
+`shouldRecordPayload: ((URLSession) -> (Bool)?)?`: Implement if you want the session to record payload data, false by default.
+
+`shouldInjectTracingHeaders: ((inout URLRequest) -> (Bool)?)?`: Allows filtering which requests you want to inject headers to follow the trace, true by default. You can also modify the request or add other headers in this method.
+
+`nameSpan: ((URLRequest) -> (String)?)?` - Modifies the name for the given request instead of stantard Opentelemetry name
+
+`createdRequest: ((URLRequest, Span) -> Void)?` - Called after request is created,  it allows to add extra information to the Span
+
+`receivedResponse: ((URLResponse, DataOrFile?, Span) -> Void)?`- Called after response is received,  it allows to add extra information to the Span
+
+`receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)?` -  Called after an errror is received,  it allows to add extra information to the Span
+
+

--- a/Sources/Instrumentation/URLSession/README.md
+++ b/Sources/Instrumentation/URLSession/README.md
@@ -1,6 +1,6 @@
 # URL Session instrumentation
 
-This package captures the network calls produced by URLSession. Just by initializing the cl
+This package captures the network calls produced by URLSession.
 
 
 ## Usage 

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -57,7 +57,7 @@ public struct URLSessionInstrumentationConfiguration {
     /// default name: `HTTP {method}` e.g. `HTTP PUT`
     public var nameSpan: ((URLRequest) -> (String)?)?
 
-    ///  Called before the span is created, it allows to add extra information to the Span through the builder
+    ///  Called before the span is created, it allows to add extra information to the Span
     public var createdRequest: ((URLRequest, Span) -> Void)?
 
     ///  Called before the span is ended, it allows to add extra information to the Span

--- a/Sources/OpenTelemetrySdk/Trace/MultiSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/MultiSpanProcessor.swift
@@ -18,12 +18,12 @@ import OpenTelemetryApi
 
 /// Implementation of the SpanProcessor that simply forwards all received events to a list of
 /// SpanProcessors.
- struct MultiSpanProcessor: SpanProcessor {
+public struct MultiSpanProcessor: SpanProcessor {
     var spanProcessorsStart = [SpanProcessor]()
     var spanProcessorsEnd = [SpanProcessor]()
     var spanProcessorsAll = [SpanProcessor]()
 
-     init(spanProcessors: [SpanProcessor]) {
+    public init(spanProcessors: [SpanProcessor]) {
         spanProcessorsAll = spanProcessors
         spanProcessorsAll.forEach {
             if $0.isStartRequired {
@@ -35,33 +35,33 @@ import OpenTelemetryApi
         }
     }
 
-     var isStartRequired: Bool {
+    public var isStartRequired: Bool {
         return spanProcessorsStart.count > 0
     }
 
-     var isEndRequired: Bool {
+    public var isEndRequired: Bool {
         return spanProcessorsEnd.count > 0
     }
 
-     func onStart(parentContext: SpanContext?, span: ReadableSpan) {
+    public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
         spanProcessorsStart.forEach {
             $0.onStart(parentContext: parentContext, span: span)
         }
     }
 
-     func onEnd(span: ReadableSpan) {
+    public func onEnd(span: ReadableSpan) {
         for var processor in spanProcessorsEnd {
             processor.onEnd(span: span)
         }
     }
 
-     func shutdown() {
+    public func shutdown() {
         for var processor in spanProcessorsAll {
             processor.shutdown()
         }
     }
 
-     func forceFlush() {
+    public func forceFlush() {
         spanProcessorsAll.forEach {
             $0.forceFlush()
         }


### PR DESCRIPTION
Also make MultiSpanProcessor public again, I found myself duplicating this code when creating Spans directly and was using several span processors, so make it useful for anyone