### PR TITLE
Make Metric and SpanData conform to Codable to support persisting them.

### DIFF
--- a/Sources/Exporters/Stdout/StdoutExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutExporter.swift
@@ -58,7 +58,7 @@ public class StdoutExporter: SpanExporter {
     public func shutdown() {}
 }
 
-private struct SpanExporterData: Encodable {
+private struct SpanExporterData {
     private let span: String
     private let traceId: String
     private let spanId: String
@@ -81,5 +81,94 @@ private struct SpanExporterData: Encodable {
         self.start = span.startTime
         self.duration = span.endTime.timeIntervalSince(span.startTime)
         self.attributes = span.attributes
+    }
+}
+
+extension SpanExporterData: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case span
+        case traceId
+        case spanId
+        case spanKind
+        case traceFlags
+        case traceState
+        case parentSpanId
+        case start
+        case duration
+        case attributes
+    }
+    
+    enum TraceFlagsCodingKeys: String, CodingKey {
+        case sampled
+    }
+    
+    enum TraceStateCodingKeys: String, CodingKey {
+        case entries
+    }
+    
+    enum TraceStateEntryCodingKeys: String, CodingKey {
+        case key
+        case value
+    }
+    
+    struct AttributesCodingKeys: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+        
+        init?(intValue: Int) {
+            self.stringValue = "\(intValue)"
+            self.intValue = intValue
+        }
+        
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+    }
+    
+    enum AttributeValueCodingKeys: String, CodingKey {
+        case description
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(span, forKey: .span)
+        try container.encode(traceId, forKey: .traceId)
+        try container.encode(spanId, forKey: .spanId)
+        try container.encode(spanKind, forKey: .spanKind)
+        
+        var traceFlagsContainer = container.nestedContainer(keyedBy: TraceFlagsCodingKeys.self, forKey: .traceFlags)
+        try traceFlagsContainer.encode(traceFlags.sampled, forKey: .sampled)
+        
+        var traceStateContainer = container.nestedContainer(keyedBy: TraceStateCodingKeys.self, forKey: .traceState)
+        var traceStateEntriesContainer = traceStateContainer.nestedUnkeyedContainer(forKey: .entries)
+        
+        try traceState.entries.forEach { entry in
+            var traceStateEntryContainer = traceStateEntriesContainer.nestedContainer(keyedBy: TraceStateEntryCodingKeys.self)
+            
+            try traceStateEntryContainer.encode(entry.key, forKey: .key)
+            try traceStateEntryContainer.encode(entry.value, forKey: .value)
+        }        
+        
+        try container.encodeIfPresent(parentSpanId, forKey: .parentSpanId)
+        try container.encode(start, forKey: .start)
+        try container.encode(duration, forKey: .duration)
+        
+        var attributesContainer = container.nestedContainer(keyedBy: AttributesCodingKeys.self, forKey: .attributes)
+        
+        try attributes.forEach { attribute in
+            
+            if let attributeValueCodingKey = AttributesCodingKeys(stringValue: attribute.key) {
+                var attributeValueContainer = attributesContainer.nestedContainer(keyedBy: AttributeValueCodingKeys.self, forKey: attributeValueCodingKey)
+                
+                try attributeValueContainer.encode(attribute.value.description, forKey: .description)
+            } else {
+                // this should never happen
+                let encodingContext = EncodingError.Context(codingPath: attributesContainer.codingPath,
+                                                            debugDescription: "Failed to create coding key")
+                
+                throw EncodingError.invalidValue(attribute, encodingContext)
+            }
+        }
     }
 }

--- a/Sources/OpenTelemetryApi/Common/AttributeValue.swift
+++ b/Sources/OpenTelemetryApi/Common/AttributeValue.swift
@@ -163,7 +163,7 @@ extension AttributeValue: Codable { }
 extension AttributeValue: Codable {
          
     public init(from decoder: Decoder) throws {
-        let explicitDecoded = AttributeValueExplicitCodable(from: decoder)
+        let explicitDecoded = try AttributeValueExplicitCodable(from: decoder)
         
         self = explicitDecoded.attributeValue
     }
@@ -171,7 +171,7 @@ extension AttributeValue: Codable {
     public func encode(to encoder: Encoder) throws {
         let explicitEncoded = AttributeValueExplicitCodable(attributeValue: self)
         
-        explicitEncoded.encode(to: encoder)
+        try explicitEncoded.encode(to: encoder)
     }
 }
 #endif

--- a/Sources/OpenTelemetryApi/Common/AttributeValue.swift
+++ b/Sources/OpenTelemetryApi/Common/AttributeValue.swift
@@ -61,13 +61,70 @@ public enum AttributeValue: Equatable, CustomStringConvertible, Hashable {
     }
 }
 
