### PR TITLE
Simplifies Persistence and Datadog exporter queue logic

### DIFF
--- a/Sources/Exporters/DatadogExporter/Logs/LogEncoder.swift
+++ b/Sources/Exporters/DatadogExporter/Logs/LogEncoder.swift
@@ -16,7 +16,7 @@ internal struct LogAttributes {
 
 /// `Encodable` representation of log. It gets sanitized before encoding.
 internal struct DDLog: Encodable {
-    internal struct TracingAttributes {
+    internal enum TracingAttributes {
         static let traceID = "dd.trace_id"
         static let spanID = "dd.span_id"
     }
@@ -80,7 +80,7 @@ internal struct DDLog: Encodable {
         self.threadName = attributes.removeValue(forKey: "threadName")?.description ?? "unkown"
         self.applicationVersion = configuration.version
 
-        let userAttributes:  [String: Encodable] = attributes.mapValues{
+        let userAttributes: [String: Encodable] = attributes.mapValues {
             switch $0 {
                 case let .string(value):
                     return value

--- a/Sources/Exporters/DatadogExporter/Logs/LogSanitizer.swift
+++ b/Sources/Exporters/DatadogExporter/Logs/LogSanitizer.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Sanitizes `Log` representation received from the user, so it can match Datadog log constraints.
 internal struct LogSanitizer {
-    struct Constraints {
+    enum Constraints {
         /// Attribute names reserved for Datadog.
         /// If any of those is used by the user, the attribute will be ignored.
         static let reservedAttributeNames: Set<String> = [
@@ -23,7 +23,7 @@ internal struct LogSanitizer {
         static let maxNumberOfAttributes: Int = 256
         /// Allowed first character of a tag name (given as ASCII values ranging from lowercased `a` to `z`) .
         /// Tags with name starting with different character will be dropped.
-        static let allowedTagNameFirstCharacterASCIIRange: [UInt8] = Array(97...122)
+        static let allowedTagNameFirstCharacterASCIIRange: [UInt8] = Array(97 ... 122)
         /// Maximum lenght of the tag.
         /// Tags exceeting this lenght will be trunkated.
         static let maxTagLength: Int = 200

--- a/Sources/Exporters/DatadogExporter/Logs/LogsExporter.swift
+++ b/Sources/Exporters/DatadogExporter/Logs/LogsExporter.swift
@@ -17,14 +17,9 @@ internal enum LogLevel: Int, Codable {
 
 internal class LogsExporter {
     let logsDirectory = "com.otel.datadog.logs/v1"
-
     let configuration: ExporterConfiguration
-
     let logsStorage: FeatureStorage
-    let logsStorageQueue = DispatchQueue(label: "com.otel.datadog.logswriter", target: .global(qos: .userInteractive))
-
     let logsUpload: FeatureUpload
-    let logsUploadQueue = DispatchQueue(label: "com.otel.datadog.logsupload", target: .global(qos: .userInteractive))
 
     init(config: ExporterConfiguration) throws {
         self.configuration = config
@@ -39,14 +34,12 @@ internal class LogsExporter {
 
         let logsFileWriter = FileWriter(
             dataFormat: dataFormat,
-            orchestrator: filesOrchestrator,
-            queue: logsStorageQueue
+            orchestrator: filesOrchestrator
         )
 
         let logsFileReader = FileReader(
             dataFormat: dataFormat,
-            orchestrator: filesOrchestrator,
-            queue: logsUploadQueue
+            orchestrator: filesOrchestrator
         )
 
         logsStorage = FeatureStorage(writer: logsFileWriter, reader: logsFileReader)
@@ -68,7 +61,6 @@ internal class LogsExporter {
                 .ddEVPOriginVersionHeader(version: configuration.version),
                 .ddRequestIDHeader()
             ] + (configuration.payloadCompression ? [RequestBuilder.HTTPHeader.contentEncodingHeader(contentEncoding: .deflate)] : [])
-
         )
 
         logsUpload = FeatureUpload(featureName: "logsUpload",

--- a/Sources/Exporters/DatadogExporter/Metrics/MetricsExporter.swift
+++ b/Sources/Exporters/DatadogExporter/Metrics/MetricsExporter.swift
@@ -8,14 +8,9 @@ import OpenTelemetrySdk
 
 internal class MetricsExporter {
     let metricsDirectory = "com.otel.datadog.metrics/v1"
-
     let configuration: ExporterConfiguration
-
     let metricsStorage: FeatureStorage
-    let metricsStorageQueue = DispatchQueue(label: "com.otel.datadog.metricswriter", target: .global(qos: .userInteractive))
-
     let metricsUpload: FeatureUpload
-    let metricsUploadQueue = DispatchQueue(label: "com.otel.datadog.metricsupload", target: .global(qos: .userInteractive))
 
     init(config: ExporterConfiguration) throws {
         configuration = config
@@ -30,14 +25,12 @@ internal class MetricsExporter {
 
         let spanFileWriter = FileWriter(
             dataFormat: dataFormat,
-            orchestrator: filesOrchestrator,
-            queue: metricsStorageQueue
+            orchestrator: filesOrchestrator
         )
 
         let spanFileReader = FileReader(
             dataFormat: dataFormat,
-            orchestrator: filesOrchestrator,
-            queue: metricsUploadQueue
+            orchestrator: filesOrchestrator
         )
 
         metricsStorage = FeatureStorage(writer: spanFileWriter, reader: spanFileReader)

--- a/Sources/Exporters/DatadogExporter/Persistence/FileReader.swift
+++ b/Sources/Exporters/DatadogExporter/Persistence/FileReader.swift
@@ -17,16 +17,12 @@ internal final class FileReader {
     private let dataFormat: DataFormat
     /// Orchestrator producing reference to readable file.
     private let orchestrator: FilesOrchestrator
-    /// Queue used to synchronize files access (read / write).
-    private let queue: DispatchQueue
-
     /// Files marked as read.
     private var filesRead: [ReadableFile] = []
 
-    init(dataFormat: DataFormat, orchestrator: FilesOrchestrator, queue: DispatchQueue) {
+    init(dataFormat: DataFormat, orchestrator: FilesOrchestrator) {
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
-        self.queue = queue
     }
 
     // MARK: - Reading batches

--- a/Sources/Exporters/DatadogExporter/Persistence/FileWriter.swift
+++ b/Sources/Exporters/DatadogExporter/Persistence/FileWriter.swift
@@ -13,17 +13,16 @@ internal final class FileWriter {
     /// JSON encoder used to encode data.
     private let jsonEncoder: JSONEncoder
     /// Queue used to synchronize files access (read / write) and perform decoding on background thread.
-    // Temporarily internal so tests can wait for the writer to finish before exiting
-    internal let queue: DispatchQueue
+    internal let queue = DispatchQueue(label: "com.otel.datadog.filewriter", target: .global(qos: .userInteractive))
 
-    init(dataFormat: DataFormat, orchestrator: FilesOrchestrator, queue: DispatchQueue) {
+    init(dataFormat: DataFormat, orchestrator: FilesOrchestrator) {
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
-        self.queue = queue
         self.jsonEncoder = JSONEncoder.default()
     }
 
     // MARK: - Writing data
+
     /// Encodes given value to JSON data and writes it to file.
     /// Comma is used to separate consecutive values in the file.
 

--- a/Sources/Exporters/DatadogExporter/Spans/SpansExporter.swift
+++ b/Sources/Exporters/DatadogExporter/Spans/SpansExporter.swift
@@ -8,14 +8,9 @@ import OpenTelemetrySdk
 
 internal class SpansExporter {
     let tracesDirectory = "com.otel.datadog.traces/v1"
-
     let configuration: ExporterConfiguration
-
     let tracesStorage: FeatureStorage
-    let tracesStorageQueue = DispatchQueue(label: "com.otel.datadog.traceswriter", target: .global(qos: .userInteractive))
-
     let tracesUpload: FeatureUpload
-    let tracesUploadQueue = DispatchQueue(label: "com.otel.datadog.tracesupload", target: .global(qos: .userInteractive))
 
     init(config: ExporterConfiguration) throws {
         self.configuration = config
@@ -30,14 +25,12 @@ internal class SpansExporter {
 
         let spanFileWriter = FileWriter(
             dataFormat: dataFormat,
-            orchestrator: filesOrchestrator,
-            queue: tracesStorageQueue
+            orchestrator: filesOrchestrator
         )
 
         let spanFileReader = FileReader(
             dataFormat: dataFormat,
-            orchestrator: filesOrchestrator,
-            queue: tracesUploadQueue
+            orchestrator: filesOrchestrator
         )
 
         tracesStorage = FeatureStorage(writer: spanFileWriter, reader: spanFileReader)

--- a/Sources/Exporters/DatadogExporter/Upload/DataUploadWorker.swift
+++ b/Sources/Exporters/DatadogExporter/Upload/DataUploadWorker.swift
@@ -13,7 +13,7 @@ internal protocol DataUploadWorkerType {
 
 internal class DataUploadWorker: DataUploadWorkerType {
     /// Queue to execute uploads.
-    private let queue: DispatchQueue
+    internal let queue = DispatchQueue(label: "com.otel.datadog.datauploadworker", target: .global(qos: .utility))
     /// File reader providing data to upload.
     private let fileReader: FileReader
     /// Data uploader sending data to server.
@@ -31,14 +31,12 @@ internal class DataUploadWorker: DataUploadWorkerType {
     private var uploadWork: DispatchWorkItem?
 
     init(
-        queue: DispatchQueue,
         fileReader: FileReader,
         dataUploader: DataUploaderType,
         uploadCondition: @escaping () -> Bool,
         delay: Delay,
         featureName: String
     ) {
-        self.queue = queue
         self.fileReader = fileReader
         self.uploadCondition = uploadCondition
         self.dataUploader = dataUploader

--- a/Sources/Exporters/DatadogExporter/Utils/Feature.swift
+++ b/Sources/Exporters/DatadogExporter/Utils/Feature.swift
@@ -36,11 +36,6 @@ internal struct FeatureUpload {
         performance: PerformancePreset,
         uploadCondition: @escaping () -> Bool
     ) {
-        let uploadQueue = DispatchQueue(
-            label: "com.datadoghq.ios-sdk-\(featureName)-upload",
-            target: .global(qos: .utility)
-        )
-
         let dataUploader = DataUploader(
             httpClient: HTTPClient(),
             requestBuilder: requestBuilder
@@ -48,7 +43,6 @@ internal struct FeatureUpload {
 
         self.init(
             uploader: DataUploadWorker(
-                queue: uploadQueue,
                 fileReader: storage.reader,
                 dataUploader: dataUploader,
                 uploadCondition: uploadCondition,

--- a/Sources/Exporters/Persistence/Export/DataExportWorker.swift
+++ b/Sources/Exporters/Persistence/Export/DataExportWorker.swift
@@ -18,7 +18,7 @@ internal protocol DataExportWorkerProtocol {
 
 internal class DataExportWorker: DataExportWorkerProtocol {
     /// Queue to execute exports.
-    private let queue: DispatchQueue
+    internal let queue = DispatchQueue(label: "com.otel.datadog.dataExportWorker", target: .global(qos: .utility))
     /// File reader providing data to export.
     private let fileReader: FileReader
     /// Data exporter sending data to server.
@@ -33,13 +33,11 @@ internal class DataExportWorker: DataExportWorkerProtocol {
     private var exportWork: DispatchWorkItem?
 
     init(
-        queue: DispatchQueue,
         fileReader: FileReader,
         dataExporter: DataExporter,
         exportCondition: @escaping () -> Bool,
         delay: Delay
     ) {
-        self.queue = queue
         self.fileReader = fileReader
         self.exportCondition = exportCondition
         self.dataExporter = dataExporter
@@ -52,7 +50,7 @@ internal class DataExportWorker: DataExportWorkerProtocol {
 
             let isSystemReady = self.exportCondition()
             let nextBatch = isSystemReady ? self.fileReader.readNextBatch() : nil
-            if let batch = nextBatch {                
+            if let batch = nextBatch {
                 // Export batch
                 let exportStatus = self.dataExporter.export(data: batch.data)
 

--- a/Sources/Exporters/Persistence/PersistenceExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceExporterDecorator.swift
@@ -9,26 +9,23 @@ import OpenTelemetrySdk
 // protocol for exporters that can be decorated with `PersistenceExporterDecorator`
 protocol DecoratedExporter {
     associatedtype SignalType
-        
+
     func export(values: [SignalType]) -> DataExportStatus
 }
 
 // a generic decorator of `DecoratedExporter` adding filesystem persistence of batches of `[T.SignalType]`.
 // `T.SignalType` must conform to `Codable`.
 internal class PersistenceExporterDecorator<T> where T: DecoratedExporter, T.SignalType: Codable {
-    
     // a wrapper of `DecoratedExporter` (T) to add conformance to `DataExporter` that can be
     // used with `DataExportWorker`.
     private class DecoratedDataExporter: DataExporter {
-        
         private let decoratedExporter: T
-        
+
         init(decoratedExporter: T) {
             self.decoratedExporter = decoratedExporter
         }
-        
+
         func export(data: Data) -> DataExportStatus {
-            
             // decode batches of `[T.SignalType]` from the raw data.
             // the data is made of batches of comma-suffixed JSON arrays, so in order to utilize
             // `JSONDecoder`, add a "[" prefix and "null]" suffix making the data a valid
@@ -36,34 +33,32 @@ internal class PersistenceExporterDecorator<T> where T: DecoratedExporter, T.Sig
             var arrayData: Data = JSONDataConstants.arrayPrefix
             arrayData.append(data)
             arrayData.append(JSONDataConstants.arraySuffix)
-            
+
             do {
                 let decoder = JSONDecoder()
                 let exportables = try decoder.decode(
                     [[T.SignalType]?].self,
-                    from: arrayData).compactMap { $0 }.flatMap { $0 }
-                
+                    from: arrayData
+                ).compactMap { $0 }.flatMap { $0 }
+
                 return decoratedExporter.export(values: exportables)
             } catch {
                 return DataExportStatus(needsRetry: false)
             }
         }
     }
-    
+
     private let performancePreset: PersistencePerformancePreset
-    
+
     private let fileWriter: FileWriter
-    
+
     private let worker: DataExportWorkerProtocol
-    
+
     public convenience init(decoratedExporter: T,
                             storageURL: URL,
-                            writerQueue: DispatchQueue,
-                            readerQueue: DispatchQueue,
-                            exportQueue: DispatchQueue,
-                            exportCondition: @escaping () -> Bool,
-                            performancePreset: PersistencePerformancePreset = .default) {
-        
+                            exportCondition: @escaping () -> Bool = { true },
+                            performancePreset: PersistencePerformancePreset = .default)
+    {
         // orchestrate writes and reads over the folder given by `storageURL`
         let filesOrchestrator = FilesOrchestrator(
             directory: Directory(url: storageURL),
@@ -72,59 +67,58 @@ internal class PersistenceExporterDecorator<T> where T: DecoratedExporter, T.Sig
         )
 
         let fileWriter = OrchestratedFileWriter(
-            orchestrator: filesOrchestrator,
-            queue: writerQueue
+            orchestrator: filesOrchestrator
         )
 
         let fileReader = OrchestratedFileReader(
-            orchestrator: filesOrchestrator,
-            queue: readerQueue
+            orchestrator: filesOrchestrator
         )
-        
+
         self.init(decoratedExporter: decoratedExporter,
                   fileWriter: fileWriter,
                   workerFactory: {
-                    return DataExportWorker(
-                        queue: exportQueue,
-                        fileReader: fileReader,
-                        dataExporter: $0,
-                        exportCondition: exportCondition,
-                        delay: DataExportDelay(performance: performancePreset))
+                      DataExportWorker(
+                          fileReader: fileReader,
+                          dataExporter: $0,
+                          exportCondition: exportCondition,
+                          delay: DataExportDelay(performance: performancePreset)
+                      )
                   },
                   performancePreset: performancePreset)
     }
-    
+
     // internal initializer for testing that accepts a worker factory that allows mocking the worker
     internal init(decoratedExporter: T,
                   fileWriter: FileWriter,
                   workerFactory createWorker: (DataExporter) -> DataExportWorkerProtocol,
-                  performancePreset: PersistencePerformancePreset) {
+                  performancePreset: PersistencePerformancePreset)
+    {
         self.performancePreset = performancePreset
-        
+
         self.fileWriter = fileWriter
-        
+
         self.worker = createWorker(DecoratedDataExporter(decoratedExporter: decoratedExporter))
     }
-        
+
     public func export(values: [T.SignalType]) throws {
         let encoder = JSONEncoder()
         var data = try encoder.encode(values)
         data.append(JSONDataConstants.arraySeparator)
-                
-        if (performancePreset.synchronousWrite) {
+
+        if performancePreset.synchronousWrite {
             fileWriter.writeSync(data: data)
         } else {
             fileWriter.write(data: data)
         }
     }
-    
+
     public func flush() {
         fileWriter.flush()
         _ = worker.flush()
     }
 }
 
-fileprivate struct JSONDataConstants {
+private enum JSONDataConstants {
     static let arrayPrefix = "[".data(using: .utf8)!
     static let arraySuffix = "null]".data(using: .utf8)!
     static let arraySeparator = ",".data(using: .utf8)!

--- a/Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift
@@ -9,7 +9,6 @@ import OpenTelemetrySdk
 // a persistence exporter decorator for `Metric`.
 // specialization of `PersistenceExporterDecorator` for `MetricExporter`.
 public class PersistenceMetricExporterDecorator: MetricExporter {
-            
     struct MetricDecoratedExporter: DecoratedExporter {
         typealias SignalType = Metric
         
@@ -29,19 +28,13 @@ public class PersistenceMetricExporterDecorator: MetricExporter {
     
     public init(metricExporter: MetricExporter,
                 storageURL: URL,
-                writerQueue: DispatchQueue,
-                readerQueue: DispatchQueue,
-                exportQueue: DispatchQueue,
-                exportCondition: @escaping () -> Bool,
-                performancePreset: PersistencePerformancePreset = .default) throws {
-        
+                exportCondition: @escaping () -> Bool = { true },
+                performancePreset: PersistencePerformancePreset = .default) throws
+    {
         self.persistenceExporter =
             PersistenceExporterDecorator<MetricDecoratedExporter>(
                 decoratedExporter: MetricDecoratedExporter(metricExporter: metricExporter),
                 storageURL: storageURL,
-                writerQueue: writerQueue,
-                readerQueue: readerQueue,
-                exportQueue: exportQueue,
                 exportCondition: exportCondition,
                 performancePreset: performancePreset)
     }

--- a/Sources/Exporters/Persistence/PersistencePerformancePreset.swift
+++ b/Sources/Exporters/Persistence/PersistencePerformancePreset.swift
@@ -29,7 +29,7 @@ internal protocol StoragePerformancePreset {
     var maxObjectsInFile: Int { get }
     /// Maximum size of serialized object data (in bytes).
     /// If serialized object data exceeds this limit, it is skipped (not written to file and not exported).
-    var maxObjectSize: UInt64 { get }     
+    var maxObjectSize: UInt64 { get }
 }
 
 internal protocol ExportPerformancePreset {

--- a/Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift
@@ -9,7 +9,6 @@ import OpenTelemetrySdk
 // a persistence exporter decorator for `SpanData`.
 // specialization of `PersistenceExporterDecorator` for `SpanExporter`.
 public class PersistenceSpanExporterDecorator: SpanExporter {
-    
     struct SpanDecoratedExporter: DecoratedExporter {
         typealias SignalType = SpanData
         
@@ -30,21 +29,15 @@ public class PersistenceSpanExporterDecorator: SpanExporter {
     
     public init(spanExporter: SpanExporter,
                 storageURL: URL,
-                writerQueue: DispatchQueue,
-                readerQueue: DispatchQueue,
-                exportQueue: DispatchQueue,
-                exportCondition: @escaping () -> Bool,
-                performancePreset: PersistencePerformancePreset = .default) throws {
-        
+                exportCondition: @escaping () -> Bool = { true },
+                performancePreset: PersistencePerformancePreset = .default) throws
+    {
         self.spanExporter = spanExporter
         
         self.persistenceExporter =
             PersistenceExporterDecorator<SpanDecoratedExporter>(
                 decoratedExporter: SpanDecoratedExporter(spanExporter: spanExporter),
                 storageURL: storageURL,
-                writerQueue: writerQueue,
-                readerQueue: readerQueue,
-                exportQueue: exportQueue,
                 exportCondition: exportCondition,
                 performancePreset: performancePreset)
     }
@@ -60,7 +53,7 @@ public class PersistenceSpanExporterDecorator: SpanExporter {
     }
     
     public func flush() -> SpanExporterResultCode {
-        persistenceExporter.flush()        
+        persistenceExporter.flush()
         return spanExporter.flush()
     }
     

--- a/Sources/Exporters/Persistence/README.md
+++ b/Sources/Exporters/Persistence/README.md
@@ -6,7 +6,7 @@ An example use case is mobile apps that operate while the device has no network 
 
 The Persistence Exporter provides decorators for MetricExporter and SpanExporter. The decorators handle exported data by:
 
-- Asynchronously serializing and writing the exported data to the disk to a specified path. Writing to the disk is performed on a specified DispatchQueue.
+- Asynchronously serializing and writing the exported data to the disk to a specified path.
 - Asynchronously picking up persisted data, deserializing it, and forwarding it to the decorated exporter.
 
 ## Getting Started
@@ -21,11 +21,7 @@ An example of decorating a `MetricExporter`:
 let metricExporter = ... // create some MetricExporter
 let persistenceMetricExporter = try PersistenceMetricExporterDecorator(
   metricExporter: metricExporter,
-  storageURL: metricsSubdirectoryURL,
-  writerQueue: DispatchQueue(label: "metricWriterQueue"),
-  readerQueue: DispatchQueue(label: "metricReaderQueue"),
-  exportQueue: DispatchQueue(label: "metricExportQueue"),
-  exportCondition: { return true })
+  storageURL: metricsSubdirectoryURL)
 ```
 
 An example of decorating a `SpanExporter`:
@@ -34,9 +30,5 @@ An example of decorating a `SpanExporter`:
 let spanExporter = ... // create some SpanExporter
 let persistenceTraceExporter = try PersistenceSpanExporterDecorator(
   spanExporter: spanExporter,
-  storageURL: tracesSubdirectoryURL,
-  writerQueue: DispatchQueue(label: "spanWriterQueue"),
-  readerQueue: DispatchQueue(label: "spanWriterQueue"),
-  exportQueue: DispatchQueue(label: "spanWriterQueue"),
-  exportCondition: { return true })
+  storageURL: tracesSubdirectoryURL)
 ```

--- a/Sources/Exporters/Persistence/Storage/Directory.swift
+++ b/Sources/Exporters/Persistence/Storage/Directory.swift
@@ -52,14 +52,14 @@ private func createCachesSubdirectoryIfNotExists(subdirectoryPath: String) throw
     guard let cachesDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
         throw StorageError.obtainCacheLibraryError
     }
-    
+
     let subdirectoryURL = cachesDirectoryURL.appendingPathComponent(subdirectoryPath, isDirectory: true)
-    
+
     do {
         try FileManager.default.createDirectory(at: subdirectoryURL, withIntermediateDirectories: true, attributes: nil)
-    } catch let error {
+    } catch {
         throw StorageError.createDirectoryError(path: subdirectoryURL, error: error)
     }
-    
+
     return subdirectoryURL
 }

--- a/Sources/Exporters/Persistence/Storage/File.swift
+++ b/Sources/Exporters/Persistence/Storage/File.swift
@@ -14,7 +14,7 @@ internal protocol WritableFile {
     func size() throws -> UInt64
 
     /// Synchronously appends given data at the end of this file.
-    func append(data: Data, synchronized: Bool ) throws
+    func append(data: Data, synchronized: Bool) throws
 }
 
 /// Provides convenient interface for reading contents and metadata of the file.

--- a/Sources/Exporters/Persistence/Storage/FileWriter.swift
+++ b/Sources/Exporters/Persistence/Storage/FileWriter.swift
@@ -7,9 +7,9 @@ import Foundation
 
 protocol FileWriter {
     func write(data: Data)
-    
+
     func writeSync(data: Data)
-    
+
     func flush()
 }
 
@@ -17,14 +17,14 @@ internal final class OrchestratedFileWriter: FileWriter {
     /// Orchestrator producing reference to writable file.
     private let orchestrator: FilesOrchestrator
     /// Queue used to synchronize files access (read / write) and perform decoding on background thread.
-    private let queue: DispatchQueue
+    internal let queue = DispatchQueue(label: "com.otel.persistence.filewriter", target: .global(qos: .userInteractive))
 
-    init(orchestrator: FilesOrchestrator, queue: DispatchQueue) {
+    init(orchestrator: FilesOrchestrator) {
         self.orchestrator = orchestrator
-        self.queue = queue        
     }
 
     // MARK: - Writing data
+
     func write(data: Data) {
         queue.async { [weak self] in
             self?.synchronizedWrite(data: data)
@@ -40,11 +40,10 @@ internal final class OrchestratedFileWriter: FileWriter {
     private func synchronizedWrite(data: Data, syncOnEnd: Bool = false) {
         do {
             let file = try orchestrator.getWritableFile(writeSize: UInt64(data.count))
-            try file.append(data: data, synchronized: syncOnEnd)            
-        } catch {            
-        }
+            try file.append(data: data, synchronized: syncOnEnd)
+        } catch {}
     }
-    
+
     func flush() {
         queue.sync(flags: .barrier) {}
     }

--- a/Sources/Exporters/Persistence/Storage/FilesOrchestrator.swift
+++ b/Sources/Exporters/Persistence/Storage/FilesOrchestrator.swift
@@ -75,7 +75,7 @@ internal class FilesOrchestrator {
                 return nil
             }
         }
-        
+
         return nil
     }
 
@@ -116,8 +116,7 @@ internal class FilesOrchestrator {
     func delete(readableFile: ReadableFile) {
         do {
             try readableFile.delete()
-        } catch {            
-        }
+        } catch {}
     }
 
     // MARK: - Directory size management
@@ -177,7 +176,7 @@ private enum FixedWidthIntegerError<T: BinaryFloatingPoint>: Error {
 }
 
 private extension FixedWidthInteger {
-    /* 
+    /*
      Self(:) is commonly used for conversion, however it fatalError() in case of conversion failure
      Self(exactly:) does the exact same thing internally yet it returns nil instead of fatalError()
      It is not trivial to guess if the conversion would fail or succeed, therefore we use Self(exactly:)

--- a/Tests/ExportersTests/DatadogExporter/Persistence/FileReaderTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Persistence/FileReaderTests.swift
@@ -7,8 +7,6 @@
 import XCTest
 
 class FileReaderTests: XCTestCase {
-    private let queue = DispatchQueue(label: "dd-tests-read", target: .global(qos: .utility))
-
     override func setUp() {
         super.setUp()
         temporaryDirectory.create()
@@ -26,8 +24,7 @@ class FileReaderTests: XCTestCase {
                 directory: temporaryDirectory,
                 performance: StoragePerformanceMock.readAllFiles,
                 dateProvider: SystemDateProvider()
-            ),
-            queue: queue
+            )
         )
         _ = try temporaryDirectory
             .createFile(named: Date.mockAny().toFileName)
@@ -47,8 +44,7 @@ class FileReaderTests: XCTestCase {
                 directory: temporaryDirectory,
                 performance: StoragePerformanceMock.readAllFiles,
                 dateProvider: dateProvider
-            ),
-            queue: queue
+            )
         )
         let file1 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
         try file1.append(data: "1".utf8Data)

--- a/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
@@ -7,9 +7,6 @@
 import XCTest
 
 class DataUploadWorkerTests: XCTestCase {
-    private let fileReadWriteQueue = DispatchQueue(label: "dd-tests-read-write", target: .global(qos: .utility))
-    private let uploaderQueue = DispatchQueue(label: "dd-tests-uploader", target: .global(qos: .utility))
-
     lazy var dateProvider = RelativeDateProvider(advancingBySeconds: 1)
     lazy var orchestrator = FilesOrchestrator(
         directory: temporaryDirectory,
@@ -18,13 +15,11 @@ class DataUploadWorkerTests: XCTestCase {
     )
     lazy var writer = FileWriter(
         dataFormat: .mockWith(prefix: "[", suffix: "]"),
-        orchestrator: orchestrator,
-        queue: fileReadWriteQueue
+        orchestrator: orchestrator
     )
     lazy var reader = FileReader(
         dataFormat: .mockWith(prefix: "[", suffix: "]"),
-        orchestrator: orchestrator,
-        queue: fileReadWriteQueue
+        orchestrator: orchestrator
     )
 
     override func setUp() {
@@ -53,7 +48,6 @@ class DataUploadWorkerTests: XCTestCase {
 
         // When
         let worker = DataUploadWorker(
-            queue: uploaderQueue,
             fileReader: reader,
             dataUploader: dataUploader,
             uploadCondition: { true },
@@ -84,7 +78,6 @@ class DataUploadWorkerTests: XCTestCase {
 
         // When
         let worker = DataUploadWorker(
-            queue: uploaderQueue,
             fileReader: reader,
             dataUploader: mockDataUploader,
             uploadCondition: { true },
@@ -111,7 +104,6 @@ class DataUploadWorkerTests: XCTestCase {
 
         // When
         let worker = DataUploadWorker(
-            queue: uploaderQueue,
             fileReader: reader,
             dataUploader: mockDataUploader,
             uploadCondition: { true },
@@ -147,7 +139,6 @@ class DataUploadWorkerTests: XCTestCase {
             requestBuilder: .mockAny()
         )
         let worker = DataUploadWorker(
-            queue: uploaderQueue,
             fileReader: reader,
             dataUploader: dataUploader,
             uploadCondition: { false },
@@ -180,7 +171,6 @@ class DataUploadWorkerTests: XCTestCase {
             requestBuilder: .mockAny()
         )
         let worker = DataUploadWorker(
-            queue: uploaderQueue,
             fileReader: reader,
             dataUploader: dataUploader,
             uploadCondition: { true },
@@ -213,7 +203,6 @@ class DataUploadWorkerTests: XCTestCase {
             requestBuilder: .mockAny()
         )
         let worker = DataUploadWorker(
-            queue: uploaderQueue,
             fileReader: reader,
             dataUploader: dataUploader,
             uploadCondition: { true },
@@ -237,7 +226,6 @@ class DataUploadWorkerTests: XCTestCase {
             requestBuilder: .mockAny()
         )
         let worker = DataUploadWorker(
-            queue: uploaderQueue,
             fileReader: reader,
             dataUploader: dataUploader,
             uploadCondition: { false },
@@ -261,7 +249,6 @@ class DataUploadWorkerTests: XCTestCase {
             requestBuilder: .mockAny()
         )
         let worker = DataUploadWorker(
-            queue: uploaderQueue,
             fileReader: reader,
             dataUploader: dataUploader,
             uploadCondition: { true },

--- a/Tests/ExportersTests/PersistenceExporter/Export/DataExportWorkerTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/Export/DataExportWorkerTests.swift
@@ -7,9 +7,6 @@
 import XCTest
 
 class DataExportWorkerTests: XCTestCase {
-    private let fileReadQueue = DispatchQueue(label: "persistence-tests-read", attributes: .concurrent)
-    private let exporterQueue = DispatchQueue(label: "persistence-tests-exporter", attributes: .concurrent)
-
     lazy var dateProvider = RelativeDateProvider(advancingBySeconds: 1)
 
     override func setUp() {
@@ -46,7 +43,6 @@ class DataExportWorkerTests: XCTestCase {
                         
         // When
         let worker = DataExportWorker(
-            queue: exporterQueue,
             fileReader: fileReader,
             dataExporter: mockDataExporter,
             exportCondition: { true },
@@ -73,7 +69,6 @@ class DataExportWorkerTests: XCTestCase {
 
         // When
         let worker = DataExportWorker(
-            queue: exporterQueue,
             fileReader: fileReader,
             dataExporter: mockDataExporter,
             exportCondition: { true },
@@ -100,7 +95,6 @@ class DataExportWorkerTests: XCTestCase {
 
         // When
         let worker = DataExportWorker(
-            queue: exporterQueue,
             fileReader: fileReader,
             dataExporter: mockDataExporter,
             exportCondition: { true },
@@ -131,7 +125,6 @@ class DataExportWorkerTests: XCTestCase {
         let mockDataExporter = DataExporterMock(exportStatus: .mockWith(needsRetry: false))
         
         let worker = DataExportWorker(
-            queue: exporterQueue,
             fileReader: fileReader,
             dataExporter: mockDataExporter,
             exportCondition: { false },
@@ -164,7 +157,6 @@ class DataExportWorkerTests: XCTestCase {
         fileReader.addFile(name: "file", data: "value".utf8Data)
         
         let worker = DataExportWorker(
-            queue: exporterQueue,
             fileReader: fileReader,
             dataExporter: mockDataExporter,
             exportCondition: { true },
@@ -197,7 +189,6 @@ class DataExportWorkerTests: XCTestCase {
         fileReader.addFile(name: "file", data: "value".utf8Data)
                 
         let worker = DataExportWorker(
-            queue: exporterQueue,
             fileReader: fileReader,
             dataExporter: mockDataExporter,
             exportCondition: { true },
@@ -221,7 +212,6 @@ class DataExportWorkerTests: XCTestCase {
         
         // Given
         let worker = DataExportWorker(
-            queue: exporterQueue,
             fileReader: fileReader,
             dataExporter: mockDataExporter,
             exportCondition: { false },
@@ -232,7 +222,7 @@ class DataExportWorkerTests: XCTestCase {
         fileReader.addFile(name: "file", data: "value".utf8Data)
 
         // Then
-        exporterQueue.sync(flags: .barrier) { }
+        worker.queue.sync(flags: .barrier) { }
     }
 
     func testItFlushesAllData() {
@@ -259,7 +249,6 @@ class DataExportWorkerTests: XCTestCase {
         
         // When
         let worker = DataExportWorker(
-            queue: exporterQueue,
             fileReader: fileReader,
             dataExporter: mockDataExporter,
             exportCondition: { true },

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceMetricExporterDecoratorTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceMetricExporterDecoratorTests.swift
@@ -59,9 +59,6 @@ class PersistenceMetricExporterDecoratorTests: XCTestCase {
             try PersistenceMetricExporterDecorator(
                 metricExporter: mockMetricExporter,
                 storageURL: temporaryDirectory.url,
-                writerQueue: DispatchQueue(label: "metricWriterQueue"),
-                readerQueue: DispatchQueue(label: "metricReaderQueue"),
-                exportQueue: DispatchQueue(label: "metricExportQueue"),
                 exportCondition: { return true },
                 performancePreset: PersistencePerformancePreset.mockWith(
                     storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceSpanExporterDecoratorTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceSpanExporterDecoratorTests.swift
@@ -69,9 +69,6 @@ class PersistenceSpanExporterDecoratorTests: XCTestCase {
             try PersistenceSpanExporterDecorator(
                 spanExporter: mockSpanExporter,
                 storageURL: temporaryDirectory.url,
-                writerQueue: DispatchQueue(label: "spanWriterQueue"),
-                readerQueue: DispatchQueue(label: "spanReaderQueue"),
-                exportQueue: DispatchQueue(label: "spanExportQueue"),
                 exportCondition: { return true },
                 performancePreset: PersistencePerformancePreset.mockWith(
                     storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,

--- a/Tests/ExportersTests/PersistenceExporter/Storage/OrchestratedFileReaderTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/Storage/OrchestratedFileReaderTests.swift
@@ -7,8 +7,6 @@
 import XCTest
 
 class OrchestratedFileReaderTests: XCTestCase {
-    private let queue = DispatchQueue(label: "persistence-tests-read", target: .global(qos: .utility))
-
     override func setUp() {
         super.setUp()
         temporaryDirectory.create()
@@ -25,8 +23,7 @@ class OrchestratedFileReaderTests: XCTestCase {
                 directory: temporaryDirectory,
                 performance: StoragePerformanceMock.readAllFiles,
                 dateProvider: SystemDateProvider()
-            ),
-            queue: queue
+            )
         )
         _ = try temporaryDirectory
             .createFile(named: Date.mockAny().toFileName)
@@ -45,8 +42,7 @@ class OrchestratedFileReaderTests: XCTestCase {
                 directory: temporaryDirectory,
                 performance: StoragePerformanceMock.readAllFiles,
                 dateProvider: dateProvider
-            ),
-            queue: queue
+            )
         )
         let file1 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
         try file1.append(data: "1".utf8Data)


### PR DESCRIPTION
Simplifies Queue logic, and removes FileRead queue that was not being used.
Upload and Writer queues are internally created now, so user dont need to create them.
It makes Persistence exporter simpler to configure providing some default values.
Updated README for Persistence exporter.
Fix some formatting