### PR TITLE
Add support for Histogram metrics

### DIFF
--- a/Sources/Exporters/DatadogExporter/Metrics/MetricUtils.swift
+++ b/Sources/Exporters/DatadogExporter/Metrics/MetricUtils.swift
@@ -24,7 +24,7 @@ internal struct MetricUtils: Encodable {
         switch metric.aggregationType {
         case .doubleSum, .intSum:
             return countType
-        case .doubleSummary, .intSummary, .intGauge, .doubleGauge:
+        case .doubleSummary, .intSummary, .intGauge, .doubleGauge, .doubleHistogram, .intHistogram:
             return gaugeType
         }
     }

--- a/Sources/Exporters/DatadogExporter/Metrics/MetricsExporter.swift
+++ b/Sources/Exporters/DatadogExporter/Metrics/MetricsExporter.swift
@@ -84,6 +84,12 @@ internal class MetricsExporter {
             case .intSummary, .intGauge:
                 let summary = metricData as! SummaryData<Int>
                 return DDMetricPoint(timestamp: metricData.timestamp, value: Double(summary.sum))
+            case .intHistogram:
+                let histogram = metricData as! HistogramData<Int>
+                return DDMetricPoint(timestamp: metricData.timestamp, value: Double(histogram.sum))
+            case .doubleHistogram:
+                let histogram = metricData as! HistogramData<Double>
+                return DDMetricPoint(timestamp: metricData.timestamp, value: histogram.sum)
             }
         }
 

--- a/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
@@ -157,6 +157,46 @@ struct MetricsAdapter {
                 }
 
                 protoMetric.doubleSummary.dataPoints.append(protoDataPoint)
+            case .intHistogram:
+                guard let histogramData = $0 as? HistogramData<Int> else {
+                    break
+                }
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint()
+                protoDataPoint.sum = Double(histogramData.sum)
+                protoDataPoint.count = UInt64(histogramData.count)
+                protoDataPoint.startTimeUnixNano = histogramData.startTimestamp.timeIntervalSince1970.toNanoseconds
+                protoDataPoint.timeUnixNano = histogramData.timestamp.timeIntervalSince1970.toNanoseconds
+                protoDataPoint.explicitBounds = histogramData.buckets.boundaries.map { Double($0) }
+                protoDataPoint.bucketCounts = histogramData.buckets.counts.map { UInt64($0) }
+                
+                histogramData.labels.forEach {
+                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    kvp.key = $0.key
+                    kvp.value = $0.value
+                    protoDataPoint.labels.append(kvp)
+                }
+                
+                protoMetric.doubleHistogram.dataPoints.append(protoDataPoint)
+            case .doubleHistogram:
+                guard let histogramData = $0 as? HistogramData<Double> else {
+                    break
+                }
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint()
+                protoDataPoint.sum = Double(histogramData.sum)
+                protoDataPoint.count = UInt64(histogramData.count)
+                protoDataPoint.startTimeUnixNano = histogramData.startTimestamp.timeIntervalSince1970.toNanoseconds
+                protoDataPoint.timeUnixNano = histogramData.timestamp.timeIntervalSince1970.toNanoseconds
+                protoDataPoint.explicitBounds = histogramData.buckets.boundaries.map { Double($0) }
+                protoDataPoint.bucketCounts = histogramData.buckets.counts.map { UInt64($0) }
+                
+                histogramData.labels.forEach {
+                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    kvp.key = $0.key
+                    kvp.value = $0.value
+                    protoDataPoint.labels.append(kvp)
+                }
+                
+                protoMetric.doubleHistogram.dataPoints.append(protoDataPoint)
             }
         }
         return protoMetric

--- a/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
@@ -176,6 +176,7 @@ struct MetricsAdapter {
                     protoDataPoint.labels.append(kvp)
                 }
                 
+                protoMetric.doubleHistogram.aggregationTemporality = .cumulative
                 protoMetric.doubleHistogram.dataPoints.append(protoDataPoint)
             case .doubleHistogram:
                 guard let histogramData = $0 as? HistogramData<Double> else {
@@ -196,6 +197,7 @@ struct MetricsAdapter {
                     protoDataPoint.labels.append(kvp)
                 }
                 
+                protoMetric.doubleHistogram.aggregationTemporality = .cumulative
                 protoMetric.doubleHistogram.dataPoints.append(protoDataPoint)
             }
         }

--- a/Sources/Exporters/Prometheus/PrometheusExporterExtensions.swift
+++ b/Sources/Exporters/Prometheus/PrometheusExporterExtensions.swift
@@ -45,6 +45,8 @@ public enum PrometheusExporterExtensions {
                     let min = summary.min
                     let max = summary.max
                     output += PrometheusExporterExtensions.writeSummary(prometheusMetric: prometheusMetric, timeStamp: now, labels: labels, metricName: metric.name, sum: Double(sum), count: count, min: Double(min), max: Double(max))
+                case .intHistogram, .doubleHistogram:
+                    break
                 }
             }
         }