-extension AttributeValue: Encodable {
+// this explicit Codable implementation for AttributeValue will probably be redundant with Swift 5.5
+extension AttributeValue: Codable {
     enum CodingKeys: String, CodingKey {
-        case description
+        case string
+        case bool
+        case int
+        case double
+        case stringArray
+        case boolArray
+        case intArray
+        case doubleArray
+    }
+         
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+        guard container.allKeys.count == 1 else {
+            let context = DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Invalid number of keys found, expected one.")
+            throw DecodingError.typeMismatch(Status.self, context)
+        }
+
+        switch container.allKeys.first.unsafelyUnwrapped {
+        case .string:
+            self = .string(try container.decode(String.self, forKey: .string))
+        case .bool:
+            self = .bool(try container.decode(Bool.self, forKey: .bool))
+        case .int:
+            self = .int(try container.decode(Int.self, forKey: .int))
+        case .double:
+            self = .double(try container.decode(Double.self, forKey: .double))
+        case .stringArray:
+            self = .stringArray(try container.decode([String].self, forKey: .stringArray))
+        case .boolArray:
+            self = .boolArray(try container.decode([Bool].self, forKey: .boolArray))
+        case .intArray:
+            self = .intArray(try container.decode([Int].self, forKey: .intArray))
+        case .doubleArray:
+            self = .doubleArray(try container.decode([Double].self, forKey: .doubleArray))
+        }
     }
 
     public func encode(to encoder: Encoder) throws {
+        
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(description, forKey: .description)
+        
+        switch self {
+        case .string(let value):
+            try container.encode(value, forKey: .string)
+        case .bool(let value):
+            try container.encode(value, forKey: .bool)
+        case .int(let value):
+            try container.encode(value, forKey: .int)
+        case .double(let value):
+            try container.encode(value, forKey: .double)
+        case .stringArray(let value):
+            try container.encode(value, forKey: .stringArray)
+        case .boolArray(let value):
+            try container.encode(value, forKey: .boolArray)
+        case .intArray(let value):
+            try container.encode(value, forKey: .intArray)
+        case .doubleArray(let value):
+            try container.encode(value, forKey: .doubleArray)
+        }
     }
 }

--- a/Sources/OpenTelemetryApi/Trace/SpanContext.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanContext.swift
@@ -8,7 +8,7 @@ import Foundation
 /// A class that represents a span context. A span context contains the state that must propagate to
 /// child Spans and across process boundaries. It contains the identifiers race_id and span_id
 /// associated with the Span and a set of options.
