### PR TITLE
Bring zipkin exporter's treatment of status into spec

### DIFF
--- a/Sources/Exporters/Zipkin/Implementation/ZipkinConversionExtension.swift
+++ b/Sources/Exporters/Zipkin/Implementation/ZipkinConversionExtension.swift
@@ -8,8 +8,8 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 
 struct ZipkinConversionExtension {
-    static let statusCode = "ot.status_code"
-    static let statusDescription = "ot.status_description"
+    static let statusCode = "otel.status_code"
+    static let statusErrorDescription = "error"
 
     static let remoteEndpointServiceNameKeyResolution = ["peer.service": 0,
                                                          "net.peer.name": 1,
@@ -65,12 +65,11 @@ struct ZipkinConversionExtension {
         }
 
         let status = otelSpan.status
-
-        if status.isOk {
-            attributeEnumerationState.tags[statusCode] = "\(status.name)".capitalized
-            if case let Status.error(description) = status {
-                attributeEnumerationState.tags[statusDescription] = description
-            }
+        if status != .unset {
+            attributeEnumerationState.tags[statusCode] = "\(status.name)".uppercased()
+        }
+        if case let Status.error(description) = status {
+            attributeEnumerationState.tags[statusErrorDescription] = description
         }
 
         let annotations = otelSpan.events.map { processEvents(event: $0) }

--- a/Tests/ExportersTests/Zipkin/Implementation/ZipkinSpanConverterTests.swift
+++ b/Tests/ExportersTests/Zipkin/Implementation/ZipkinSpanConverterTests.swift
@@ -34,7 +34,20 @@ class ZipkinSpanConverterTests: XCTestCase {
         XCTAssertEqual(zipkinSpan.remoteEndpoint?.serviceName, "RemoteServiceName")
     }
 
-    public static func createTestSpan(setAttributes: Bool = true, additionalAttributes: [String: Any]? = nil, addEvents: Bool = true, addLinks: Bool = true) -> SpanData {
+    func testStatusUnset() {
+        let span = ZipkinSpanConverterTests.createTestSpan(status: Status.unset)
+        let zipkinSpan = ZipkinConversionExtension.toZipkinSpan(otelSpan: span, defaultLocalEndpoint: defaultZipkinEndpoint)
+        XCTAssertNil(zipkinSpan.tags["otel.status_code"])
+    }
+
+    func testStatusError() {
+        let span = ZipkinSpanConverterTests.createTestSpan(status: Status.error(description: "error message"))
+        let zipkinSpan = ZipkinConversionExtension.toZipkinSpan(otelSpan: span, defaultLocalEndpoint: defaultZipkinEndpoint)
+        XCTAssertEqual(zipkinSpan.tags["otel.status_code"], "ERROR")
+        XCTAssertEqual(zipkinSpan.tags["error"], "error message")
+    }
+
+    public static func createTestSpan(setAttributes: Bool = true, additionalAttributes: [String: Any]? = nil, addEvents: Bool = true, addLinks: Bool = true, status: Status = Status.ok) -> SpanData {
         let startTimestamp = Date(timeIntervalSince1970: Double(Int(Date().timeIntervalSince1970))) // Round for comparison
         let endTimestamp = startTimestamp.addingTimeInterval(60)
         let eventTimestamp = startTimestamp
@@ -58,6 +71,6 @@ class ZipkinSpanConverterTests: XCTestCase {
 
 //        let linkedSpanId = SpanId(fromHexString: "888915b6286b9c41")
 
-        return SpanData(traceId: traceId, spanId: spanId, parentSpanId: parentSpanId, resource: Resource.empty, name: "Name", kind: .client, startTime: startTimestamp, attributes: attributes, events: events, status: Status.ok, endTime: endTimestamp)
+        return SpanData(traceId: traceId, spanId: spanId, parentSpanId: parentSpanId, resource: Resource.empty, name: "Name", kind: .client, startTime: startTimestamp, attributes: attributes, events: events, status: status, endTime: endTimestamp)
     }
 }

--- a/Tests/ExportersTests/Zipkin/ZipkinExporterTests.swift
+++ b/Tests/ExportersTests/Zipkin/ZipkinExporterTests.swift
@@ -34,7 +34,7 @@ class ZipkinExporterTests: XCTestCase {
 
         let exporterOutputArray = spans.map { ZipkinConversionExtension.toZipkinSpan(otelSpan: $0, defaultLocalEndpoint: ZipkinTraceExporter.getLocalZipkinEndpoint(name: "Open Telemetry Exporter")) }.map { $0.write() }
 
-        let expectedOutputString = #"{"traceId":"e8ea7e9ac72de94e91fabc613f9686b2","name":"Name","parentId":"\#(span.parentSpanId!.hexString)","id":"\#(span.spanId.hexString)","kind":"CLIENT","timestamp":\#(timestamp),"duration":60000000,"localEndpoint":{"serviceName":"Open Telemetry Exporter"\#(ipInformation)},"annotations":[{"timestamp":\#(timestamp),"value":"Event1"},{"timestamp":\#(timestamp),"value":"Event2"}],"tags":{"stringKey":"value","longKey":"1","longKey2":"1","doubleKey":"1.0","doubleKey2":"1.0","boolKey":"true","ot.status_code":"Ok"}}"#
+        let expectedOutputString = #"{"traceId":"e8ea7e9ac72de94e91fabc613f9686b2","name":"Name","parentId":"\#(span.parentSpanId!.hexString)","id":"\#(span.spanId.hexString)","kind":"CLIENT","timestamp":\#(timestamp),"duration":60000000,"localEndpoint":{"serviceName":"Open Telemetry Exporter"\#(ipInformation)},"annotations":[{"timestamp":\#(timestamp),"value":"Event1"},{"timestamp":\#(timestamp),"value":"Event2"}],"tags":{"stringKey":"value","longKey":"1","longKey2":"1","doubleKey":"1.0","doubleKey2":"1.0","boolKey":"true","otel.status_code":"OK"}}"#
         let expectedData = expectedOutputString.data(using: .utf8)!
         let expectedOutputObject = try? JSONSerialization.jsonObject(with: expectedData)
         let expectedOutput = expectedOutputObject as! NSDictionary


### PR DESCRIPTION
Use proper names (otel.status_code, error) and criteria for when/how they should be added as zipkin tags.

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status