### PR TITLE
Datadog Exporter - Don't force the name in the encoder

### DIFF
--- a/Sources/Exporters/DatadogExporter/Spans/SpanEncoder.swift
+++ b/Sources/Exporters/DatadogExporter/Spans/SpanEncoder.swift
@@ -70,8 +70,8 @@ internal struct DDSpan: Encodable {
         self.spanID = spanData.spanId
         self.parentID = spanData.parentSpanId
 
-        if let testType = spanData.attributes["test.type"] {
-            self.name = "XCTest.\(testType.description)"
+        if let type = spanData.attributes["type"] {
+            self.name = spanData.name
         } else {
             self.name = spanData.name + "." + spanData.kind.rawValue
         }


### PR DESCRIPTION
Datadog exporter was setting a name depending on an attibute, avoid forcing it and use exact provided name when a custom "type" is set