### PR TITLE
Typo fix: ipv5 used for ipv6 in the ZipkinExporter

### DIFF
--- a/Sources/Exporters/Zipkin/Implementation/ZipkinEndpoint.swift
+++ b/Sources/Exporters/Zipkin/Implementation/ZipkinEndpoint.swift
@@ -21,15 +21,15 @@ class ZipkinEndpoint: Encodable {
     var ipv6: String?
     var port: Int?
 
-    public init(serviceName: String, ipv4: String? = nil, ipv5: String? = nil, port: Int? = nil) {
+    public init(serviceName: String, ipv4: String? = nil, ipv6: String? = nil, port: Int? = nil) {
         self.serviceName = serviceName
         self.ipv4 = ipv4
-        self.ipv6 = ipv5
+        self.ipv6 = ipv6
         self.port = port
     }
 
     public func clone(serviceName: String) -> ZipkinEndpoint {
-        return ZipkinEndpoint(serviceName: serviceName, ipv4: ipv4, ipv5: ipv6, port: port)
+        return ZipkinEndpoint(serviceName: serviceName, ipv4: ipv4, ipv6: ipv6, port: port)
     }
 
     public func write() -> [String: Any] {

--- a/Sources/Exporters/Zipkin/ZipkinTraceExporter.swift
+++ b/Sources/Exporters/Zipkin/ZipkinTraceExporter.swift
@@ -76,7 +76,7 @@ public class ZipkinTraceExporter: SpanExporter {
         #if os(OSX)
         let ipv4 = Host.current().addresses.filter{ NetworkUtils.isValidIpv4Address($0) }.sorted().first
             let ipv6 = Host.current().addresses.filter { NetworkUtils.isValidIpv6Address($0) }.sorted().first
-            return ZipkinEndpoint(serviceName: hostname, ipv4: ipv4, ipv5: ipv6, port: nil)
+            return ZipkinEndpoint(serviceName: hostname, ipv4: ipv4, ipv6: ipv6, port: nil)
         #else
             return ZipkinEndpoint(serviceName: hostname)
         #endif


### PR DESCRIPTION
This file originated whole-cloth in #47 with this typo in place. I searched around to see if there might be some quirk that ipv5 is used by convention in Zipkin-related code but didn't find anything else. Assuming this is simply a typo, here's a simple fix. Thank you!