--- a/Sources/OpenTelemetryApi/Metrics/BoundHistogramMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/BoundHistogramMetric.swift
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Bound histogram metric
+open class BoundHistogramMetric<T> {
+    public init(boundaries: Array<T>) {}
+
+    /// Record the given value to the bound histogram metric.
+    /// - Parameters:
+    ///   - value: the histogram to be recorded.
+    open func record(value: T) {
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/BoundHistogramMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/BoundHistogramMetric.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Bound histogram metric
 open class BoundHistogramMetric<T> {
-    public init(boundaries: Array<T>) {}
+    public init(explicitBoundaries: Array<T>? = nil) {}
 
     /// Record the given value to the bound histogram metric.
     /// - Parameters:

--- a/Sources/OpenTelemetryApi/Metrics/HistogramMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/HistogramMetric.swift
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Measure instrument.
+public protocol HistogramMetric {
+    associatedtype T
+    /// Gets the bound histogram metric with given labelset.
+    /// - Parameters:
+    ///   - labelset: The labelset from which bound instrument should be constructed.
+    /// - Returns: The bound histogram metric.
+
+    func bind(labelset: LabelSet) -> BoundHistogramMetric<T>
+
+    /// Gets the bound histogram metric with given labelset.
+    /// - Parameters:
+    ///   - labels: The labels or dimensions associated with this value.
+    /// - Returns: The bound histogram metric.
+    func bind(labels: [String: String]) -> BoundHistogramMetric<T>
+}
+
+public extension HistogramMetric {
+    /// Records a histogram.
+    /// - Parameters:
+    ///   - value: value to record.
+    ///   - labelset: The labelset associated with this value.
+    func record(value: T, labelset: LabelSet) {
+        bind(labelset: labelset).record(value: value)
+    }
+
+    /// Records a histogram.
+    /// - Parameters:
+    ///   - value: value to record.
+    ///   - labels: The labels or dimensions associated with this value.
+    func record(value: T, labels: [String: String]) {
+        bind(labels: labels).record(value: value)
+    }
+}
+
+public struct AnyHistogramMetric<T>: HistogramMetric {
+    private let _bindLabelSet: (LabelSet) -> BoundHistogramMetric<T>
+    private let _bindLabels: ([String: String]) -> BoundHistogramMetric<T>
+
+    public init<U: HistogramMetric>(_ histogram: U) where U.T == T {
+        _bindLabelSet = histogram.bind(labelset:)
+        _bindLabels = histogram.bind(labels:)
+    }
+
+    public func bind(labelset: LabelSet) -> BoundHistogramMetric<T> {
+        _bindLabelSet(labelset)
+    }
+
+    public func bind(labels: [String: String]) -> BoundHistogramMetric<T> {
+        _bindLabels(labels)
+    }
+}
+
+public struct NoopHistogramMetric<T>: HistogramMetric {
+    public init() {}
+
+    public func bind(labelset: LabelSet) -> BoundHistogramMetric<T> {
+        BoundHistogramMetric<T>(boundaries: [])
+    }
+
+    public func bind(labels: [String: String]) -> BoundHistogramMetric<T> {
+        BoundHistogramMetric<T>(boundaries: [])
+    }
+}

--- a/Sources/OpenTelemetryApi/Metrics/HistogramMetric.swift
+++ b/Sources/OpenTelemetryApi/Metrics/HistogramMetric.swift
@@ -62,10 +62,10 @@ public struct NoopHistogramMetric<T>: HistogramMetric {
     public init() {}
 
     public func bind(labelset: LabelSet) -> BoundHistogramMetric<T> {
-        BoundHistogramMetric<T>(boundaries: [])
+        BoundHistogramMetric<T>()
     }
 
     public func bind(labels: [String: String]) -> BoundHistogramMetric<T> {
-        BoundHistogramMetric<T>(boundaries: [])
+        BoundHistogramMetric<T>()
     }
 }

--- a/Sources/OpenTelemetryApi/Metrics/Meter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Meter.swift
@@ -34,6 +34,22 @@ public protocol Meter {
     ///   - absolute: indicates if only positive values are expected.
     /// - Returns:The measure instance.
     func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double>
+    
+    /// Creates Int Histogram with given name and boundaries.
+    /// - Parameters:
+    ///   - name: The name of the measure.
+    ///   - boundaries: The boundary for sorting values into buckets
+    ///   - absolute: indicates if only positive values are expected.
+    /// - Returns:The histogram instance.
+    func createIntHistogram(name: String, boundaries: Array<Int>, absolute: Bool) -> AnyHistogramMetric<Int>
+    
+    /// Creates Double Histogram with given name and boundaries.
+    /// - Parameters:
+    ///   - name: The name of the measure.
+    ///   - boundaries: The boundary for sorting values into buckets
+    ///   - absolute: indicates if only positive values are expected.
+    /// - Returns:The histogram instance.
+    func createDoubleHistogram(name: String, boundaries: Array<Double>, absolute: Bool) -> AnyHistogramMetric<Double>
 
     /// Creates Int Observer with given name.
     /// - Parameters:

--- a/Sources/OpenTelemetryApi/Metrics/Meter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Meter.swift
@@ -38,18 +38,18 @@ public protocol Meter {
     /// Creates Int Histogram with given name and boundaries.
     /// - Parameters:
     ///   - name: The name of the measure.
-    ///   - boundaries: The boundary for sorting values into buckets
+    ///   - explicitBoundaries: The boundary for sorting values into buckets
     ///   - absolute: indicates if only positive values are expected.
     /// - Returns:The histogram instance.
-    func createIntHistogram(name: String, boundaries: Array<Int>, absolute: Bool) -> AnyHistogramMetric<Int>
+    func createIntHistogram(name: String, explicitBoundaries: Array<Int>?, absolute: Bool) -> AnyHistogramMetric<Int>
     
     /// Creates Double Histogram with given name and boundaries.
     /// - Parameters:
     ///   - name: The name of the measure.
-    ///   - boundaries: The boundary for sorting values into buckets
+    ///   - explicitBoundaries: The boundary for sorting values into buckets
     ///   - absolute: indicates if only positive values are expected.
     /// - Returns:The histogram instance.
-    func createDoubleHistogram(name: String, boundaries: Array<Double>, absolute: Bool) -> AnyHistogramMetric<Double>
+    func createDoubleHistogram(name: String, explicitBoundaries: Array<Double>?, absolute: Bool) -> AnyHistogramMetric<Double>
 
     /// Creates Int Observer with given name.
     /// - Parameters:

--- a/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
@@ -28,6 +28,14 @@ public struct ProxyMeter: Meter {
     public func createDoubleMeasure(name: String, absolute: Bool) -> AnyMeasureMetric<Double> {
         return realMeter?.createDoubleMeasure(name: name, absolute: absolute) ?? AnyMeasureMetric<Double>(NoopMeasureMetric<Double>())
     }
+    
+    public func createIntHistogram(name: String, boundaries: Array<Int>, absolute: Bool) -> AnyHistogramMetric<Int> {
+        return realMeter?.createIntHistogram(name: name, boundaries: boundaries, absolute: absolute) ?? AnyHistogramMetric<Int>(NoopHistogramMetric<Int>())
+    }
+    
+    public func createDoubleHistogram(name: String, boundaries: Array<Double>, absolute: Bool) -> AnyHistogramMetric<Double> {
+        return realMeter?.createDoubleHistogram(name: name, boundaries: boundaries, absolute: absolute) ?? AnyHistogramMetric<Double>(NoopHistogramMetric<Double>())
+    }
 
     public func createIntObservableGauge(name: String, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
         return realMeter?.createIntObservableGauge(name: name, callback: callback) ?? NoopIntObserverMetric()

--- a/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/ProxyMeter.swift
@@ -29,12 +29,12 @@ public struct ProxyMeter: Meter {
         return realMeter?.createDoubleMeasure(name: name, absolute: absolute) ?? AnyMeasureMetric<Double>(NoopMeasureMetric<Double>())
     }
     
-    public func createIntHistogram(name: String, boundaries: Array<Int>, absolute: Bool) -> AnyHistogramMetric<Int> {
-        return realMeter?.createIntHistogram(name: name, boundaries: boundaries, absolute: absolute) ?? AnyHistogramMetric<Int>(NoopHistogramMetric<Int>())
+    public func createIntHistogram(name: String, explicitBoundaries: Array<Int>? = nil, absolute: Bool) -> AnyHistogramMetric<Int> {
+        return realMeter?.createIntHistogram(name: name, explicitBoundaries: explicitBoundaries, absolute: absolute) ?? AnyHistogramMetric<Int>(NoopHistogramMetric<Int>())
     }
     
-    public func createDoubleHistogram(name: String, boundaries: Array<Double>, absolute: Bool) -> AnyHistogramMetric<Double> {
-        return realMeter?.createDoubleHistogram(name: name, boundaries: boundaries, absolute: absolute) ?? AnyHistogramMetric<Double>(NoopHistogramMetric<Double>())
+    public func createDoubleHistogram(name: String, explicitBoundaries: Array<Double>?, absolute: Bool) -> AnyHistogramMetric<Double> {
+        return realMeter?.createDoubleHistogram(name: name, explicitBoundaries: explicitBoundaries, absolute: absolute) ?? AnyHistogramMetric<Double>(NoopHistogramMetric<Double>())
     }
 
     public func createIntObservableGauge(name: String, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {

--- a/Sources/OpenTelemetrySdk/Metrics/Aggregators/HistogramAggregator.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Aggregators/HistogramAggregator.swift
@@ -1,0 +1,105 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Aggregator which calculates histogram (bucket distribution, sum, count) from measures.
+public class HistogramAggregator<T: SignedNumeric & Comparable>: Aggregator<T> {
+    fileprivate var histogram: Histogram<T>
+    fileprivate var pointCheck: Histogram<T>
+    fileprivate var boundaries: Array<T>
+    
+    private let lock = Lock()
+    
+    public init(boundaries: Array<T>) throws {
+        if boundaries.count == 0 {
+            throw HistogramError(description: "HistogramAggregator should be created with boundaries.")
+        }
+        
+        // we need to an ordered set to be able to correctly compute count for each
+        // boundary since we'll iterate on each in order.
+        self.boundaries = boundaries.sorted { $0 < $1 }
+        self.histogram = Histogram<T>(boundaries: self.boundaries)
+        self.pointCheck = Histogram<T>(boundaries: self.boundaries)
+    }
+    
+    override public func update(value: T) {
+        lock.withLockVoid {
+            self.histogram.count += 1
+            self.histogram.sum += value
+            
+            for i in 0..<self.boundaries.count {
+                if value < self.boundaries[i] {
+                    self.histogram.buckets.counts[i] += 1
+                    return
+                }
+            }
+            // value is above all observed boundaries
+            self.histogram.buckets.counts[self.boundaries.count] += 1
+        }
+    }
+    
+    override public func checkpoint() {
+        lock.withLockVoid {
+            super.checkpoint()
+            pointCheck = histogram
+            histogram = Histogram<T>(boundaries: self.boundaries)
+        }
+    }
+    
+    public override func toMetricData() -> MetricData {
+        return HistogramData<T>(startTimestamp: lastStart,
+                                timestamp: lastEnd,
+                                buckets: pointCheck.buckets,
+                                count: pointCheck.count,
+                                sum: pointCheck.sum)
+    }
+    
+    public override func getAggregationType() -> AggregationType {
+        if T.self == Double.Type.self {
+            return .doubleHistogram
+        } else {
+            return .intHistogram
+        }
+    }
+}
+
+private struct Histogram<T> where T: SignedNumeric {
+    /*
+     * Buckets are implemented using two different arrays:
+     *  - boundaries: contains every finite bucket boundary, which are inclusive lower bounds
+     *  - counts: contains event counts for each bucket
+     *
+     * Note that we'll always have n+1 buckets, where n is the number of boundaries.
+     * This is because we need to count events that are below the lowest boundary.
+     *
+     * Example: if we measure the values: [5, 30, 5, 40, 5, 15, 15, 15, 25]
+     *  with the boundaries [ 10, 20, 30 ], we will have the following state:
+     *
+     * buckets: {
+     *  boundaries: [10, 20, 30],
+     *  counts: [3, 3, 1, 2],
+     * }
+     */
+    var buckets: (
+        boundaries: Array<T>,
+        counts: Array<Int>
+    )
+    var sum: T
+    var count: Int
+    
+    init(boundaries: Array<T>) {
+        sum = 0
+        count = 0
+        buckets = (
+            boundaries: boundaries,
+            counts: Array(repeating: 0, count: boundaries.count + 1)
+        )
+    }
+}
+
+internal struct HistogramError: Error, CustomStringConvertible {
+    let description: String
+}

--- a/Sources/OpenTelemetrySdk/Metrics/BoundHistogramMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundHistogramMetricSdk.swift
@@ -9,9 +9,9 @@ import OpenTelemetryApi
 internal class BoundHistogramMetricSdk<T: SignedNumeric & Comparable>: BoundHistogramMetricSdkBase<T> {
     private var histogramAggregator: HistogramAggregator<T>
 
-    override init(boundaries: Array<T>) {
-        self.histogramAggregator = try! HistogramAggregator(boundaries: boundaries)
-        super.init(boundaries: boundaries)
+    override init(explicitBoundaries: Array<T>? = nil) {
+        self.histogramAggregator = try! HistogramAggregator(explicitBoundaries: explicitBoundaries)
+        super.init(explicitBoundaries: explicitBoundaries)
     }
 
     override func record(value: T) {

--- a/Sources/OpenTelemetrySdk/Metrics/BoundHistogramMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundHistogramMetricSdk.swift
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+
+internal class BoundHistogramMetricSdk<T: SignedNumeric & Comparable>: BoundHistogramMetricSdkBase<T> {
+    private var histogramAggregator: HistogramAggregator<T>
+
+    override init(boundaries: Array<T>) {
+        self.histogramAggregator = try! HistogramAggregator(boundaries: boundaries)
+        super.init(boundaries: boundaries)
+    }
+
+    override func record(value: T) {
+        histogramAggregator.update(value: value)
+    }
+
+    override func getAggregator() -> HistogramAggregator<T> {
+        return histogramAggregator
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/BoundHistogramMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundHistogramMetricSdkBase.swift
@@ -7,8 +7,8 @@ import Foundation
 import OpenTelemetryApi
 
 class BoundHistogramMetricSdkBase<T>: BoundHistogramMetric<T> {
-    override init(boundaries: Array<T>) {
-        super.init(boundaries: boundaries)
+    override init(explicitBoundaries: Array<T>? = nil) {
+        super.init(explicitBoundaries: explicitBoundaries)
     }
 
     func getAggregator() -> Aggregator<T> {

--- a/Sources/OpenTelemetrySdk/Metrics/BoundHistogramMetricSdkBase.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/BoundHistogramMetricSdkBase.swift
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+
+class BoundHistogramMetricSdkBase<T>: BoundHistogramMetric<T> {
+    override init(boundaries: Array<T>) {
+        super.init(boundaries: boundaries)
+    }
+
+    func getAggregator() -> Aggregator<T> {
+        fatalError()
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/AggregationType.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/AggregationType.swift
@@ -12,4 +12,6 @@ public enum AggregationType {
     case intSum
     case doubleSummary
     case intSummary
+    case doubleHistogram
+    case intHistogram
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Export/MetricData.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/MetricData.swift
@@ -33,3 +33,15 @@ public struct SummaryData<T>: MetricData {
     public var min: T
     public var max: T
 }
+
+public struct HistogramData<T>: MetricData {
+    public var startTimestamp: Date
+    public var timestamp: Date
+    public var labels: [String: String] = [String: String]()
+    public var buckets: (
+      boundaries: Array<T>,
+      counts: Array<Int>
+    )
+    public var count: Int
+    public var sum: T
+}

--- a/Sources/OpenTelemetrySdk/Metrics/HistogramMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/HistogramMetricSdk.swift
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+
+internal class HistogramMetricSdk<T: SignedNumeric & Comparable>: HistogramMetric {
+    public private(set) var boundInstruments = [LabelSet: BoundHistogramMetricSdkBase<T>]()
+    let metricName: String
+    let boundaries: Array<T>
+
+    init(name: String, boundaries: Array<T>) {
+        metricName = name
+        self.boundaries = boundaries
+    }
+
+    func bind(labelset: LabelSet) -> BoundHistogramMetric<T> {
+        var boundInstrument = boundInstruments[labelset]
+        if boundInstrument == nil {
+            boundInstrument = createMetric()
+            boundInstruments[labelset] = boundInstrument!
+        }
+        return boundInstrument!
+    }
+
+    func bind(labels: [String: String]) -> BoundHistogramMetric<T> {
+        return bind(labelset: LabelSet(labels: labels))
+    }
+
+    func createMetric() -> BoundHistogramMetricSdkBase<T> {
+        return BoundHistogramMetricSdk<T>(boundaries: boundaries)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/HistogramMetricSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/HistogramMetricSdk.swift
@@ -9,11 +9,11 @@ import OpenTelemetryApi
 internal class HistogramMetricSdk<T: SignedNumeric & Comparable>: HistogramMetric {
     public private(set) var boundInstruments = [LabelSet: BoundHistogramMetricSdkBase<T>]()
     let metricName: String
-    let boundaries: Array<T>
+    let explicitBoundaries: Array<T>?
 
-    init(name: String, boundaries: Array<T>) {
+    init(name: String, explicitBoundaries: Array<T>? = nil) {
         metricName = name
-        self.boundaries = boundaries
+        self.explicitBoundaries = explicitBoundaries
     }
 
     func bind(labelset: LabelSet) -> BoundHistogramMetric<T> {
@@ -30,6 +30,6 @@ internal class HistogramMetricSdk<T: SignedNumeric & Comparable>: HistogramMetri
     }
 
     func createMetric() -> BoundHistogramMetricSdkBase<T> {
-        return BoundHistogramMetricSdk<T>(boundaries: boundaries)
+        return BoundHistogramMetricSdk<T>(explicitBoundaries: explicitBoundaries)
     }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
@@ -19,6 +19,8 @@ class MeterSdk: Meter {
     var doubleCounters = [String: CounterMetricSdk<Double>]()
     var intMeasures = [String: MeasureMetricSdk<Int>]()
     var doubleMeasures = [String: MeasureMetricSdk<Double>]()
+    var intHistogram = [String: HistogramMetricSdk<Int>]()
+    var doubleHistogram = [String: HistogramMetricSdk<Double>]()
     var intObservers = [String: IntObserverMetricSdk]()
     var doubleObservers = [String: DoubleObserverMetricSdk]()
 
@@ -127,6 +129,36 @@ class MeterSdk: Meter {
                 let metricName = measure.key
                 let measureInstrument = measure.value
                 var metric = Metric(namespace: meterName, name: metricName, desc: meterName + metricName, type: AggregationType.doubleSummary, resource: resource, instrumentationLibraryInfo: instrumentationLibraryInfo)
+                measureInstrument.boundInstruments.forEach { boundInstrument in
+                    let labelSet = boundInstrument.key
+                    let aggregator = boundInstrument.value.getAggregator()
+                    aggregator.checkpoint()
+                    var metricData = aggregator.toMetricData()
+                    metricData.labels = labelSet.labels
+                    metric.data.append(metricData)
+                }
+                metricProcessor.process(metric: metric)
+            }
+            
+            intHistogram.forEach { histogram in
+                let metricName = histogram.key
+                let measureInstrument = histogram.value
+                var metric = Metric(namespace: meterName, name: metricName, desc: meterName + metricName, type: AggregationType.intHistogram, resource: resource, instrumentationLibraryInfo: instrumentationLibraryInfo)
+                measureInstrument.boundInstruments.forEach { boundInstrument in
+                    let labelSet = boundInstrument.key
+                    let aggregator = boundInstrument.value.getAggregator()
+                    aggregator.checkpoint()
+                    var metricData = aggregator.toMetricData()
+                    metricData.labels = labelSet.labels
+                    metric.data.append(metricData)
+                }
+                metricProcessor.process(metric: metric)
+            }
+            
+            doubleHistogram.forEach { histogram in
+                let metricName = histogram.key
+                let measureInstrument = histogram.value
+                var metric = Metric(namespace: meterName, name: metricName, desc: meterName + metricName, type: AggregationType.doubleHistogram, resource: resource, instrumentationLibraryInfo: instrumentationLibraryInfo)
                 measureInstrument.boundInstruments.forEach { boundInstrument in
                     let labelSet = boundInstrument.key
                     let aggregator = boundInstrument.value.getAggregator()
@@ -280,6 +312,29 @@ class MeterSdk: Meter {
         }
         return AnyMeasureMetric<Double>(measure!)
     }
+    
+    func createIntHistogram(name: String, boundaries: Array<Int>, absolute: Bool) -> AnyHistogramMetric<Int> {
+        var histogram = intHistogram[name]
+        if histogram == nil {
+            histogram = HistogramMetricSdk<Int>(name: name, boundaries: boundaries)
+            collectLock.withLockVoid {
+                intHistogram[name] = histogram!
+            }
+        }
+        return AnyHistogramMetric<Int>(histogram!)
+    }
+    
+    func createDoubleHistogram(name: String, boundaries: Array<Double>, absolute: Bool) -> AnyHistogramMetric<Double> {
+        var histogram = doubleHistogram[name]
+        if histogram == nil {
+            histogram = HistogramMetricSdk<Double>(name: name, boundaries: boundaries)
+            collectLock.withLockVoid {
+                doubleHistogram[name] = histogram!
+            }
+        }
+        return AnyHistogramMetric<Double>(histogram!)
+    }
+    
 
     func createIntObserver(name: String, absolute _: Bool, callback: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
         var observer = intObservers[name]

--- a/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
@@ -313,10 +313,10 @@ class MeterSdk: Meter {
         return AnyMeasureMetric<Double>(measure!)
     }
     
-    func createIntHistogram(name: String, boundaries: Array<Int>, absolute: Bool) -> AnyHistogramMetric<Int> {
+    func createIntHistogram(name: String, explicitBoundaries: Array<Int>? = nil, absolute: Bool) -> AnyHistogramMetric<Int> {
         var histogram = intHistogram[name]
         if histogram == nil {
-            histogram = HistogramMetricSdk<Int>(name: name, boundaries: boundaries)
+            histogram = HistogramMetricSdk<Int>(name: name, explicitBoundaries: explicitBoundaries)
             collectLock.withLockVoid {
                 intHistogram[name] = histogram!
             }
@@ -324,10 +324,10 @@ class MeterSdk: Meter {
         return AnyHistogramMetric<Int>(histogram!)
     }
     
-    func createDoubleHistogram(name: String, boundaries: Array<Double>, absolute: Bool) -> AnyHistogramMetric<Double> {
+    func createDoubleHistogram(name: String, explicitBoundaries: Array<Double>? = nil, absolute: Bool) -> AnyHistogramMetric<Double> {
         var histogram = doubleHistogram[name]
         if histogram == nil {
-            histogram = HistogramMetricSdk<Double>(name: name, boundaries: boundaries)
+            histogram = HistogramMetricSdk<Double>(name: name, explicitBoundaries: explicitBoundaries)
             collectLock.withLockVoid {
                 doubleHistogram[name] = histogram!
             }

--- a/Tests/OpenTelemetryApiTests/Metrics/DefaultMeterProviderTests.swift
+++ b/Tests/OpenTelemetryApiTests/Metrics/DefaultMeterProviderTests.swift
@@ -80,6 +80,14 @@ class TestNoopMeter: Meter {
     func createDoubleMeasure(name _: String, absolute _: Bool) -> AnyMeasureMetric<Double> {
         return AnyMeasureMetric<Double>(NoopMeasureMetric<Double>())
     }
+    
+    func createIntHistogram(name: String, boundaries: Array<Int>, absolute: Bool) -> AnyHistogramMetric<Int> {
+        return AnyHistogramMetric<Int>(NoopHistogramMetric<Int>())
+    }
+    
+    func createDoubleHistogram(name: String, boundaries: Array<Double>, absolute: Bool) -> AnyHistogramMetric<Double> {
+        return AnyHistogramMetric<Double>(NoopHistogramMetric<Double>())
+    }
 
     func createIntObserver(name _: String, absolute _: Bool, callback _: @escaping (IntObserverMetric) -> Void) -> IntObserverMetric {
         return NoopIntObserverMetric()

--- a/Tests/OpenTelemetryApiTests/Metrics/DefaultMeterProviderTests.swift
+++ b/Tests/OpenTelemetryApiTests/Metrics/DefaultMeterProviderTests.swift
@@ -81,11 +81,11 @@ class TestNoopMeter: Meter {
         return AnyMeasureMetric<Double>(NoopMeasureMetric<Double>())
     }
     
-    func createIntHistogram(name: String, boundaries: Array<Int>, absolute: Bool) -> AnyHistogramMetric<Int> {
+    func createIntHistogram(name: String, explicitBoundaries: Array<Int>? = nil, absolute: Bool) -> AnyHistogramMetric<Int> {
         return AnyHistogramMetric<Int>(NoopHistogramMetric<Int>())
     }
     
-    func createDoubleHistogram(name: String, boundaries: Array<Double>, absolute: Bool) -> AnyHistogramMetric<Double> {
+    func createDoubleHistogram(name: String, explicitBoundaries: Array<Double>? = nil, absolute: Bool) -> AnyHistogramMetric<Double> {
         return AnyHistogramMetric<Double>(NoopHistogramMetric<Double>())
     }
 

--- a/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/HistogramAggregatorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/HistogramAggregatorTests.swift
@@ -8,23 +8,26 @@ import XCTest
 
 final class HistogramAggregatorTests: XCTestCase {
     public func testConstructedHistogramAggregator() {
-        XCTAssertNoThrow(try HistogramAggregator(boundaries: [5, 10, 25]))
+        XCTAssertNoThrow(try HistogramAggregator(explicitBoundaries: [5, 10, 25]))
     }
     
-    public func testThrowsWithNoBoundaries() {
-        let boundaries = [Int]()
-        XCTAssertThrowsError(try HistogramAggregator(boundaries: boundaries))
+    public func testUsesDefaultBoundariesWhenNotExplicit() {
+      let aggregator = try! HistogramAggregator<Int>()
+      let histogram = aggregator.toMetricData() as! HistogramData<Int>
+      
+      XCTAssertEqual([5, 10, 25, 50, 75, 100, 250, 500, 750, 1_000, 2_500, 5_000, 7_500,
+                      10_000], histogram.buckets.boundaries)
     }
     
     public func testSortsBoundaries() {
-        let aggregator = try! HistogramAggregator(boundaries: [100, 5, 10, 50, 25])
+        let aggregator = try! HistogramAggregator(explicitBoundaries: [100, 5, 10, 50, 25])
         let histogram = aggregator.toMetricData() as! HistogramData<Int>
         
         XCTAssertEqual([5, 10, 25, 50, 100], histogram.buckets.boundaries)
     }
     
     public func testUpdatesBucketsWithValue() {
-        let aggregator = try! HistogramAggregator(boundaries: [100, 200])
+        let aggregator = try! HistogramAggregator(explicitBoundaries: [100, 200])
         
         // Should start with 0 values
         var histogram = aggregator.toMetricData() as! HistogramData<Int>
@@ -64,7 +67,7 @@ final class HistogramAggregatorTests: XCTestCase {
     }
     
     public func testUpdatesCountSumWithValue() {
-        let aggregator = try! HistogramAggregator(boundaries: [100, 200])
+        let aggregator = try! HistogramAggregator(explicitBoundaries: [100, 200])
         
         // Should start with 0 values
         var histogram = aggregator.toMetricData() as! HistogramData<Int>

--- a/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/HistogramAggregatorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Aggregators/HistogramAggregatorTests.swift
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class HistogramAggregatorTests: XCTestCase {
+    public func testConstructedHistogramAggregator() {
+        XCTAssertNoThrow(try HistogramAggregator(boundaries: [5, 10, 25]))
+    }
+    
+    public func testThrowsWithNoBoundaries() {
+        let boundaries = [Int]()
+        XCTAssertThrowsError(try HistogramAggregator(boundaries: boundaries))
+    }
+    
+    public func testSortsBoundaries() {
+        let aggregator = try! HistogramAggregator(boundaries: [100, 5, 10, 50, 25])
+        let histogram = aggregator.toMetricData() as! HistogramData<Int>
+        
+        XCTAssertEqual([5, 10, 25, 50, 100], histogram.buckets.boundaries)
+    }
+    
+    public func testUpdatesBucketsWithValue() {
+        let aggregator = try! HistogramAggregator(boundaries: [100, 200])
+        
+        // Should start with 0 values
+        var histogram = aggregator.toMetricData() as! HistogramData<Int>
+        XCTAssertEqual(0, histogram.count)
+        
+        // Should update the second bucket
+        aggregator.update(value: 150)
+        aggregator.checkpoint()
+        histogram = aggregator.toMetricData() as! HistogramData<Int>
+        XCTAssertEqual(0, histogram.buckets.counts[0])
+        XCTAssertEqual(1, histogram.buckets.counts[1])
+        XCTAssertEqual(0, histogram.buckets.counts[2])
+        
+        // Should update the first bucket
+        aggregator.update(value: 1)
+        aggregator.checkpoint()
+        histogram = aggregator.toMetricData() as! HistogramData<Int>
+        XCTAssertEqual(1, histogram.buckets.counts[0])
+        XCTAssertEqual(0, histogram.buckets.counts[1])
+        XCTAssertEqual(0, histogram.buckets.counts[2])
+        
+        // Should update the third bucket for out of boundary value
+        aggregator.update(value: 1000)
+        aggregator.checkpoint()
+        histogram = aggregator.toMetricData() as! HistogramData<Int>
+        XCTAssertEqual(0, histogram.buckets.counts[0])
+        XCTAssertEqual(0, histogram.buckets.counts[1])
+        XCTAssertEqual(1, histogram.buckets.counts[2])
+        
+        // Should update the third bucket for boundary edge
+        aggregator.update(value: 200)
+        aggregator.checkpoint()
+        histogram = aggregator.toMetricData() as! HistogramData<Int>
+        XCTAssertEqual(0, histogram.buckets.counts[0])
+        XCTAssertEqual(0, histogram.buckets.counts[1])
+        XCTAssertEqual(1, histogram.buckets.counts[2])
+    }
+    
+    public func testUpdatesCountSumWithValue() {
+        let aggregator = try! HistogramAggregator(boundaries: [100, 200])
+        
+        // Should start with 0 values
+        var histogram = aggregator.toMetricData() as! HistogramData<Int>
+        XCTAssertEqual(0, histogram.count)
+        
+        // Updating 1 value
+        aggregator.update(value: 150)
+        aggregator.checkpoint()
+        histogram = aggregator.toMetricData() as! HistogramData<Int>
+        XCTAssertEqual(1, histogram.count)
+        XCTAssertEqual(150, histogram.sum)
+        
+        // Updating multiple values in different buckets
+        aggregator.update(value: 50)
+        aggregator.update(value: 100)
+        aggregator.update(value: 150)
+        aggregator.update(value: 200)
+        aggregator.checkpoint()
+        histogram = aggregator.toMetricData() as! HistogramData<Int>
+        XCTAssertEqual(4, histogram.count)
+        XCTAssertEqual(50 + 100 + 150 + 200, histogram.sum)
+    }
+}


### PR DESCRIPTION
One of the projects I've been working on has needed histogram metrics to capture latency distributions, so I've been working off of a fork where I added a histogram aggregator to support this. I tried to package this up to get included here so that others could also use histogram metrics if desired.

This adds support for a histogram metric that will sort recorded values into corresponding buckets. You can optionally pass in explicit bounds for the buckets, otherwise default them to standard bucket values. This is based off the implementations I followed in the js and java SDKs.

I was able to test this in my environment exporting from OTLP to a Otel-collector to verify that the metrics are exporting as expected. I haven't had the opportunity to test this with the other exporters available.