### PR TITLE
Datadog Exporter: Fix log attributes

### DIFF
--- a/Examples/Datadog Sample/main.swift
+++ b/Examples/Datadog Sample/main.swift
@@ -34,7 +34,7 @@ tracer = OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: instr
 let exporterConfiguration = ExporterConfiguration(
     serviceName: "Opentelemetry exporter Example",
     resource: "Opentelemetry exporter",
-    applicationName: "SimpleExample",
+    applicationName: "SwiftDatadogSample",
     applicationVersion: "1.0.0",
     environment: "test",
     clientToken: clientKey,
@@ -64,7 +64,8 @@ func testTraces() {
 func simpleSpan() {
     let span = tracer.spanBuilder(spanName: "SimpleSpan").setSpanKind(spanKind: .client).startSpan()
     span.setAttribute(key: sampleKey, value: sampleValue)
-    span.addEvent(name: "My event", attributes: ["message": AttributeValue.string("test message")])
+    span.addEvent(name: "My event", attributes: ["message": AttributeValue.string("test message"),
+                                                 "newKey": AttributeValue.string("New Value")])
     span.end()
 }
 

--- a/Sources/Exporters/DatadogExporter/Logs/LogEncoder.swift
+++ b/Sources/Exporters/DatadogExporter/Logs/LogEncoder.swift
@@ -90,7 +90,27 @@ internal struct DDLog: Encodable {
         self.threadName = attributes.removeValue(forKey: "threadName")?.description ?? "unkown"
         self.applicationVersion = configuration.version
 
-        self.attributes = LogAttributes(userAttributes: event.attributes, internalAttributes: internalAttributes)
+        let userAttributes:  [String: Encodable] = attributes.mapValues{
+            switch $0 {
+                case let .string(value):
+                    return value
+                case let .bool(value):
+                    return value
+                case let .int(value):
+                    return value
+                case let .double(value):
+                    return value
+                case let .stringArray(value):
+                    return value
+                case let .boolArray(value):
+                    return value
+                case let .intArray(value):
+                    return value
+                case let .doubleArray(value):
+                    return value
+            }
+        }
+        self.attributes = LogAttributes(userAttributes: userAttributes, internalAttributes: internalAttributes)
         self.tags = nil // tags
     }
 }

--- a/Tests/ExportersTests/DatadogExporter/Logs/LogsExporterTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Logs/LogsExporterTests.swift
@@ -85,7 +85,7 @@ class LogsExporterTests: XCTestCase {
                         name: "spanName",
                         kind: .server,
                         startTime: Date(timeIntervalSinceReferenceDate: 3000),
-                        events: [SpanData.Event(name: "event", timestamp: Date())],
+                        events: [SpanData.Event(name: "event", timestamp: Date(), attributes:["attributeKey": AttributeValue.string("attributeValue")])],
                         endTime: Date(timeIntervalSinceReferenceDate: 3001),
                         hasRemoteParent: false)
     }


### PR DESCRIPTION
Log attributes were being encoded with an extra description tag