### PR TITLE
Use a versioned dependency of Reachability external library

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "Reachability",
         "repositoryURL": "https://github.com/ashleymills/Reachability.swift",
         "state": {
-          "branch": "master",
-          "revision": "a81b7367f2c46875f29577e03a60c39cdfad0c8d",
-          "version": null
+          "branch": null,
+          "revision": "c01bbdf2d633cf049ae1ed1a68a2020a8bda32e2",
+          "version": "5.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         .package(name: "grpc-swift", url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),
         .package(name: "swift-atomics", url: "https://github.com/apple/swift-atomics.git", from: "0.0.1"),
         .package(name: "swift-metrics", url: "https://github.com/apple/swift-metrics.git", from: "2.1.1"),
-        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", .branch("master")),
+        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "5.1.0"),
 
     ],
     targets: [

--- a/Sources/Instrumentation/NetworkStatus/NetworkMonitor.swift
+++ b/Sources/Instrumentation/NetworkStatus/NetworkMonitor.swift
@@ -6,9 +6,9 @@
 import Foundation
 import Reachability
 
-public class NetworkMonitor : NetworkMonitorProtocol {
-    public private(set) var reachability :Reachability
-    
+public class NetworkMonitor: NetworkMonitorProtocol {
+    public private(set) var reachability: Reachability
+
     public init() throws {
         reachability = try Reachability()
         try reachability.startNotifier()
@@ -17,17 +17,15 @@ public class NetworkMonitor : NetworkMonitorProtocol {
     deinit {
         reachability.stopNotifier()
     }
-    
+
     public func getConnection() -> Connection {
         switch reachability.connection {
         case .wifi:
             return .wifi
         case .cellular:
             return .cellular
-        case .unavailable:
+        case .unavailable, .none:
             return .unavailable
         }
     }
-    
-    
 }

--- a/Sources/OpenTelemetrySdk/Resources/Resource.swift
+++ b/Sources/OpenTelemetrySdk/Resources/Resource.swift
@@ -40,14 +40,14 @@ public struct Resource: Equatable, Hashable {
     }
 
     /// Modifies the current Resource by merging with the other Resource.
-    /// In case of a collision, current Resource takes precedence.
+    /// In case of a collision, new Resource takes precedence.
     /// - Parameter other: the Resource that will be merged with this
     public mutating func merge(other: Resource) {
         attributes.merge(other.attributes) { _, other in other }
     }
 
     /// Returns a new, merged Resource by merging the current Resource with the other Resource.
-    /// In case of a collision, current Resource takes precedence.
+    /// In case of a collision, new Resource takes precedence.
     /// - Parameter other: the Resource that will be merged with this
     public func merging(other: Resource) -> Resource {
         let labelsCopy = attributes.merging(other.attributes) { _, other in other }


### PR DESCRIPTION
We must use a versioned dependency of Reachability, or a versioned dependency of opentelemetry-swift cannot be used.

Also fix a documentation error in `Resource` merging method