### PR TITLE
Fix startTime of span.

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -44,10 +44,9 @@ public class RecordEventsReadableSpan: ReadableSpan {
     public private(set) var clock: Clock
     /// The resource associated with this span.
     public private(set) var resource: Resource
-    /// The start time of the span.
     /// instrumentation library of the named tracer which created this span
     public private(set) var instrumentationLibraryInfo: InstrumentationLibraryInfo
-    /// The resource associated with this span.
+    /// The start time of the span.
     public private(set) var startTime: Date
     /// Set of recorded attributes. DO NOT CALL any other method that changes the ordering of events.
     private var attributes: AttributesDictionary
@@ -132,7 +131,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
     ///   - attributes: the attributes set during span creation.
     ///   - links: the links set during span creation, may be truncated.
     ///   - totalRecordedLinks: the total number of links set (including dropped links).
-    ///   - startTime: the time for the new span.
+    ///   - startTime: the time for the new span, if not set it will use assigned Clock time
     public static func startSpan(context: SpanContext,
                                  name: String,
                                  instrumentationLibraryInfo: InstrumentationLibraryInfo,

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -146,7 +146,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
                                  attributes: AttributesDictionary,
                                  links: [SpanData.Link],
                                  totalRecordedLinks: Int,
-                                 startTime: Date) -> RecordEventsReadableSpan
+                                 startTime: Date?) -> RecordEventsReadableSpan
     {
         let span = RecordEventsReadableSpan(context: context,
                                             name: name,

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
@@ -33,7 +33,7 @@ class SpanBuilderSdk: SpanBuilder {
 
     private var startAsActive: Bool = false
 
-    private var startTime = Date()
+    private var startTime: Date?
 
     init(spanName: String,
          instrumentationLibraryInfo: InstrumentationLibraryInfo,


### PR DESCRIPTION
SpanBuilderSDK's startTime was being initialised with current system time, this was forcing this value to be used as the startTime when the RecordEventsReadableSpan was initialised. This was causing two big issues:
- The start time was set when the spanBuilder was created, not when the span was really started
- If the user decided to use an external clock, it would only be used for the end time, not for the start time. Which would make the duration to be always wrong