### PR TITLE
Downgrade minimum swift-tools-version to 5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
 it allows older versions of swift and Xcode to compile and use the project.

This is the minimum needed for the current code.