### PR TITLE
Fix compiling OpenTelemetryAPI for mac with Xcode13 RC

### DIFF
--- a/Sources/OpenTelemetryApi/Context/TaskLocalContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/TaskLocalContextManager.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-#if swift(>=5.5)
+#if canImport(_Concurrency)
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, *)
 enum ContextManagement {
     @TaskLocal


### PR DESCRIPTION
Xcode 13 RC(13A233) includes swift 5.5 but not Monterey SDK so no Concurrency for mac.

Anyway there are some other compiler issues that avoid compiling some other targets for mac with this Xcode 13 RC (13A233) version, e.g: it fails compiling `SwiftNIO` (apple provided library) dependency for mac but works well for iOS