### PR TITLE
Revert "Datadog Exporter: Set gzip compression for traces and logs up loads"

### DIFF
--- a/Sources/Exporters/DatadogExporter/Logs/LogsExporter.swift
+++ b/Sources/Exporters/DatadogExporter/Logs/LogsExporter.swift
@@ -69,8 +69,7 @@ internal class LogsExporter {
                 appName: configuration.applicationName,
                 appVersion: configuration.version,
                 device: Device.current
-            ),
-            .compressedContentEncodingHeader()
+            )
         ])
 
         logsUpload = FeatureUpload(featureName: "logsUpload",

--- a/Sources/Exporters/DatadogExporter/Metrics/MetricsExporter.swift
+++ b/Sources/Exporters/DatadogExporter/Metrics/MetricsExporter.swift
@@ -60,8 +60,6 @@ internal class MetricsExporter {
                 appVersion: configuration.version,
                 device: Device.current
             ),
-            // metrics endpoint doesnt accept gzipped content
-            //.compressedContentEncodingHeader()
         ])
 
         metricsUpload = FeatureUpload(featureName: "metricsUpload",

--- a/Sources/Exporters/DatadogExporter/Spans/SpansExporter.swift
+++ b/Sources/Exporters/DatadogExporter/Spans/SpansExporter.swift
@@ -59,8 +59,7 @@ internal class SpansExporter {
                 appName: configuration.applicationName,
                 appVersion: configuration.version,
                 device: Device.current
-            ),
-            .compressedContentEncodingHeader()
+            )
         ])
 
         tracesUpload = FeatureUpload(featureName: "tracesUpload",

--- a/Sources/Exporters/DatadogExporter/Upload/DataUploader.swift
+++ b/Sources/Exporters/DatadogExporter/Upload/DataUploader.swift
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Compression
 import Foundation
 
 /// Creates URL and adds query items before providing them
@@ -108,32 +107,8 @@ internal final class DataUploader {
         var request = URLRequest(url: urlProvider.url)
         request.httpMethod = "POST"
         request.allHTTPHeaderFields = httpHeaders.all
-        request.httpBody = httpHeaders.all["Content-Encoding"] != nil ? compressData(data: data) : data
+        request.httpBody = data
         return request
-    }
-
-    private func compressData(data: Data) -> Data {
-        let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: data.count + 10)
-        var compressedSize: Int = 0
-        data.withUnsafeBytes { (source: UnsafeRawBufferPointer) in
-            // Set gzip header
-            destinationBuffer[0] = 31
-            destinationBuffer[1] = 139
-            destinationBuffer[2] = 8
-            destinationBuffer[3] = 0
-            destinationBuffer[4] = 0
-            destinationBuffer[5] = 0
-            destinationBuffer[6] = 0
-            destinationBuffer[7] = 0
-            destinationBuffer[8] = 0
-            destinationBuffer[9] = 0
-            // Actually compress the buffer
-            compressedSize = compression_encode_buffer(destinationBuffer.advanced(by: 10), data.count,
-                                                       source.bindMemory(to: UInt8.self).baseAddress!, data.count,
-                                                       nil,
-                                                       COMPRESSION_ZLIB)
-        }
-        return Data(bytesNoCopy: destinationBuffer, count: compressedSize + 2, deallocator: .free)
     }
 }
 

--- a/Sources/Exporters/DatadogExporter/Upload/HTTPHeaders.swift
+++ b/Sources/Exporters/DatadogExporter/Upload/HTTPHeaders.swift
@@ -22,10 +22,6 @@ internal struct HTTPHeaders {
             return HTTPHeader(field: "Content-Type", value: contentType.rawValue)
         }
 
-        static func compressedContentEncodingHeader() -> HTTPHeader {
-            return HTTPHeader( field: "Content-Encoding", value: "gzip")
-        }
-
         static func userAgentHeader(appName: String, appVersion: String, device: Device) -> HTTPHeader {
             return HTTPHeader(
                 field: "User-Agent",


### PR DESCRIPTION
This reverts commit 7e8718f86a59388c76c78b966d06231f8506d374.

It is not working reliably, and probably moving to the new api in the near future, so revert for now