### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
@@ -75,7 +75,7 @@ class OtlpMetricExproterTests: XCTestCase {
         // Start the server and print its address once it has started.
         let server = Server.insecure(group: serverGroup)
             .withServiceProviders([fakeCollector])
-            .bind(host: "localhost", port: 55680)
+            .bind(host: "localhost", port: 4317)
 
         server.map {
             $0.channel.localAddress
@@ -87,7 +87,7 @@ class OtlpMetricExproterTests: XCTestCase {
 
     func startChannel() -> ClientConnection {
         let channel = ClientConnection.insecure(group: channelGroup)
-            .connect(host: "localhost", port: 55680)
+            .connect(host: "localhost", port: 4317)
         return channel
     }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -95,7 +95,7 @@ class OtlpTraceExporterTests: XCTestCase {
         // Start the server and print its address once it has started.
         let server = Server.insecure(group: serverGroup)
             .withServiceProviders([fakeCollector])
-            .bind(host: "localhost", port: 55680)
+            .bind(host: "localhost", port: 4317)
 
         server.map {
             $0.channel.localAddress
@@ -107,7 +107,7 @@ class OtlpTraceExporterTests: XCTestCase {
 
     func startChannel() -> ClientConnection {
         let channel = ClientConnection.insecure(group: channelGroup)
-            .connect(host: "localhost", port: 55680)
+            .connect(host: "localhost", port: 4317)
         return channel
     }
 }


### PR DESCRIPTION
**Description:**
The legacy gRPC port(55680) in OTLP Receiver will be disabled in OTel Collector before the collector GA.

This CR replaced all gRPC port occurrences from `55680` to `4317` in this repo.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565