### PR TITLE
Bryce/metric processor improvements

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -26,7 +26,7 @@ class PushMetricController {
                     return
                 }
                 let start = Date()
-                let values = self.meterProvider.getMeters().values
+                let values = meterProvider.getMeters().values
                 values.forEach {
                     $0.collect()
                 }

--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -9,10 +9,9 @@ class PushMetricController {
     unowned var meterProvider: MeterProviderSdk
 
     let pushMetricQueue = DispatchQueue(label: "org.opentelemetry.PushMetricController.pushMetricQueue")
-    let metricPushTimer : DispatchSourceTimer
+    let metricPushTimer: DispatchSourceTimer
 
     init(meterProvider: MeterProviderSdk, meterSharedState: MeterSharedState, shouldCancel: (() -> Bool)? = nil) {
-
         self.meterProvider = meterProvider
         self.meterSharedState = meterSharedState
         metricPushTimer = DispatchSource.makeTimerSource(flags: DispatchSource.TimerFlags(), queue: pushMetricQueue)
@@ -21,7 +20,7 @@ class PushMetricController {
                 guard let self = self else {
                     return
                 }
-                if(shouldCancel?() ?? false) {
+                if shouldCancel?() ?? false {
                     self.metricPushTimer.cancel()
                     return
                 }
@@ -43,7 +42,7 @@ class PushMetricController {
 
     deinit {
         metricPushTimer.suspend() // suspending the timer prior to checking `isCancelled()` prevents a race condition between the check and actually calling `cancel()`
-        if (!metricPushTimer.isCancelled) {
+        if !metricPushTimer.isCancelled {
             metricPushTimer.cancel()
             metricPushTimer.resume()
         }

--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -6,7 +6,7 @@ import Foundation
 
 class PushMetricController {
     var meterSharedState: MeterSharedState
-    unowned var meterProvider: MeterProviderSdk
+    weak var meterProvider: MeterProviderSdk?
 
     let pushMetricQueue = DispatchQueue(label: "org.opentelemetry.PushMetricController.pushMetricQueue")
     let metricPushTimer: DispatchSourceTimer

--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -6,35 +6,46 @@ import Foundation
 
 class PushMetricController {
     var meterSharedState: MeterSharedState
-    var meterProvider: MeterProviderSdk
+    unowned var meterProvider: MeterProviderSdk
 
     let pushMetricQueue = DispatchQueue(label: "org.opentelemetry.PushMetricController.pushMetricQueue")
+    let metricPushTimer : DispatchSourceTimer
 
     init(meterProvider: MeterProviderSdk, meterSharedState: MeterSharedState, shouldCancel: (() -> Bool)? = nil) {
+
         self.meterProvider = meterProvider
         self.meterSharedState = meterSharedState
-        pushMetricQueue.asyncAfter(deadline: .now() + meterSharedState.metricPushInterval) { [weak self] in
-            guard let self = self else {
-                return
-            }
-            while !(shouldCancel?() ?? false) {
-                autoreleasepool {
-                    let start = Date()
-                    let values = self.meterProvider.getMeters().values
-                    values.forEach {
-                        $0.collect()
-                    }
-
-                    let metricToExport = self.meterSharedState.metricProcessor.finishCollectionCycle()
-
-                    _ = meterSharedState.metricExporter.export(metrics: metricToExport, shouldCancel: shouldCancel)
-                    let timeInterval = Date().timeIntervalSince(start)
-                    let remainingWait = meterSharedState.metricPushInterval - timeInterval
-                    if remainingWait > 0 {
-                        usleep(UInt32(remainingWait * 1000000))
-                    }
+        metricPushTimer = DispatchSource.makeTimerSource(flags: DispatchSource.TimerFlags(), queue: pushMetricQueue)
+        metricPushTimer.setEventHandler { [weak self] in
+            autoreleasepool {
+                guard let self = self else {
+                    return
                 }
+                if(shouldCancel?() ?? false) {
+                    self.metricPushTimer.cancel()
+                    return
+                }
+                let start = Date()
+                let values = self.meterProvider.getMeters().values
+                values.forEach {
+                    $0.collect()
+                }
+
+                let metricToExport = self.meterSharedState.metricProcessor.finishCollectionCycle()
+
+                _ = meterSharedState.metricExporter.export(metrics: metricToExport, shouldCancel: shouldCancel)
             }
+        }
+
+        metricPushTimer.schedule(deadline: .now() + meterSharedState.metricPushInterval, repeating: meterSharedState.metricPushInterval)
+        metricPushTimer.activate()
+    }
+
+    deinit {
+        metricPushTimer.suspend() // suspending the timer prior to checking `isCancelled()` prevents a race condition between the check and actually calling `cancel()`
+        if (!metricPushTimer.isCancelled) {
+            metricPushTimer.cancel()
+            metricPushTimer.resume()
         }
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/PushMetricController.swift
@@ -17,7 +17,8 @@ class PushMetricController {
         metricPushTimer = DispatchSource.makeTimerSource(flags: DispatchSource.TimerFlags(), queue: pushMetricQueue)
         metricPushTimer.setEventHandler { [weak self] in
             autoreleasepool {
-                guard let self = self else {
+                guard let self = self,
+                      let meterProvider = self.meterProvider else {
                     return
                 }
                 if shouldCancel?() ?? false {

--- a/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
@@ -15,7 +15,6 @@ public class MeterProviderSdk: MeterProvider {
     var meterSharedState: MeterSharedState
     var pushMetricController: PushMetricController!
     var defaultMeter: MeterSdk
-    var shutdown: Bool = false
 
     public convenience init() {
         self.init(metricProcessor: NoopMetricProcessor(),
@@ -33,13 +32,9 @@ public class MeterProviderSdk: MeterProvider {
 
         pushMetricController = PushMetricController(
             meterProvider: self,
-            meterSharedState: self.meterSharedState) { [shutdown] in
-                shutdown
-        }
-    }
-
-    deinit {
-        shutdown = true
+            meterSharedState: self.meterSharedState) {
+                false
+             }
     }
 
     public func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Meter {

--- a/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
@@ -15,6 +15,7 @@ public class MeterProviderSdk: MeterProvider {
     var meterSharedState: MeterSharedState
     var pushMetricController: PushMetricController!
     var defaultMeter: MeterSdk
+    var shutdown: Bool = false
 
     public convenience init() {
         self.init(metricProcessor: NoopMetricProcessor(),
@@ -32,13 +33,13 @@ public class MeterProviderSdk: MeterProvider {
 
         pushMetricController = PushMetricController(
             meterProvider: self,
-            meterSharedState: self.meterSharedState) {
-                false
+            meterSharedState: self.meterSharedState) { [shutdown] in
+                shutdown
         }
     }
 
     deinit {
-
+        shutdown = true
     }
 
     public func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Meter {

--- a/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
@@ -37,6 +37,10 @@ public class MeterProviderSdk: MeterProvider {
         }
     }
 
+    deinit {
+
+    }
+
     public func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Meter {
         if instrumentationName.isEmpty {
             return defaultMeter

--- a/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
@@ -26,15 +26,16 @@ public class MeterProviderSdk: MeterProvider {
                 metricPushInterval: TimeInterval = MeterProviderSdk.defaultPushInterval,
                 resource: Resource = EnvVarResource.resource)
     {
-        self.meterSharedState = MeterSharedState(metricProcessor: metricProcessor, metricPushInterval: metricPushInterval, metricExporter: metricExporter, resource: resource)
+        meterSharedState = MeterSharedState(metricProcessor: metricProcessor, metricPushInterval: metricPushInterval, metricExporter: metricExporter, resource: resource)
 
-        defaultMeter = MeterSdk(meterSharedState: self.meterSharedState, instrumentationLibraryInfo: InstrumentationLibraryInfo())
+        defaultMeter = MeterSdk(meterSharedState: meterSharedState, instrumentationLibraryInfo: InstrumentationLibraryInfo())
 
         pushMetricController = PushMetricController(
             meterProvider: self,
-            meterSharedState: self.meterSharedState) {
-                false
-             }
+            meterSharedState: meterSharedState
+        ) {
+            false
+        }
     }
 
     public func get(instrumentationName: String, instrumentationVersion: String? = nil) -> Meter {
@@ -49,7 +50,7 @@ public class MeterProviderSdk: MeterProvider {
         let instrumentationLibraryInfo = InstrumentationLibraryInfo(name: instrumentationName, version: instrumentationVersion)
         var meter: MeterSdk! = meterRegistry[instrumentationLibraryInfo]
         if meter == nil {
-            meter = MeterSdk(meterSharedState: self.meterSharedState, instrumentationLibraryInfo: instrumentationLibraryInfo)
+            meter = MeterSdk(meterSharedState: meterSharedState, instrumentationLibraryInfo: instrumentationLibraryInfo)
             meterRegistry[instrumentationLibraryInfo] = meter!
         }
         return meter!

--- a/Tests/ExportersTests/DatadogExporter/DatadogExporterTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/DatadogExporterTests.swift
@@ -120,10 +120,11 @@ class DatadogExporterTests: XCTestCase {
 
         let datadogExporter = try! DatadogExporter(config: exporterConfiguration)
 
+        let provider = MeterProviderSdk(metricProcessor: UngroupedBatcher(),
+                              metricExporter: datadogExporter,
+                              metricPushInterval: 0.1)
 
-        let meter = MeterProviderSdk(metricProcessor: UngroupedBatcher(),
-                                     metricExporter: datadogExporter,
-                                     metricPushInterval: 0.1).get(instrumentationName: "MyMeter")
+        let meter = provider.get(instrumentationName: "MyMeter")
 
         let testCounter = meter.createIntCounter(name: "MyCounter")
 

--- a/Tests/ExportersTests/Prometheus/PrometheusExporterTests.swift
+++ b/Tests/ExportersTests/Prometheus/PrometheusExporterTests.swift
@@ -12,6 +12,7 @@ class PrometheusExporterTests: XCTestCase {
     let metricPushIntervalSec = 0.05
     let waitDuration = 0.1 + 0.1
 
+    
     func testMetricsHttpServerAsync() {
         let promOptions = PrometheusExporterOptions(url: "http://localhost:9184/metrics/")
         let promExporter = PrometheusExporter(options: promOptions)
@@ -29,7 +30,7 @@ class PrometheusExporterTests: XCTestCase {
             }
         }
 
-        collectMetrics(simpleProcessor: simpleProcessor, exporter: promExporter)
+        let retain_me = collectMetrics(simpleProcessor: simpleProcessor, exporter: promExporter)
         usleep(useconds_t(waitDuration * 1000000))
         let url = URL(string: "http://localhost:9184/metrics/")!
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
@@ -59,10 +60,10 @@ class PrometheusExporterTests: XCTestCase {
         metricsHttpServer.stop()
     }
 
-    private func collectMetrics(simpleProcessor: UngroupedBatcher, exporter: MetricExporter) {
+    private func collectMetrics(simpleProcessor: UngroupedBatcher, exporter: MetricExporter) -> MeterProviderSdk {
 
         let meterProvider = MeterProviderSdk(metricProcessor: simpleProcessor, metricExporter: exporter, metricPushInterval: metricPushIntervalSec)
-
+        
         let meter = meterProvider.get(instrumentationName: "library1")
 
         let testCounter = meter.createIntCounter(name: "testCounter")
@@ -81,6 +82,7 @@ class PrometheusExporterTests: XCTestCase {
             testMeasure.record(value: 5, labelset: meter.getLabelSet(labels: labels1))
             testMeasure.record(value: 500, labelset: meter.getLabelSet(labels: labels1))
         }
+        return meterProvider
     }
 
     private func validateResponse(responseText: String) {


### PR DESCRIPTION
This PR fixes a retention loop between MetricProviderSdk & PushMetricController, and also fixes the resulting crash by using a DispatchSourceTimer to clean up the dispatched thread when the PushMetricController is released.

fixes #198 