### PR TITLE
Fix appleTV linking when using URLSession instrumentation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -70,7 +70,7 @@ let package = Package(
         .target(name: "NetworkStatus",
                 dependencies: ["Reachability", "OpenTelemetryApi"],
                 path: "Sources/Instrumentation/NetworkStatus",
-                linkerSettings: [.linkedFramework("CoreTelephony")]),
+                linkerSettings: [.linkedFramework("CoreTelephony", .when(platforms: [.iOS], configuration: nil))]),
         .target(name: "SignPostIntegration",
                 dependencies: ["OpenTelemetrySdk"],
                 path: "Sources/Instrumentation/SignPostIntegration",


### PR DESCRIPTION
Avoid linking CoreTelephony when platform is not iOS, this dependency is brought to the final user of the library and fails always in the case of appleTV