### PR TITLE
Add aggregationTemporality to OTEL metrics exporter

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
@@ -100,6 +100,7 @@ struct MetricsAdapter {
                     protoDataPoint.labels.append(kvp)
                 }
 
+                protoMetric.doubleSum.aggregationTemporality = .cumulative
                 protoMetric.doubleSum.dataPoints.append(protoDataPoint)
             case .doubleSummary:
 
@@ -136,6 +137,7 @@ struct MetricsAdapter {
                     protoDataPoint.labels.append(kvp)
                 }
 
+                protoMetric.intSum.aggregationTemporality = .cumulative
                 protoMetric.intSum.dataPoints.append(protoDataPoint)
             case .intSummary:
                 guard let summaryData = $0 as? SummaryData<Int> else {


### PR DESCRIPTION
Not 100% sure if `cumulative` is the correct answer here, but it does work for my use case. Without this, these metrics do not pass the OTEL collector's exporter validation (tested forwarding events to Prometheus) as it complains about the invalid temporality setting.

With this fix, we're seeing events successfully go through the collector and land in Prom.