### PR TITLE
Several fixes for URLSessionInstrumentation

### DIFF
--- a/Sources/Exporters/DatadogExporter/Utils/EncodableValue.swift
+++ b/Sources/Exporters/DatadogExporter/Utils/EncodableValue.swift
@@ -62,7 +62,7 @@ internal struct JSONStringEncodableValue: Encodable {
         } else {
             let jsonData: Data
 
-            if #available(iOS 13.0, *) {
+            if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
                 jsonData = try jsonEncoder.encode(encodable)
             } else {
                 // Prior to `iOS13.0` the `JSONEncoder` is unable to encode primitive values - it expects them to be

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -79,7 +79,7 @@ class URLSessionLogger {
         }
 
         var returnRequest: URLRequest?
-        if shouldInjectHeaders {
+        if shouldInjectHeaders && (instrumentation.configuration.shouldInjectTracingHeaders?(request) ?? true) {
             returnRequest = instrumentedRequest(for: request, span: span, instrumentation: instrumentation)
         }
 
@@ -91,7 +91,7 @@ class URLSessionLogger {
 
         instrumentation.configuration.createdRequest?(returnRequest ?? request, span)
 
-        return returnRequest ?? request
+        return returnRequest
     }
 
     /// This methods ends a Span when a response arrives

--- a/Tests/ExportersTests/DatadogExporter/Utils/JSONEncoderTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Utils/JSONEncoderTests.swift
@@ -22,7 +22,7 @@ class JSONEncoderTests: XCTestCase {
             EncodingContainer(URL(string: "https://example.com/foo")!)
         )
 
-        if #available(iOS 13.0, OSX 10.15, *) {
+        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
             XCTAssertEqual(encodedURL.utf8String, #"{"value":"https://example.com/foo"}"#)
         } else {
             XCTAssertEqual(encodedURL.utf8String, #"{"value":"https:\/\/example.com\/foo"}"#)


### PR DESCRIPTION
- Fix with iOS < 13, it could create duplicated spans
- Fix with iOS < 13, delegate calls could fail to be called 
- Fix payload was not properly saved and reported with some methods
- Avoid modifying the URLRequest when not injecting tracing headers

Fixes #229 