-public struct SpanContext: Equatable, CustomStringConvertible, Hashable {
+public struct SpanContext: Equatable, CustomStringConvertible, Hashable, Codable {
     /// The trace identifier associated with this SpanContext
     public private(set) var traceId: TraceId
 

--- a/Sources/OpenTelemetryApi/Trace/SpanId.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanId.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// A struct that represents a span identifier. A valid span identifier is an 8-byte array with at
 /// least one non-zero byte.
-public struct SpanId: Equatable, Comparable, Hashable, CustomStringConvertible {
+public struct SpanId: Equatable, Comparable, Hashable, CustomStringConvertible, Codable {
     public static let size = 8
     public static let invalidId: UInt64 = 0
     public static let invalid = SpanId(id: invalidId)

--- a/Sources/OpenTelemetryApi/Trace/SpanKind.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanKind.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Type of span. Can be used to specify additional relationships between spans in addition to a
 /// parent/child relationship
-public enum SpanKind: String, Equatable {
+public enum SpanKind: String, Equatable, Codable {
     /// Default value. Indicates that the span is used internally.
     case `internal`
     /// ndicates that the span covers server-side handling of an RPC or other remote request.

--- a/Sources/OpenTelemetryApi/Trace/Status.swift
+++ b/Sources/OpenTelemetryApi/Trace/Status.swift
@@ -130,7 +130,7 @@ extension Status: Codable { }
 extension Status: Codable {
 
     public init(from decoder: Decoder) throws {
-        let explicitDecoded = StatusExplicitCodable(from: decoder)
+        let explicitDecoded = try StatusExplicitCodable(from: decoder)
         
         self = explicitDecoded.status
     }
@@ -138,7 +138,7 @@ extension Status: Codable {
     public func encode(to encoder: Encoder) throws {
         let explicitEncoded = StatusExplicitCodable(status: self)
         
-        explicitEncoded.encode(to: encoder)
+        try explicitEncoded.encode(to: encoder)
     }        
 }
 #endif

--- a/Sources/OpenTelemetryApi/Trace/TraceFlags.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceFlags.swift
@@ -8,7 +8,7 @@ import Foundation
 /// A struct that represents global trace options. These options are propagated to all child spans.
 /// These determine features such as whether a Span should be traced. It is
 /// implemented as a bitmask.
-public struct TraceFlags: Equatable, CustomStringConvertible {
+public struct TraceFlags: Equatable, CustomStringConvertible, Codable {
     /// Default options. Nothing set.
     private static let defaultOptions: UInt8 = 0
     /// Bit to represent whether trace is sampled or not.
@@ -86,16 +86,5 @@ public struct TraceFlags: Equatable, CustomStringConvertible {
 
     public var description: String {
         "TraceFlags{sampled=\(sampled)}"
-    }
-}
-
-extension TraceFlags: Encodable {
-    enum CodingKeys: String, CodingKey {
-        case sampled
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(sampled, forKey: .sampled)
     }
 }

--- a/Sources/OpenTelemetryApi/Trace/TraceId.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceId.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// A struct that represents a trace identifier. A valid trace identifier is a 16-byte array with at
 /// least one non-zero byte.
-public struct TraceId: Comparable, Hashable, CustomStringConvertible, Equatable {
+public struct TraceId: Comparable, Hashable, CustomStringConvertible, Equatable, Codable {
     public static let size = 16
     public static let invalidId: UInt64 = 0
     public static let invalid = TraceId()

--- a/Sources/OpenTelemetryApi/Trace/TraceState.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceState.swift
@@ -13,7 +13,7 @@ import Foundation
 /// forward slashes /.
 /// Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the
 /// range 0x20 to 0x7E) except comma , and =.
-public struct TraceState: Equatable {
+public struct TraceState: Equatable, Codable {
     private static let maxKeyValuePairs = 32
 
     public private(set) var entries = [Entry]()
@@ -78,7 +78,7 @@ public struct TraceState: Equatable {
     }
 
     /// Immutable key-value pair for TraceState
-    public struct Entry: Equatable, Encodable {
+    public struct Entry: Equatable, Codable {
         /// The key of the Entry
         public private(set) var key: String
 
@@ -97,16 +97,5 @@ public struct TraceState: Equatable {
             }
             return nil
         }
-    }
-}
-
-extension TraceState: Encodable {
-    enum CodingKeys: String, CodingKey {
-        case entries
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(entries, forKey: .entries)
     }
 }

--- a/Sources/OpenTelemetrySdk/Common/InstrumentationLibraryInfo.swift
+++ b/Sources/OpenTelemetrySdk/Common/InstrumentationLibraryInfo.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Holds information about the instrumentation library specified when creating an instance of
 /// TracerSdk using TracerProviderSdk.
-public struct InstrumentationLibraryInfo: Hashable {
+public struct InstrumentationLibraryInfo: Hashable, Codable {
     public private(set) var name: String = ""
     public private(set) var version: String?
 

--- a/Sources/OpenTelemetrySdk/Metrics/Export/AggregationType.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/AggregationType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public enum AggregationType {
+public enum AggregationType : String, Codable {
     case intGauge
     case doubleGauge
     case doubleSum

--- a/Sources/OpenTelemetrySdk/Metrics/Export/Metric.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/Metric.swift
@@ -23,3 +23,191 @@ public struct Metric {
         self.resource = resource
     }
 }
+
+extension Metric: Equatable {
+    private static func isEqual<T: Equatable>(type: T.Type, lhs: Any, rhs: Any) -> Bool {
+        guard let lhs = lhs as? T, let rhs = rhs as? T else { return false }
+
+        return lhs == rhs
+    }
+    
+    public static func == (lhs: Metric, rhs: Metric) -> Bool {
+        if lhs.namespace == rhs.namespace &&
+            lhs.resource == rhs.resource &&
+            lhs.instrumentationLibraryInfo == rhs.instrumentationLibraryInfo &&
+            lhs.name == rhs.name &&
+            lhs.description == rhs.description &&
+            lhs.aggregationType == rhs.aggregationType {
+            
+            switch lhs.aggregationType {
+            case .doubleGauge:
+                return isEqual(type: [SumData<Double>].self, lhs: lhs.data, rhs: rhs.data)
+            case .intGauge:
+                return isEqual(type: [SumData<Int>].self, lhs: lhs.data, rhs: rhs.data)
+            case .doubleSum:
+                return isEqual(type: [SumData<Double>].self, lhs: lhs.data, rhs: rhs.data)
+            case .doubleSummary:
+                return isEqual(type: [SummaryData<Double>].self, lhs: lhs.data, rhs: rhs.data)
+            case .intSum:
+                return isEqual(type: [SumData<Int>].self, lhs: lhs.data, rhs: rhs.data)
+            case .intSummary:
+                return isEqual(type: [SummaryData<Int>].self, lhs: lhs.data, rhs: rhs.data)
+            case .doubleHistogram:
+                return isEqual(type: [HistogramData<Double>].self, lhs: lhs.data, rhs: rhs.data)
+            case .intHistogram:
+                return isEqual(type: [HistogramData<Int>].self, lhs: lhs.data, rhs: rhs.data)
+            }
+            
+        }
+        
+        return false
+    }        
+}
+
+// explicit encoding & decoding implementation is needed in order to correctly
+// deduce the concrete type of `Metric.data`.
+extension Metric: Codable {
+    enum CodingKeys: String, CodingKey {
+        case namespace
+        case resource
+        case instrumentationLibraryInfo
+        case name
+        case description
+        case aggregationType
+        case data
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let namespace = try container.decode(String.self, forKey: .namespace)
+        let resource = try container.decode(Resource.self, forKey: .resource)
+        let instrumentationLibraryInfo = try container.decode(InstrumentationLibraryInfo.self, forKey: .instrumentationLibraryInfo)
+        let name = try container.decode(String.self, forKey: .name)
+        let description = try container.decode(String.self, forKey: .description)
+        let aggregationType = try container.decode(AggregationType.self, forKey: .aggregationType)
+        
+        self.init(namespace: namespace, name: name, desc: description, type: aggregationType, resource: resource, instrumentationLibraryInfo: instrumentationLibraryInfo)
+        
+        switch aggregationType {
+        case .doubleGauge:
+            data = try container.decode([SumData<Double>].self, forKey: .data)
+        case .intGauge:
+            data = try container.decode([SumData<Int>].self, forKey: .data)
+        case .doubleSum:
+            data = try container.decode([SumData<Double>].self, forKey: .data)
+        case .doubleSummary:
+            data = try container.decode([SummaryData<Double>].self, forKey: .data)
+        case .intSum:
+            data = try container.decode([SumData<Int>].self, forKey: .data)
+        case .intSummary:
+            data = try container.decode([SummaryData<Int>].self, forKey: .data)
+        case .doubleHistogram:
+            data = try container.decode([HistogramData<Double>].self, forKey: .data)
+        case .intHistogram:
+            data = try container.decode([HistogramData<Int>].self, forKey: .data)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(namespace, forKey: .namespace)
+        try container.encode(resource, forKey: .resource)
+        try container.encode(instrumentationLibraryInfo, forKey: .instrumentationLibraryInfo)
+        try container.encode(name, forKey: .name)
+        try container.encode(description, forKey: .description)
+        try container.encode(aggregationType, forKey: .aggregationType)
+        
+        switch aggregationType {
+        case .doubleGauge:
+            guard let gaugeData = data as? [SumData<Double>] else {
+                let encodingContext = EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Expected [SumData<Double>] type for doubleGauge aggregationType, but instead found \(type(of: data))"
+                )
+                
+                throw EncodingError.invalidValue(data, encodingContext)
+            }
+            
+            try container.encode(gaugeData, forKey: .data)
+        case .intGauge:
+            guard let gaugeData = data as? [SumData<Int>] else {
+                let encodingContext = EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Expected [SumData<Int>] type for intGauge aggregationType, but instead found \(type(of: data))"
+                )
+                
+                throw EncodingError.invalidValue(data, encodingContext)
+            }
+            
+            try container.encode(gaugeData, forKey: .data)
+        case .doubleSum:
+            guard let sumData = data as? [SumData<Double>] else {
+                let encodingContext = EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Expected [SumData<Double>] type for doubleSum aggregationType, but instead found \(type(of: data))"
+                )
+                
+                throw EncodingError.invalidValue(data, encodingContext)
+            }
+            
+            try container.encode(sumData, forKey: .data)
+        case .doubleSummary:
+            guard let summaryData = data as? [SummaryData<Double>] else {
+                let encodingContext = EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Expected [SummaryData<Double>] type for doubleSummary aggregationType, but instead found \(type(of: data))"
+                )
+                
+                throw EncodingError.invalidValue(data, encodingContext)
+            }
+            
+            try container.encode(summaryData, forKey: .data)
+        case .intSum:
+            guard let sumData = data as? [SumData<Int>] else {
+                let encodingContext = EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Expected [SumData<Int>] type for intSum aggregationType, but instead found \(type(of: data))"
+                )
+                
+                throw EncodingError.invalidValue(data, encodingContext)
+            }
+            
+            try container.encode(sumData, forKey: .data)
+        case .intSummary:
+            guard let summaryData = data as? [SummaryData<Int>] else {
+                let encodingContext = EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Expected [SummaryData<Int>] type for intSummary aggregationType, but instead found \(type(of: data))"
+                )
+                
+                throw EncodingError.invalidValue(data, encodingContext)
+            }
+            
+            try container.encode(summaryData, forKey: .data)
+        case .doubleHistogram:
+            guard let summaryData = data as? [HistogramData<Double>] else {
+                let encodingContext = EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Expected [HistogramData<Double>] type for doubleHistogram aggregationType, but instead found \(type(of: data))"
+                )
+                
+                throw EncodingError.invalidValue(data, encodingContext)
+            }
+            
+            try container.encode(summaryData, forKey: .data)
+        case .intHistogram:
+            guard let summaryData = data as? [HistogramData<Int>] else {
+                let encodingContext = EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Expected [HistogramData<Int>] type for intHistogram aggregationType, but instead found \(type(of: data))"
+                )
+                
+                throw EncodingError.invalidValue(data, encodingContext)
+            }
+            
+            try container.encode(summaryData, forKey: .data)
+        }
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Export/MetricData.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Export/MetricData.swift
@@ -45,3 +45,73 @@ public struct HistogramData<T>: MetricData {
     public var count: Int
     public var sum: T
 }
+
+extension NoopMetricData: Equatable, Codable {}
+
+extension SumData: Equatable where T: Equatable {}
+
+extension SumData: Codable where T: Codable {}
+
+extension SummaryData: Equatable where T: Equatable {}
+
+extension SummaryData: Codable where T: Codable {}
+
+extension HistogramData: Equatable where T: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.startTimestamp == rhs.startTimestamp &&
+            lhs.timestamp == rhs.timestamp &&
+            lhs.labels == rhs.labels &&
+            lhs.buckets.boundaries == rhs.buckets.boundaries &&
+            lhs.buckets.counts == rhs.buckets.counts &&
+            lhs.count == rhs.count &&
+            lhs.sum == rhs.sum
+    }
+}
+
+extension HistogramData: Codable where T: Codable {
+    enum CodingKeys: String, CodingKey {
+        case startTimestamp
+        case timestamp
+        case labels
+        case buckets
+        case count
+        case sum
+    }
+    
+    enum BucketsCodingKeys: String, CodingKey {
+        case boundaries
+        case counts        
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let startTimestamp = try container.decode(Date.self, forKey: .startTimestamp)
+        let timestamp = try container.decode(Date.self, forKey: .timestamp)
+        let labels = try container.decode([String: String].self, forKey: .labels)
+        
+        let bucketsContainer = try container.nestedContainer(keyedBy: BucketsCodingKeys.self, forKey: .buckets)
+        let bucketsBoundaries = try bucketsContainer.decode([T].self, forKey: .boundaries)
+        let bucketsCounts = try bucketsContainer.decode([Int].self, forKey: .counts)
+        
+        let count = try container.decode(Int.self, forKey: .count)
+        let sum = try container.decode(T.self, forKey: .sum)
+        
+        self.init(startTimestamp: startTimestamp, timestamp: timestamp, labels: labels, buckets: (boundaries: bucketsBoundaries, counts: bucketsCounts), count: count, sum: sum)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(startTimestamp, forKey: .startTimestamp)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(labels, forKey: .labels)
+        
+        var bucketsCountainer = container.nestedContainer(keyedBy: BucketsCodingKeys.self, forKey: .buckets)
+        try bucketsCountainer.encode(buckets.boundaries, forKey: .boundaries)
+        try bucketsCountainer.encode(buckets.counts, forKey: .counts)
+        
+        try container.encode(count, forKey: .count)
+        try container.encode(sum, forKey: .sum)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Resources/Resource.swift
+++ b/Sources/OpenTelemetrySdk/Resources/Resource.swift
@@ -8,7 +8,7 @@ import OpenTelemetryApi
 
 /// Resource represents a resource, which capture identifying information about the entities
 /// for which signals (stats or traces) are reported.
-public struct Resource: Equatable, Hashable {
+public struct Resource: Equatable, Hashable, Codable {
     private static let maxLength = 255
 
     /// A dictionary of labels that describe the resource.

--- a/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
@@ -7,7 +7,7 @@ import Foundation
 import OpenTelemetryApi
 
 /// representation of all data collected by the Span.
-public struct SpanData: Equatable {
+public struct SpanData: Equatable, Codable {
     /// The trace id for this span.
     public private(set) var traceId: TraceId
 
@@ -195,7 +195,7 @@ public struct SpanData: Equatable {
 
 public extension SpanData {
     /// Timed event.
-    struct Event: Equatable {
+    struct Event: Equatable, Codable {
         public private(set) var timestamp: Date
         public private(set) var name: String
         public private(set) var attributes: [String: AttributeValue]
@@ -222,7 +222,7 @@ public extension SpanData {
 }
 
 public extension SpanData {
-    struct Link {
+    struct Link: Codable {
         public let context: SpanContext
         public let attributes: [String: AttributeValue]
 

--- a/Tests/OpenTelemetryApiTests/Common/AttributeValueTests.swift
+++ b/Tests/OpenTelemetryApiTests/Common/AttributeValueTests.swift
@@ -74,4 +74,81 @@ class AttributeValueTest: XCTestCase {
         attribute = AttributeValue.doubleArray([1.11, 0.01, -2.22])
         XCTAssertEqual(attribute.description, "[1.11, 0.01, -2.22]")
     }
+    
+    func testAttributeValue_Codable() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        var attribute = AttributeValue.string("")
+        var decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.string("MyStringAttributeValue")
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.bool(true)
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.int(123456)
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.int(0)
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.int(-123456)
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.double(1.23456)
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.double(0.0)
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.double(-1.23456)
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.stringArray([])
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.stringArray(["MyStringAttributeValue1", "MyStringAttributeValue2"])
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.boolArray([])
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.boolArray([true, false])
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.intArray([])
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.intArray([1, 3, 2])
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.doubleArray([])
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        attribute = AttributeValue.doubleArray([1.11, 0.01, -2.22])
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute, decodedAttribute)
+        
+        XCTAssertThrowsError(try decoder.decode(AttributeValue.self, from: "".data(using: .utf8)!))
+        XCTAssertThrowsError(try decoder.decode(AttributeValue.self,
+                                                from: #"{"string":"MyStringAttributeValue", "int":1234}"#.data(using: .utf8)!))
+    }
 }

--- a/Tests/OpenTelemetryApiTests/Common/AttributeValueTests.swift
+++ b/Tests/OpenTelemetryApiTests/Common/AttributeValueTests.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import OpenTelemetryApi
+@testable import OpenTelemetryApi
 import XCTest
 
 class AttributeValueTest: XCTestCase {
@@ -149,6 +149,87 @@ class AttributeValueTest: XCTestCase {
         
         XCTAssertThrowsError(try decoder.decode(AttributeValue.self, from: "".data(using: .utf8)!))
         XCTAssertThrowsError(try decoder.decode(AttributeValue.self,
-                                                from: #"{"string":"MyStringAttributeValue", "int":1234}"#.data(using: .utf8)!))
+                                                from: #"{"string":{"_0":"MyStringAttributeValue"}, "int":{"_0":1234}}"#.data(using: .utf8)!))
     }
+    
+    #if swift(>=5.5)
+    // this test covers forward compatibility of the pre swift 5.5 encoding with post swift 5.5 decoding
+    func testAttributeValue_ExplicitCodableForwardCompatibility() throws {
+        
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        var attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.string(""))
+        var decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+        
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.string("MyStringAttributeValue"))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.bool(true))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.int(123456))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.int(0))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.int(-123456))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.double(1.23456))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.double(0.0))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.double(-1.23456))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.stringArray([]))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.stringArray(["MyStringAttributeValue1", "MyStringAttributeValue2"]))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.boolArray([]))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.boolArray([true, false]))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.intArray([]))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.intArray([1, 3, 2]))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.doubleArray([]))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        attribute = AttributeValueExplicitCodable(attributeValue: AttributeValue.doubleArray([1.11, 0.01, -2.22]))
+        decodedAttribute = try decoder.decode(AttributeValue.self, from: try encoder.encode(attribute))
+        XCTAssertEqual(attribute.attributeValue, decodedAttribute)
+
+        XCTAssertThrowsError(try decoder.decode(AttributeValueExplicitCodable.self, from: "".data(using: .utf8)!))
+        XCTAssertThrowsError(try decoder.decode(AttributeValueExplicitCodable.self,
+                                                from: #"{"string":{"_0":"MyStringAttributeValue"}, "int":{"_0":1234}}"#.data(using: .utf8)!))
+    }
+    #endif
 }

--- a/Tests/OpenTelemetryApiTests/Trace/SpanContextTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/SpanContextTests.swift
@@ -95,4 +95,13 @@ final class SpanContextTests: XCTestCase {
         XCTAssert(second.description.contains(SpanId(fromBytes: secondSpanIdBytes).description))
         XCTAssert(second.description.contains(TraceFlags().settingIsSampled(true).description))
     }
+    
+    func testSpanContext_Codable() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        XCTAssertEqual(first, try decoder.decode(SpanContext.self, from: try encoder.encode(first)))
+        XCTAssertEqual(second, try decoder.decode(SpanContext.self, from: try encoder.encode(second)))
+        XCTAssertEqual(remote, try decoder.decode(SpanContext.self, from: try encoder.encode(remote)))
+    }
 }

--- a/Tests/OpenTelemetryApiTests/Trace/SpanIdTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/SpanIdTests.swift
@@ -48,7 +48,7 @@ final class SpanIdTests: XCTestCase {
         XCTAssertEqual(first, SpanId(fromBytes: firstBytes))
     }
 
-    func testTraceId_EqualsAndHashCode() {
+    func testSpanId_EqualsAndHashCode() {
         XCTAssertEqual(SpanId.invalid, SpanId.invalid)
         XCTAssertNotEqual(SpanId.invalid, first)
         XCTAssertNotEqual(SpanId.invalid, SpanId(fromBytes: firstBytes))
@@ -60,10 +60,19 @@ final class SpanIdTests: XCTestCase {
         XCTAssertEqual(second, SpanId(fromBytes: secondBytes))
     }
 
-    func testTraceId_ToString() {
+    func testSpanId_ToString() {
         XCTAssertTrue(SpanId.invalid.description.contains("0000000000000000"))
         XCTAssertTrue(first.description.contains("0000000000000061"))
         XCTAssertTrue(second.description.contains("ff00000000000041"))
+    }
+    
+    func testSpanId_Codable() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        XCTAssertEqual(SpanId.invalid, try decoder.decode(SpanId.self, from: try encoder.encode(SpanId.invalid)))
+        XCTAssertEqual(first, try decoder.decode(SpanId.self, from: try encoder.encode(first)))
+        XCTAssertEqual(second, try decoder.decode(SpanId.self, from: try encoder.encode(second)))
     }
 
     static var allTests = [
@@ -72,7 +81,8 @@ final class SpanIdTests: XCTestCase {
         ("testToHexString", testToHexString),
         ("testToHexString", testToHexString),
         ("testSpanId_CompareTo", testSpanId_CompareTo),
-        ("testTraceId_EqualsAndHashCode", testTraceId_EqualsAndHashCode),
-        ("testTraceId_ToString", testTraceId_ToString),
+        ("testSpanId_EqualsAndHashCode", testSpanId_EqualsAndHashCode),
+        ("testSpanId_ToString", testSpanId_ToString),
+        ("testSpanId_Codable", testSpanId_Codable),
     ]
 }

--- a/Tests/OpenTelemetryApiTests/Trace/StatusTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/StatusTests.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import OpenTelemetryApi
+@testable import OpenTelemetryApi
 import XCTest
 
 final class StatusTests: XCTestCase {
@@ -49,4 +49,32 @@ final class StatusTests: XCTestCase {
         XCTAssertThrowsError(try decoder.decode(Status.self,
                                                 from: #"{"error":{"description":"Error"}, "ok":{}}"#.data(using: .utf8)!))
     }
+    
+    #if swift(>=5.5)
+    // this test covers forward compatibility of the pre swift 5.5 encoding with post swift 5.5 decoding
+    func testStatusExplicitCodableForwardCompatibility() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        var status = StatusExplicitCodable(status: Status.ok)
+        var decodedStatus = try decoder.decode(Status.self, from: try encoder.encode(status))
+        XCTAssertEqual(status.status, decodedStatus)
+        
+        status = StatusExplicitCodable(status: Status.unset)
+        decodedStatus = try decoder.decode(Status.self, from: try encoder.encode(status))
+        XCTAssertEqual(status.status, decodedStatus)
+        
+        status = StatusExplicitCodable(status: Status.error(description: "Error"))
+        decodedStatus = try decoder.decode(Status.self, from: try encoder.encode(status))
+        XCTAssertEqual(status.status, decodedStatus)
+        
+        status = StatusExplicitCodable(status: Status.error(description: ""))
+        decodedStatus = try decoder.decode(Status.self, from: try encoder.encode(status))
+        XCTAssertEqual(status.status, decodedStatus)
+        
+        XCTAssertThrowsError(try decoder.decode(StatusExplicitCodable.self, from: "".data(using: .utf8)!))
+        XCTAssertThrowsError(try decoder.decode(StatusExplicitCodable.self,
+                                                from: #"{"error":{"description":"Error"}, "ok":{}}"#.data(using: .utf8)!))
+    }
+    #endif
 }

--- a/Tests/OpenTelemetryApiTests/Trace/StatusTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/StatusTests.swift
@@ -24,4 +24,29 @@ final class StatusTests: XCTestCase {
         let statusError = Status.error(description: "Error")
         XCTAssertTrue(statusError.isError)
     }
+    
+    func testStatusCodable() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        var status = Status.ok
+        var decodedStatus = try decoder.decode(Status.self, from: try encoder.encode(status))
+        XCTAssertEqual(status, decodedStatus)
+        
+        status = Status.unset
+        decodedStatus = try decoder.decode(Status.self, from: try encoder.encode(status))
+        XCTAssertEqual(status, decodedStatus)
+        
+        status = Status.error(description: "Error")
+        decodedStatus = try decoder.decode(Status.self, from: try encoder.encode(status))
+        XCTAssertEqual(status, decodedStatus)
+        
+        status = Status.error(description: "")
+        decodedStatus = try decoder.decode(Status.self, from: try encoder.encode(status))
+        XCTAssertEqual(status, decodedStatus)
+        
+        XCTAssertThrowsError(try decoder.decode(Status.self, from: "".data(using: .utf8)!))
+        XCTAssertThrowsError(try decoder.decode(Status.self,
+                                                from: #"{"error":{"description":"Error"}, "ok":{}}"#.data(using: .utf8)!))
+    }
 }

--- a/Tests/OpenTelemetryApiTests/Trace/TraceFlagsTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/TraceFlagsTests.swift
@@ -54,4 +54,27 @@ final class TraceFlagsTests: XCTestCase {
         XCTAssert(TraceFlags().description.contains("sampled=false"))
         XCTAssert(TraceFlags().settingIsSampled(true).description.contains("sampled=true"))
     }
+    
+    func testTraceFlags_Codabe() {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        var traceFlags = TraceFlags()
+        XCTAssertEqual(traceFlags, try decoder.decode(TraceFlags.self, from: try encoder.encode(traceFlags)))
+        
+        traceFlags = TraceFlags().settingIsSampled(true)
+        XCTAssertEqual(traceFlags, try decoder.decode(TraceFlags.self, from: try encoder.encode(traceFlags)))
+        
+        traceFlags = TraceFlags().settingIsSampled(false)
+        XCTAssertEqual(traceFlags, try decoder.decode(TraceFlags.self, from: try encoder.encode(traceFlags)))
+        
+        traceFlags = TraceFlags(fromByte: firstByte)
+        XCTAssertEqual(traceFlags, try decoder.decode(TraceFlags.self, from: try encoder.encode(traceFlags)))
+        
+        traceFlags = TraceFlags(fromByte: secondByte)
+        XCTAssertEqual(traceFlags, try decoder.decode(TraceFlags.self, from: try encoder.encode(traceFlags)))
+        
+        traceFlags = TraceFlags(fromByte: thirdByte)
+        XCTAssertEqual(traceFlags, try decoder.decode(TraceFlags.self, from: try encoder.encode(traceFlags)))
+    }
 }

--- a/Tests/OpenTelemetryApiTests/Trace/TraceIdTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/TraceIdTests.swift
@@ -94,6 +94,16 @@ final class TraceIdTests: XCTestCase {
         XCTAssertTrue(second.description.contains("ff000000000000000000000000000041"))
         XCTAssertTrue(short.description.contains("0000000000000062"))
     }
+    
+    func testTraceId_Codable() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        XCTAssertEqual(TraceId.invalid, try decoder.decode(TraceId.self, from: try encoder.encode(TraceId.invalid)))
+        XCTAssertEqual(first, try decoder.decode(TraceId.self, from: try encoder.encode(first)))
+        XCTAssertEqual(second, try decoder.decode(TraceId.self, from: try encoder.encode(second)))
+        XCTAssertEqual(short, try decoder.decode(TraceId.self, from: try encoder.encode(short)))
+    }
 
     static var allTests = [
         ("testInvalidTraceId", testInvalidTraceId),
@@ -106,5 +116,6 @@ final class TraceIdTests: XCTestCase {
         ("testTraceId_CompareTo", testTraceId_CompareTo),
         ("testTraceId_EqualsAndHashCode", testTraceId_EqualsAndHashCode),
         ("testTraceId_ToString", testTraceId_ToString),
+        ("testTraceId_Codable", testTraceId_Codable),
     ]
 }

--- a/Tests/OpenTelemetryApiTests/Trace/TracestateTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/TracestateTests.swift
@@ -149,6 +149,16 @@ final class TraceStateTests: XCTestCase {
     func testTraceState_ToString() {
         XCTAssertEqual("\(TraceState())", "TraceState(entries: [])")
     }
+    
+    func testTraceState_Codable() {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        XCTAssertEqual(empty, try decoder.decode(TraceState.self, from: try encoder.encode(empty)))
+        XCTAssertEqual(firstTraceState, try decoder.decode(TraceState.self, from: try encoder.encode(firstTraceState)))
+        XCTAssertEqual(secondTraceState, try decoder.decode(TraceState.self, from: try encoder.encode(secondTraceState)))
+        XCTAssertEqual(multiValueTraceState, try decoder.decode(TraceState.self, from: try encoder.encode(multiValueTraceState)))
+    }
 
     static var allTests = [
         ("testGet", testGet),
@@ -174,5 +184,6 @@ final class TraceStateTests: XCTestCase {
         ("testAddAndRemoveEntry", testAddAndRemoveEntry),
         ("testTraceState_EqualsAndHashCode", testTraceState_EqualsAndHashCode),
         ("testTraceState_ToString", testTraceState_ToString),
+        ("testTraceState_Codable", testTraceState_Codable),
     ]
 }

--- a/Tests/OpenTelemetrySdkTests/Metrics/MetricCodableTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/MetricCodableTests.swift
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+
+class MetricCodableTests: XCTestCase {
+    let library = InstrumentationLibraryInfo(name: "lib", version: "semver:0.0.0")
+    let resource = Resource(attributes: ["string": .string("string"),
+                                         "int": .int(5),
+                                         "bool": .bool(true),
+                                         "stringArray": .stringArray(["string1", "string2"]),
+                                         "intArray": .intArray([1, 2, 3]),
+                                         "boolArray": .boolArray([true, false])])
+    
+    private func generateDoubleSumMetric() -> Metric {
+        var metric = Metric(namespace: "namespace", name: "metric", desc: "description", type: .doubleSum, resource: resource, instrumentationLibraryInfo: library)
+        let data = SumData<Double>(startTimestamp: Date(), timestamp: Date(), labels: ["hello": "world"], sum: 1.5)
+        metric.data.append(data)
+        return metric
+    }
+    
+    private func generateIntSumMetric() -> Metric {
+        var metric = Metric(namespace: "namespace", name: "metric", desc: "description", type: .intSum, resource: resource, instrumentationLibraryInfo: library)
+        let data = SumData<Int>(startTimestamp: Date(), timestamp: Date(), labels: ["hello": "world"], sum: 1)
+        metric.data.append(data)
+        return metric
+    }
+    
+    private func generateDoubleSummaryMetric() -> Metric {
+        var metric = Metric(namespace: "namespace", name: "metric", desc: "description", type: .doubleSummary, resource: resource, instrumentationLibraryInfo: library)
+        let data = SummaryData<Double>(startTimestamp: Date(), timestamp: Date(), labels: ["hello": "world"], count: 2, sum: 2.0, min: 0.5, max: 1.5)
+        metric.data.append(data)
+        return metric
+    }
+    
+    private func generateIntSummaryMetric() -> Metric {
+        var metric = Metric(namespace: "namespace", name: "metric", desc: "description", type: .intSummary, resource: resource, instrumentationLibraryInfo: library)
+        let data = SummaryData<Int>(startTimestamp: Date(), timestamp: Date(), labels: ["hello": "world"], count:2, sum: 3, min: 1, max: 2)
+        metric.data.append(data)
+        return metric
+    }
+
+    private func generateDoubleGaugeMetric() -> Metric {
+        var metric = Metric(namespace: "namespace", name: "MyGauge", desc: "description", type: .doubleGauge, resource: Resource(), instrumentationLibraryInfo: library)
+        let data = SumData<Double>(startTimestamp: Date(), timestamp: Date(), labels: ["hello": "world"], sum: 100.5)
+        metric.data.append(data)
+        return metric
+    }
+    
+    private func generateIntGaugeMetric() -> Metric {
+        var metric = Metric(namespace: "namespace", name: "MyGauge", desc: "description", type: .intGauge, resource: resource, instrumentationLibraryInfo: library)
+        let data = SumData<Int>(startTimestamp: Date(), timestamp: Date(), labels: ["hello": "world"], sum: 100)
+        metric.data.append(data)
+        return metric
+    }
+    
+    private func generateDoubleHistogramMetric() -> Metric {
+        var metric = Metric(namespace: "namespace", name: "MyHistogram", desc: "description", type: .doubleHistogram, resource: Resource(), instrumentationLibraryInfo: library)
+        let data = HistogramData<Double>(startTimestamp: Date(), timestamp: Date(), labels: ["hello": "world"], buckets: (boundaries: [45.25, 55.25], counts: [5, 6]), count:2, sum: 100.5)
+        metric.data.append(data)
+        return metric
+    }
+    
+    private func generateIntHistogramMetric() -> Metric {
+        var metric = Metric(namespace: "namespace", name: "MyHistogram", desc: "description", type: .intHistogram, resource: Resource(), instrumentationLibraryInfo: library)
+        let data = HistogramData<Int>(startTimestamp: Date(), timestamp: Date(), labels: ["hello": "world"], buckets: (boundaries: [45, 55], counts: [5, 6]), count:2, sum: 100)
+        metric.data.append(data)
+        return metric
+    }
+    
+    func testCodable() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        var testData = generateIntSumMetric()
+        XCTAssertEqual(testData, try decoder.decode(Metric.self, from: try encoder.encode(testData)))
+        
+        testData = generateDoubleSumMetric()
+        XCTAssertEqual(testData, try decoder.decode(Metric.self, from: try encoder.encode(testData)))
+        
+        testData = generateIntSummaryMetric()
+        XCTAssertEqual(testData, try decoder.decode(Metric.self, from: try encoder.encode(testData)))
+        
+        testData = generateDoubleSummaryMetric()
+        XCTAssertEqual(testData, try decoder.decode(Metric.self, from: try encoder.encode(testData)))
+        
+        testData = generateIntGaugeMetric()
+        XCTAssertEqual(testData, try decoder.decode(Metric.self, from: try encoder.encode(testData)))
+        
+        testData = generateDoubleGaugeMetric()
+        XCTAssertEqual(testData, try decoder.decode(Metric.self, from: try encoder.encode(testData)))
+        
+        testData = generateDoubleHistogramMetric()
+        XCTAssertEqual(testData, try decoder.decode(Metric.self, from: try encoder.encode(testData)))
+        
+        testData = generateIntHistogramMetric()
+        XCTAssertEqual(testData, try decoder.decode(Metric.self, from: try encoder.encode(testData)))
+    }
+}

--- a/Tests/OpenTelemetrySdkTests/Trace/Data/SpanDataTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Data/SpanDataTests.swift
@@ -34,4 +34,39 @@ class SpanDataTests: XCTestCase {
                         endTime: endTime,
                         hasRemoteParent: false)
     }
+    
+    func testSpanDataCodable() {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        var testData = createBasicSpan()
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+        
+        testData.settingHasEnded(false)
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+        
+        testData.settingAttributes(["key": AttributeValue.bool(true)])
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+        
+        testData.settingTotalAttributeCount(2)
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+        
+        testData.settingEvents([SpanData.Event(name: "my_event", timestamp: Date(timeIntervalSince1970: 12347))])
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+        
+        testData.settingTotalRecordedEvents(3)
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+ 
+        let traceId = TraceId(fromBytes: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4])
+        let spanId = SpanId(fromBytes: [0, 0, 0, 0, 4, 3, 2, 1])
+        let spanContext = SpanContext.create(traceId: traceId, spanId: spanId, traceFlags: TraceFlags(), traceState: TraceState())
+        testData.settingLinks([SpanData.Link(context: spanContext)])
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+        
+        testData.settingTotalRecordedLinks(2)
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+        
+        testData.settingStatus(.ok)
+        XCTAssertEqual(testData, try decoder.decode(SpanData.self, from: try encoder.encode(testData)))
+    }
 }


### PR DESCRIPTION
This submission is making `Metric` and `SpanData` conform to `Codable` in order to allow them to be persisted. Being able to persist signals' data is required to support use cases where signals may collected when there is no network connectivity, and so they have to be exported later - possibly after the process was terminated and relaunched - when network connectivity is back.

The core of the change is making `Metric` and `SpanData` conform to the `Codable` protocol. To that end all the types `Metric` and `SpanData` depend on were made `Codable` as well. 

Most of the types could simply have the `Codable` protocol implementation synthesized. However there were several cases where an explicit implementation was required:

1. `Metric` - explicit encoding & decoding logic was required to deduce the concrete type of `Metric.data` by `Metric.aggregationType`
2. `AttributeValue` - enum with associated values
3. `Status` - enum with associated values
4. `HistogramData` - has a tuple type member
5. Conflict with existing Encodable implementation used specifically in StdoutExporter. In this case an explicit Encodable implementation was written for `SpanExporterData`.

Tests were added to cover the encoding & decoding code, and corresponding Equatable conformance for `Metric` that was required for tests verification was added.