### PR TITLE
fix env variables as per changes in the otel spec

### DIFF
--- a/Sources/OpenTelemetrySdk/Resources/EnvVarResource.swift
+++ b/Sources/OpenTelemetrySdk/Resources/EnvVarResource.swift
@@ -8,7 +8,7 @@ import OpenTelemetryApi
 
 /// Provides a framework for detection of resource information from the environment variable "OC_RESOURCE_LABELS".
 public struct EnvVarResource {
-    private static let otelResourceAttributesEnv = "OTEL_RESOURCE_ATTRIBUTES_ENV"
+    private static let otelResourceAttributesEnv = "OTEL_RESOURCE_ATTRIBUTES"
     private static let labelListSplitter = Character(",")
     private static let labelKeyValueSplitter = Character("=")
 

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -11,8 +11,8 @@ import OpenTelemetryApi
  */
 
 public struct EnvironmentContextPropagator: TextMapPropagator {
-    static let traceParent = "OTEL_TRACE_PARENT"
-    static let traceState = "OTEL_TRACE_STATE"
+    static let traceParent = "TRACEPARENT"
+    static let traceState = "TRACESTATE"
     let w3cPropagator = W3CTraceContextPropagator()
 
     public let fields: Set<String> = [traceState, traceParent]

--- a/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/SpanBuilderSdkTests.swift
@@ -238,7 +238,7 @@ class SpanBuilderSdkTest: XCTestCase {
     }
 
     func testParentEnvironmentContext() {
-        setenv("OTEL_TRACE_PARENT", "00-ff000000000000000000000000000041-ff00000000000041-01", 1)
+        setenv("TRACEPARENT", "00-ff000000000000000000000000000041-ff00000000000041-01", 1)
         let providerWithEnv = TracerProviderSdk()
         let tracerAux = providerWithEnv.get(instrumentationName: "SpanBuilderWithEnvTest")
         let parent = tracerAux.spanBuilder(spanName: spanName).setNoParent().setActive(true).startSpan()
@@ -247,7 +247,7 @@ class SpanBuilderSdkTest: XCTestCase {
         XCTAssertEqual(parent.context.traceId.hexString, "ff000000000000000000000000000041")
         span.end()
         parent.end()
-        unsetenv("OTEL_TRACE_PARENT")
+        unsetenv("TRACEPARENT")
     }
 
     func testParent_timestampConverter() {


### PR DESCRIPTION
1. Changed the env variable to OTEL_RESOURCE_ATTRIBUTES as per the spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable
2. Changing the environment variables to TRACEPARENT and TRACESTATE for inter-process propagation https://github.com/open-telemetry/opentelemetry-specification/issues/74