### PR TITLE
Update Resource Values with Semantic Attributes

### DIFF
--- a/Scripts/semantic-convention/templates/SemanticAttributes.swift.j2
+++ b/Scripts/semantic-convention/templates/SemanticAttributes.swift.j2
@@ -82,7 +82,7 @@ public enum {{enum}}: String {
         /**
         {{member.brief | to_doc_brief}}.
         */
-        static let {{ member.member_id | to_camelcase }} = {{class_name}}({{ print_value(type, member.value) }})
+        public static let {{ member.member_id | to_camelcase }} = {{class_name}}({{ print_value(type, member.value) }})
         {%- endfor %}
 
         internal let value: String

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/IOperatingSystemDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/IOperatingSystemDataSource.swift
@@ -8,4 +8,6 @@ import Foundation
 public protocol IOperatingSystemDataSource {
     var type: String { get }
     var description: String { get }
+    var name: String { get }
+    var version: String { get }
 }

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/OperatingSystemDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/OperatingSystemDataSource.swift
@@ -10,13 +10,18 @@
 #endif
 
 import Foundation
+import OpenTelemetrySdk
 
 public class OperatingSystemDataSource: IOperatingSystemDataSource {
     public var description: String {
-        ProcessInfo.processInfo.operatingSystemVersionString
+        name + " " + ProcessInfo.processInfo.operatingSystemVersionString
     }
 
     public var type: String {
+        ResourceAttributes.OsTypeValues.darwin.description
+    }
+    
+    public var name: String {
         #if os(watchOS)
             return "watchOS"
         #elseif os(macOS)
@@ -24,5 +29,10 @@ public class OperatingSystemDataSource: IOperatingSystemDataSource {
         #else
             return UIDevice.current.systemName
         #endif
+    }
+    
+    public var version: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
     }
 }

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
@@ -4,10 +4,11 @@
  */
 
 import Foundation
+import OpenTelemetrySdk
 
 public class TelemetryDataSource: ITelemetryDataSource {
     public var language: String {
-        "swift"
+        ResourceAttributes.TelemetrySdkLanguageValues.swift.description
     }
 
     public var name: String {

--- a/Sources/Instrumentation/SDKResourceExtension/DeviceResourceProvider.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DeviceResourceProvider.swift
@@ -19,12 +19,11 @@ public class DeviceResourceProvider: ResourceProvider {
         var attributes = [String: AttributeValue]()
 
         if let deviceModel = deviceSource.model {
-            // TODO: update with semantic convention when it is added to the OTel sdk.
-            attributes["device.model"] = AttributeValue.string(deviceModel)
+            attributes[ResourceAttributes.deviceModelIdentifier.rawValue] = AttributeValue.string(deviceModel)
         }
 
         if let deviceId = deviceSource.identifier {
-            attributes[ResourceAttributes.hostId.rawValue] = AttributeValue.string(deviceId)
+            attributes[ResourceAttributes.deviceId.rawValue] = AttributeValue.string(deviceId)
         }
 
         return attributes

--- a/Sources/Instrumentation/SDKResourceExtension/OSResourceProvider.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/OSResourceProvider.swift
@@ -17,8 +17,10 @@ public class OSResourceProvider: ResourceProvider {
     override public var attributes: [String: AttributeValue] {
         var attributes = [String: AttributeValue]()
 
-        attributes[ResourceAttributes.osType.rawValue] = AttributeValue.string(osDataSource.type)
-        attributes[ResourceAttributes.osDescription.rawValue] = AttributeValue.string(osDataSource.description)
+        attributes[ResourceAttributes.osType.rawValue] = .string(osDataSource.type)
+        attributes[ResourceAttributes.osName.rawValue] = .string(osDataSource.name)
+        attributes[ResourceAttributes.osDescription.rawValue] = .string(osDataSource.description)
+        attributes[ResourceAttributes.osVersion.rawValue] = .string(osDataSource.version)
 
         return attributes
     }

--- a/Sources/OpenTelemetryApi/Trace/SemanticAttributes.swift
+++ b/Sources/OpenTelemetryApi/Trace/SemanticAttributes.swift
@@ -1392,191 +1392,191 @@ public enum SemanticAttributes: String {
         /**
         Some other SQL database. Fallback only. See notes.
         */
-        static let otherSql = DbSystemValues("other_sql")
+        public static let otherSql = DbSystemValues("other_sql")
         /**
         Microsoft SQL Server.
         */
-        static let mssql = DbSystemValues("mssql")
+        public static let mssql = DbSystemValues("mssql")
         /**
         MySQL.
         */
-        static let mysql = DbSystemValues("mysql")
+        public static let mysql = DbSystemValues("mysql")
         /**
         Oracle Database.
         */
-        static let oracle = DbSystemValues("oracle")
+        public static let oracle = DbSystemValues("oracle")
         /**
         IBM Db2.
         */
-        static let db2 = DbSystemValues("db2")
+        public static let db2 = DbSystemValues("db2")
         /**
         PostgreSQL.
         */
-        static let postgresql = DbSystemValues("postgresql")
+        public static let postgresql = DbSystemValues("postgresql")
         /**
         Amazon Redshift.
         */
-        static let redshift = DbSystemValues("redshift")
+        public static let redshift = DbSystemValues("redshift")
         /**
         Apache Hive.
         */
-        static let hive = DbSystemValues("hive")
+        public static let hive = DbSystemValues("hive")
         /**
         Cloudscape.
         */
-        static let cloudscape = DbSystemValues("cloudscape")
+        public static let cloudscape = DbSystemValues("cloudscape")
         /**
         HyperSQL DataBase.
         */
-        static let hsqldb = DbSystemValues("hsqldb")
+        public static let hsqldb = DbSystemValues("hsqldb")
         /**
         Progress Database.
         */
-        static let progress = DbSystemValues("progress")
+        public static let progress = DbSystemValues("progress")
         /**
         SAP MaxDB.
         */
-        static let maxdb = DbSystemValues("maxdb")
+        public static let maxdb = DbSystemValues("maxdb")
         /**
         SAP HANA.
         */
-        static let hanadb = DbSystemValues("hanadb")
+        public static let hanadb = DbSystemValues("hanadb")
         /**
         Ingres.
         */
-        static let ingres = DbSystemValues("ingres")
+        public static let ingres = DbSystemValues("ingres")
         /**
         FirstSQL.
         */
-        static let firstsql = DbSystemValues("firstsql")
+        public static let firstsql = DbSystemValues("firstsql")
         /**
         EnterpriseDB.
         */
-        static let edb = DbSystemValues("edb")
+        public static let edb = DbSystemValues("edb")
         /**
         InterSystems Caché.
         */
-        static let cache = DbSystemValues("cache")
+        public static let cache = DbSystemValues("cache")
         /**
         Adabas (Adaptable Database System).
         */
-        static let adabas = DbSystemValues("adabas")
+        public static let adabas = DbSystemValues("adabas")
         /**
         Firebird.
         */
-        static let firebird = DbSystemValues("firebird")
+        public static let firebird = DbSystemValues("firebird")
         /**
         Apache Derby.
         */
-        static let derby = DbSystemValues("derby")
+        public static let derby = DbSystemValues("derby")
         /**
         FileMaker.
         */
-        static let filemaker = DbSystemValues("filemaker")
+        public static let filemaker = DbSystemValues("filemaker")
         /**
         Informix.
         */
-        static let informix = DbSystemValues("informix")
+        public static let informix = DbSystemValues("informix")
         /**
         InstantDB.
         */
-        static let instantdb = DbSystemValues("instantdb")
+        public static let instantdb = DbSystemValues("instantdb")
         /**
         InterBase.
         */
-        static let interbase = DbSystemValues("interbase")
+        public static let interbase = DbSystemValues("interbase")
         /**
         MariaDB.
         */
-        static let mariadb = DbSystemValues("mariadb")
+        public static let mariadb = DbSystemValues("mariadb")
         /**
         Netezza.
         */
-        static let netezza = DbSystemValues("netezza")
+        public static let netezza = DbSystemValues("netezza")
         /**
         Pervasive PSQL.
         */
-        static let pervasive = DbSystemValues("pervasive")
+        public static let pervasive = DbSystemValues("pervasive")
         /**
         PointBase.
         */
-        static let pointbase = DbSystemValues("pointbase")
+        public static let pointbase = DbSystemValues("pointbase")
         /**
         SQLite.
         */
-        static let sqlite = DbSystemValues("sqlite")
+        public static let sqlite = DbSystemValues("sqlite")
         /**
         Sybase.
         */
-        static let sybase = DbSystemValues("sybase")
+        public static let sybase = DbSystemValues("sybase")
         /**
         Teradata.
         */
-        static let teradata = DbSystemValues("teradata")
+        public static let teradata = DbSystemValues("teradata")
         /**
         Vertica.
         */
-        static let vertica = DbSystemValues("vertica")
+        public static let vertica = DbSystemValues("vertica")
         /**
         H2.
         */
-        static let h2 = DbSystemValues("h2")
+        public static let h2 = DbSystemValues("h2")
         /**
         ColdFusion IMQ.
         */
-        static let coldfusion = DbSystemValues("coldfusion")
+        public static let coldfusion = DbSystemValues("coldfusion")
         /**
         Apache Cassandra.
         */
-        static let cassandra = DbSystemValues("cassandra")
+        public static let cassandra = DbSystemValues("cassandra")
         /**
         Apache HBase.
         */
-        static let hbase = DbSystemValues("hbase")
+        public static let hbase = DbSystemValues("hbase")
         /**
         MongoDB.
         */
-        static let mongodb = DbSystemValues("mongodb")
+        public static let mongodb = DbSystemValues("mongodb")
         /**
         Redis.
         */
-        static let redis = DbSystemValues("redis")
+        public static let redis = DbSystemValues("redis")
         /**
         Couchbase.
         */
-        static let couchbase = DbSystemValues("couchbase")
+        public static let couchbase = DbSystemValues("couchbase")
         /**
         CouchDB.
         */
-        static let couchdb = DbSystemValues("couchdb")
+        public static let couchdb = DbSystemValues("couchdb")
         /**
         Microsoft Azure Cosmos DB.
         */
-        static let cosmosdb = DbSystemValues("cosmosdb")
+        public static let cosmosdb = DbSystemValues("cosmosdb")
         /**
         Amazon DynamoDB.
         */
-        static let dynamodb = DbSystemValues("dynamodb")
+        public static let dynamodb = DbSystemValues("dynamodb")
         /**
         Neo4j.
         */
-        static let neo4j = DbSystemValues("neo4j")
+        public static let neo4j = DbSystemValues("neo4j")
         /**
         Apache Geode.
         */
-        static let geode = DbSystemValues("geode")
+        public static let geode = DbSystemValues("geode")
         /**
         Elasticsearch.
         */
-        static let elasticsearch = DbSystemValues("elasticsearch")
+        public static let elasticsearch = DbSystemValues("elasticsearch")
         /**
         Memcached.
         */
-        static let memcached = DbSystemValues("memcached")
+        public static let memcached = DbSystemValues("memcached")
         /**
         CockroachDB.
         */
-        static let cockroachdb = DbSystemValues("cockroachdb")
+        public static let cockroachdb = DbSystemValues("cockroachdb")
 
         internal let value: String
 
@@ -1706,15 +1706,15 @@ public enum SemanticAttributes: String {
         /**
         When a new object is created.
         */
-        static let insert = FaasDocumentOperationValues("insert")
+        public static let insert = FaasDocumentOperationValues("insert")
         /**
         When an object is modified.
         */
-        static let edit = FaasDocumentOperationValues("edit")
+        public static let edit = FaasDocumentOperationValues("edit")
         /**
         When an object is deleted.
         */
-        static let delete = FaasDocumentOperationValues("delete")
+        public static let delete = FaasDocumentOperationValues("delete")
 
         internal let value: String
 
@@ -1734,23 +1734,23 @@ public enum SemanticAttributes: String {
         /**
         HTTP 1.0.
         */
-        static let http10 = HttpFlavorValues("1.0")
+        public static let http10 = HttpFlavorValues("1.0")
         /**
         HTTP 1.1.
         */
-        static let http11 = HttpFlavorValues("1.1")
+        public static let http11 = HttpFlavorValues("1.1")
         /**
         HTTP 2.
         */
-        static let http20 = HttpFlavorValues("2.0")
+        public static let http20 = HttpFlavorValues("2.0")
         /**
         SPDY protocol.
         */
-        static let spdy = HttpFlavorValues("SPDY")
+        public static let spdy = HttpFlavorValues("SPDY")
         /**
         QUIC protocol.
         */
-        static let quic = HttpFlavorValues("QUIC")
+        public static let quic = HttpFlavorValues("QUIC")
 
         internal let value: String
 
@@ -1770,23 +1770,23 @@ public enum SemanticAttributes: String {
         /**
         wifi.
         */
-        static let wifi = NetHostConnectionTypeValues("wifi")
+        public static let wifi = NetHostConnectionTypeValues("wifi")
         /**
         wired.
         */
-        static let wired = NetHostConnectionTypeValues("wired")
+        public static let wired = NetHostConnectionTypeValues("wired")
         /**
         cell.
         */
-        static let cell = NetHostConnectionTypeValues("cell")
+        public static let cell = NetHostConnectionTypeValues("cell")
         /**
         unavailable.
         */
-        static let unavailable = NetHostConnectionTypeValues("unavailable")
+        public static let unavailable = NetHostConnectionTypeValues("unavailable")
         /**
         unknown.
         */
-        static let unknown = NetHostConnectionTypeValues("unknown")
+        public static let unknown = NetHostConnectionTypeValues("unknown")
 
         internal let value: String
 
@@ -1806,87 +1806,87 @@ public enum SemanticAttributes: String {
         /**
         GPRS.
         */
-        static let gprs = NetHostConnectionSubtypeValues("gprs")
+        public static let gprs = NetHostConnectionSubtypeValues("gprs")
         /**
         EDGE.
         */
-        static let edge = NetHostConnectionSubtypeValues("edge")
+        public static let edge = NetHostConnectionSubtypeValues("edge")
         /**
         UMTS.
         */
-        static let umts = NetHostConnectionSubtypeValues("umts")
+        public static let umts = NetHostConnectionSubtypeValues("umts")
         /**
         CDMA.
         */
-        static let cdma = NetHostConnectionSubtypeValues("cdma")
+        public static let cdma = NetHostConnectionSubtypeValues("cdma")
         /**
         EVDO Rel. 0.
         */
-        static let evdo0 = NetHostConnectionSubtypeValues("evdo_0")
+        public static let evdo0 = NetHostConnectionSubtypeValues("evdo_0")
         /**
         EVDO Rev. A.
         */
-        static let evdoA = NetHostConnectionSubtypeValues("evdo_a")
+        public static let evdoA = NetHostConnectionSubtypeValues("evdo_a")
         /**
         CDMA2000 1XRTT.
         */
-        static let cdma20001xrtt = NetHostConnectionSubtypeValues("cdma2000_1xrtt")
+        public static let cdma20001xrtt = NetHostConnectionSubtypeValues("cdma2000_1xrtt")
         /**
         HSDPA.
         */
-        static let hsdpa = NetHostConnectionSubtypeValues("hsdpa")
+        public static let hsdpa = NetHostConnectionSubtypeValues("hsdpa")
         /**
         HSUPA.
         */
-        static let hsupa = NetHostConnectionSubtypeValues("hsupa")
+        public static let hsupa = NetHostConnectionSubtypeValues("hsupa")
         /**
         HSPA.
         */
-        static let hspa = NetHostConnectionSubtypeValues("hspa")
+        public static let hspa = NetHostConnectionSubtypeValues("hspa")
         /**
         IDEN.
         */
-        static let iden = NetHostConnectionSubtypeValues("iden")
+        public static let iden = NetHostConnectionSubtypeValues("iden")
         /**
         EVDO Rev. B.
         */
-        static let evdoB = NetHostConnectionSubtypeValues("evdo_b")
+        public static let evdoB = NetHostConnectionSubtypeValues("evdo_b")
         /**
         LTE.
         */
-        static let lte = NetHostConnectionSubtypeValues("lte")
+        public static let lte = NetHostConnectionSubtypeValues("lte")
         /**
         EHRPD.
         */
-        static let ehrpd = NetHostConnectionSubtypeValues("ehrpd")
+        public static let ehrpd = NetHostConnectionSubtypeValues("ehrpd")
         /**
         HSPAP.
         */
-        static let hspap = NetHostConnectionSubtypeValues("hspap")
+        public static let hspap = NetHostConnectionSubtypeValues("hspap")
         /**
         GSM.
         */
-        static let gsm = NetHostConnectionSubtypeValues("gsm")
+        public static let gsm = NetHostConnectionSubtypeValues("gsm")
         /**
         TD-SCDMA.
         */
-        static let tdScdma = NetHostConnectionSubtypeValues("td_scdma")
+        public static let tdScdma = NetHostConnectionSubtypeValues("td_scdma")
         /**
         IWLAN.
         */
-        static let iwlan = NetHostConnectionSubtypeValues("iwlan")
+        public static let iwlan = NetHostConnectionSubtypeValues("iwlan")
         /**
         5G NR (New Radio).
         */
-        static let nr = NetHostConnectionSubtypeValues("nr")
+        public static let nr = NetHostConnectionSubtypeValues("nr")
         /**
         5G NRNSA (New Radio Non-Standalone).
         */
-        static let nrnsa = NetHostConnectionSubtypeValues("nrnsa")
+        public static let nrnsa = NetHostConnectionSubtypeValues("nrnsa")
         /**
         LTE CA.
         */
-        static let lteCa = NetHostConnectionSubtypeValues("lte_ca")
+        public static let lteCa = NetHostConnectionSubtypeValues("lte_ca")
 
         internal let value: String
 
@@ -1920,19 +1920,19 @@ public enum SemanticAttributes: String {
         /**
         Alibaba Cloud.
         */
-        static let alibabaCloud = FaasInvokedProviderValues("alibaba_cloud")
+        public static let alibabaCloud = FaasInvokedProviderValues("alibaba_cloud")
         /**
         Amazon Web Services.
         */
-        static let aws = FaasInvokedProviderValues("aws")
+        public static let aws = FaasInvokedProviderValues("aws")
         /**
         Microsoft Azure.
         */
-        static let azure = FaasInvokedProviderValues("azure")
+        public static let azure = FaasInvokedProviderValues("azure")
         /**
         Google Cloud Platform.
         */
-        static let gcp = FaasInvokedProviderValues("gcp")
+        public static let gcp = FaasInvokedProviderValues("gcp")
 
         internal let value: String
 

--- a/Sources/OpenTelemetrySdk/Resources/ResourceAttributes.swift
+++ b/Sources/OpenTelemetrySdk/Resources/ResourceAttributes.swift
@@ -936,19 +936,19 @@ public enum ResourceAttributes: String {
         /**
         Alibaba Cloud.
         */
-        static let alibabaCloud = CloudProviderValues("alibaba_cloud")
+        public static let alibabaCloud = CloudProviderValues("alibaba_cloud")
         /**
         Amazon Web Services.
         */
-        static let aws = CloudProviderValues("aws")
+        public static let aws = CloudProviderValues("aws")
         /**
         Microsoft Azure.
         */
-        static let azure = CloudProviderValues("azure")
+        public static let azure = CloudProviderValues("azure")
         /**
         Google Cloud Platform.
         */
-        static let gcp = CloudProviderValues("gcp")
+        public static let gcp = CloudProviderValues("gcp")
 
         internal let value: String
 
@@ -968,71 +968,71 @@ public enum ResourceAttributes: String {
         /**
         Alibaba Cloud Elastic Compute Service.
         */
-        static let alibabaCloudEcs = CloudPlatformValues("alibaba_cloud_ecs")
+        public static let alibabaCloudEcs = CloudPlatformValues("alibaba_cloud_ecs")
         /**
         Alibaba Cloud Function Compute.
         */
-        static let alibabaCloudFc = CloudPlatformValues("alibaba_cloud_fc")
+        public static let alibabaCloudFc = CloudPlatformValues("alibaba_cloud_fc")
         /**
         AWS Elastic Compute Cloud.
         */
-        static let awsEc2 = CloudPlatformValues("aws_ec2")
+        public static let awsEc2 = CloudPlatformValues("aws_ec2")
         /**
         AWS Elastic Container Service.
         */
-        static let awsEcs = CloudPlatformValues("aws_ecs")
+        public static let awsEcs = CloudPlatformValues("aws_ecs")
         /**
         AWS Elastic Kubernetes Service.
         */
-        static let awsEks = CloudPlatformValues("aws_eks")
+        public static let awsEks = CloudPlatformValues("aws_eks")
         /**
         AWS Lambda.
         */
-        static let awsLambda = CloudPlatformValues("aws_lambda")
+        public static let awsLambda = CloudPlatformValues("aws_lambda")
         /**
         AWS Elastic Beanstalk.
         */
-        static let awsElasticBeanstalk = CloudPlatformValues("aws_elastic_beanstalk")
+        public static let awsElasticBeanstalk = CloudPlatformValues("aws_elastic_beanstalk")
         /**
         Azure Virtual Machines.
         */
-        static let azureVm = CloudPlatformValues("azure_vm")
+        public static let azureVm = CloudPlatformValues("azure_vm")
         /**
         Azure Container Instances.
         */
-        static let azureContainerInstances = CloudPlatformValues("azure_container_instances")
+        public static let azureContainerInstances = CloudPlatformValues("azure_container_instances")
         /**
         Azure Kubernetes Service.
         */
-        static let azureAks = CloudPlatformValues("azure_aks")
+        public static let azureAks = CloudPlatformValues("azure_aks")
         /**
         Azure Functions.
         */
-        static let azureFunctions = CloudPlatformValues("azure_functions")
+        public static let azureFunctions = CloudPlatformValues("azure_functions")
         /**
         Azure App Service.
         */
-        static let azureAppService = CloudPlatformValues("azure_app_service")
+        public static let azureAppService = CloudPlatformValues("azure_app_service")
         /**
         Google Cloud Compute Engine (GCE).
         */
-        static let gcpComputeEngine = CloudPlatformValues("gcp_compute_engine")
+        public static let gcpComputeEngine = CloudPlatformValues("gcp_compute_engine")
         /**
         Google Cloud Run.
         */
-        static let gcpCloudRun = CloudPlatformValues("gcp_cloud_run")
+        public static let gcpCloudRun = CloudPlatformValues("gcp_cloud_run")
         /**
         Google Cloud Kubernetes Engine (GKE).
         */
-        static let gcpKubernetesEngine = CloudPlatformValues("gcp_kubernetes_engine")
+        public static let gcpKubernetesEngine = CloudPlatformValues("gcp_kubernetes_engine")
         /**
         Google Cloud Functions (GCF).
         */
-        static let gcpCloudFunctions = CloudPlatformValues("gcp_cloud_functions")
+        public static let gcpCloudFunctions = CloudPlatformValues("gcp_cloud_functions")
         /**
         Google Cloud App Engine (GAE).
         */
-        static let gcpAppEngine = CloudPlatformValues("gcp_app_engine")
+        public static let gcpAppEngine = CloudPlatformValues("gcp_app_engine")
 
         internal let value: String
 
@@ -1066,31 +1066,31 @@ public enum ResourceAttributes: String {
         /**
         AMD64.
         */
-        static let amd64 = HostArchValues("amd64")
+        public static let amd64 = HostArchValues("amd64")
         /**
         ARM32.
         */
-        static let arm32 = HostArchValues("arm32")
+        public static let arm32 = HostArchValues("arm32")
         /**
         ARM64.
         */
-        static let arm64 = HostArchValues("arm64")
+        public static let arm64 = HostArchValues("arm64")
         /**
         Itanium.
         */
-        static let ia64 = HostArchValues("ia64")
+        public static let ia64 = HostArchValues("ia64")
         /**
         32-bit PowerPC.
         */
-        static let ppc32 = HostArchValues("ppc32")
+        public static let ppc32 = HostArchValues("ppc32")
         /**
         64-bit PowerPC.
         */
-        static let ppc64 = HostArchValues("ppc64")
+        public static let ppc64 = HostArchValues("ppc64")
         /**
         32-bit x86.
         */
-        static let x86 = HostArchValues("x86")
+        public static let x86 = HostArchValues("x86")
 
         internal let value: String
 
@@ -1110,47 +1110,47 @@ public enum ResourceAttributes: String {
         /**
         Microsoft Windows.
         */
-        static let windows = OsTypeValues("windows")
+        public static let windows = OsTypeValues("windows")
         /**
         Linux.
         */
-        static let linux = OsTypeValues("linux")
+        public static let linux = OsTypeValues("linux")
         /**
         Apple Darwin.
         */
-        static let darwin = OsTypeValues("darwin")
+        public static let darwin = OsTypeValues("darwin")
         /**
         FreeBSD.
         */
-        static let freebsd = OsTypeValues("freebsd")
+        public static let freebsd = OsTypeValues("freebsd")
         /**
         NetBSD.
         */
-        static let netbsd = OsTypeValues("netbsd")
+        public static let netbsd = OsTypeValues("netbsd")
         /**
         OpenBSD.
         */
-        static let openbsd = OsTypeValues("openbsd")
+        public static let openbsd = OsTypeValues("openbsd")
         /**
         DragonFly BSD.
         */
-        static let dragonflybsd = OsTypeValues("dragonflybsd")
+        public static let dragonflybsd = OsTypeValues("dragonflybsd")
         /**
         HP-UX (Hewlett Packard Unix).
         */
-        static let hpux = OsTypeValues("hpux")
+        public static let hpux = OsTypeValues("hpux")
         /**
         AIX (Advanced Interactive eXecutive).
         */
-        static let aix = OsTypeValues("aix")
+        public static let aix = OsTypeValues("aix")
         /**
         Oracle Solaris.
         */
-        static let solaris = OsTypeValues("solaris")
+        public static let solaris = OsTypeValues("solaris")
         /**
         IBM z/OS.
         */
-        static let zOs = OsTypeValues("z_os")
+        public static let zOs = OsTypeValues("z_os")
 
         internal let value: String
 
@@ -1170,48 +1170,47 @@ public enum ResourceAttributes: String {
         /**
         cpp.
         */
-        static let cpp = TelemetrySdkLanguageValues("cpp")
+        public static let cpp = TelemetrySdkLanguageValues("cpp")
         /**
         dotnet.
         */
-        static let dotnet = TelemetrySdkLanguageValues("dotnet")
+        public static let dotnet = TelemetrySdkLanguageValues("dotnet")
         /**
         erlang.
         */
-        static let erlang = TelemetrySdkLanguageValues("erlang")
+        public static let erlang = TelemetrySdkLanguageValues("erlang")
         /**
         go.
         */
-        static let go = TelemetrySdkLanguageValues("go")
+        public static let go = TelemetrySdkLanguageValues("go")
         /**
         java.
         */
-        static let java = TelemetrySdkLanguageValues("java")
+        public static let java = TelemetrySdkLanguageValues("java")
         /**
         nodejs.
         */
-        static let nodejs = TelemetrySdkLanguageValues("nodejs")
+        public static let nodejs = TelemetrySdkLanguageValues("nodejs")
         /**
         php.
         */
-        static let php = TelemetrySdkLanguageValues("php")
+        public static let php = TelemetrySdkLanguageValues("php")
         /**
         python.
         */
-        static let python = TelemetrySdkLanguageValues("python")
+        public static let python = TelemetrySdkLanguageValues("python")
         /**
         ruby.
         */
-        static let ruby = TelemetrySdkLanguageValues("ruby")
+        public static let ruby = TelemetrySdkLanguageValues("ruby")
         /**
         webjs.
         */
-        static let webjs = TelemetrySdkLanguageValues("webjs")
+        public static let webjs = TelemetrySdkLanguageValues("webjs")
         /**
-         swift.
-         */
-        static let swift = TelemetrySdkLanguageValues("swift")
-
+        swift.
+        */
+        public static let swift = TelemetrySdkLanguageValues("swift")
 
         internal let value: String
 

--- a/Tests/InstrumentationTests/SDKResourceExtensionTests/DeviceResourceProviderTests.swift
+++ b/Tests/InstrumentationTests/SDKResourceExtensionTests/DeviceResourceProviderTests.swift
@@ -16,7 +16,7 @@ class DeviceResourceProviderTests: XCTestCase {
 
         let resource = provider.create()
 
-        XCTAssertEqual(mock.model, resource.attributes["device.model"]?.description)
-        XCTAssertEqual(mock.identifier, resource.attributes[ResourceAttributes.hostId.rawValue]?.description)
+        XCTAssertEqual(mock.model, resource.attributes[ResourceAttributes.deviceModelIdentifier.rawValue]?.description)
+        XCTAssertEqual(mock.identifier, resource.attributes[ResourceAttributes.deviceId.rawValue]?.description)
     }
 }

--- a/Tests/InstrumentationTests/SDKResourceExtensionTests/Mocks/MockOperatingSystemDataSource.swift
+++ b/Tests/InstrumentationTests/SDKResourceExtensionTests/Mocks/MockOperatingSystemDataSource.swift
@@ -9,9 +9,13 @@ import Foundation
 class MockOperatingSystemDataSource: IOperatingSystemDataSource {
     private(set) var type: String
     private(set) var description: String
+    private(set) var name: String
+    private(set) var version: String
 
-    init(type: String, description: String) {
+    init(type: String, description: String, name: String, version: String) {
         self.type = type
         self.description = description
+        self.name = name
+        self.version = version
     }
 }

--- a/Tests/InstrumentationTests/SDKResourceExtensionTests/OSResourceProviderTests.swift
+++ b/Tests/InstrumentationTests/SDKResourceExtensionTests/OSResourceProviderTests.swift
@@ -12,13 +12,18 @@ import XCTest
 
     class OSResourceProviderTests: XCTestCase {
         func testContents() {
-            let mock = MockOperatingSystemDataSource(type: "swift", description: "test version string")
+            let mock = MockOperatingSystemDataSource(
+                type: "darwin", description: "iOS Version 15.0 (Build 19A339)",
+                name: "iOS", version: "15.0.2"
+            )
             let provider = OSResourceProvider(source: mock)
 
             let resource = provider.create()
 
             XCTAssertEqual(mock.type, resource.attributes["os.type"]?.description)
             XCTAssertEqual(mock.description, resource.attributes["os.description"]?.description)
+            XCTAssertEqual(mock.version, resource.attributes["os.version"]?.description)
+            XCTAssertEqual(mock.name, resource.attributes["os.name"]?.description)
         }
     }
 


### PR DESCRIPTION
* Added extra parameters to resource attributes, as per the updated spec.
* Fixed bug where enum values were not public, and thus could not be used by clients.
* Addressed misuse of OS "type" which, as per spec, MUST be of type "darwin" for our clients.
* Used ResourceAttributes enum values, where possible, to avoid future bugs.
* Replaced use of hostId with the now correct deviceId.

Closes #274.