### PR TITLE
Update swift-atomics to 1.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "26e346cd64f6b92d4089e7fafe2f8e82f60ddb8c",
-          "version": "0.0.2"
+          "revision": "59f7fbf47952b50aceb2c09d3c12e0a120e82456",
+          "version": "1.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         .package(name: "Thrift", url: "https://github.com/undefinedlabs/Thrift-Swift", from: "1.1.1"),
         .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(name: "grpc-swift", url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),
-        .package(name: "swift-atomics", url: "https://github.com/apple/swift-atomics.git", from: "0.0.1"),
+        .package(name: "swift-atomics", url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
         .package(name: "swift-metrics", url: "https://github.com/apple/swift-metrics.git", from: "2.1.1"),
     ],
     targets: [


### PR DESCRIPTION
Pro: swift-atomics went 1.0 about a month ago; the final api changes were fairly minimal and don't affect our code base; and it does bring good benefits like support for library evolution.  

Con: Some of our (otel-swift's) users may also depend on swift-atomics. Unfortunately, Swift Package Manager doesn't have a way to express that otel-swift would be happy with "0.x OR 1.x".  So, there is a small risk of user impact where somebody would be forced into upgrading from swift-atomics 0.0.x to 1.0 (which, again, should be very easy to do).

Balancing everything I think it's OK to move now, but I can also understand wanting to wait a while.