### PR TITLE
update the OTLP Exporter to match the changes in the metrics specifications (labels -> attributes)

### DIFF
--- a/Examples/OTLP Exporter/collector-config.yaml
+++ b/Examples/OTLP Exporter/collector-config.yaml
@@ -3,13 +3,12 @@ receivers:
     protocols:
       grpc:
       http:
-        cors_allowed_origins:
-        - http://*
-        - https://*
+        cors:
+          allowed_origins:
+            - http://*
+            - https://*
 
 exporters:
-  logging:
-    loglevel: debug
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
   prometheus:
@@ -24,10 +23,13 @@ processors:
   batch:
 
 service:
+  telemetry:
+    logs:
+      level: "debug"
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [zipkin, logging]
+      exporters: [zipkin]
       processors: [resource, batch]
     metrics:
       receivers: [otlp]

--- a/Examples/OTLP Exporter/docker-compose.yaml
+++ b/Examples/OTLP Exporter/docker-compose.yaml
@@ -2,8 +2,8 @@ version: "3"
 services:
   # Collector
   collector:
-    image: otel/opentelemetry-collector:0.25.0
-#    image: otel/opentelemetry-collector:latest
+#    image: otel/opentelemetry-collector:0.25.0
+    image: otel/opentelemetry-collector:latest
     command: ["--config=/conf/collector-config.yaml", "--log-level=DEBUG"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml

--- a/Examples/OTLP Exporter/docker-compose.yaml
+++ b/Examples/OTLP Exporter/docker-compose.yaml
@@ -2,9 +2,9 @@ version: "3"
 services:
   # Collector
   collector:
-#    image: otel/opentelemetry-collector:0.25.0
-    image: otel/opentelemetry-collector:latest
-    command: ["--config=/conf/collector-config.yaml", "--log-level=DEBUG"]
+    image: otel/opentelemetry-collector:0.50.0
+#    image: otel/opentelemetry-collector:latest
+    command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml
     ports:

--- a/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
@@ -54,60 +54,70 @@ struct MetricsAdapter {
                 guard let gaugeData = $0 as? SumData<Double> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleDataPoint()
+//                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_NumberDataPoint()
+
                 protoDataPoint.timeUnixNano = gaugeData.timestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.startTimeUnixNano = gaugeData.startTimestamp.timeIntervalSince1970.toNanoseconds
-                protoDataPoint.value = gaugeData.sum
+                protoDataPoint.value = .asDouble(gaugeData.sum)
                 gaugeData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+//                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.doubleGauge.dataPoints.append(protoDataPoint)
+                protoMetric.gauge.dataPoints.append(protoDataPoint)
             case .intGauge:
                 guard let gaugeData = $0 as? SumData<Int> else {
                     break
                 }
 
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_IntDataPoint()
+//                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_IntDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_NumberDataPoint()
 
-                protoDataPoint.value = Int64(gaugeData.sum)
+                protoDataPoint.value = .asInt(Int64(exactly: gaugeData.sum)!)
                 protoDataPoint.timeUnixNano = gaugeData.timestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.startTimeUnixNano = gaugeData.startTimestamp.timeIntervalSince1970.toNanoseconds
                 gaugeData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+//                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.intGauge.dataPoints.append(protoDataPoint)
+                protoMetric.gauge.dataPoints.append(protoDataPoint)
             case .doubleSum:
                 guard let sumData = $0 as? SumData<Double> else {
                     break
                 }
 
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleDataPoint()
-                protoDataPoint.value = sumData.sum
+//                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_NumberDataPoint()
+
+                protoDataPoint.value = .asDouble(sumData.sum)
                 protoDataPoint.timeUnixNano = sumData.timestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.startTimeUnixNano = sumData.startTimestamp.timeIntervalSince1970.toNanoseconds
                 sumData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+//                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.doubleSum.aggregationTemporality = .cumulative
-                protoMetric.doubleSum.dataPoints.append(protoDataPoint)
+                protoMetric.sum.aggregationTemporality = .cumulative
+                protoMetric.sum.dataPoints.append(protoDataPoint)
             case .doubleSummary:
 
                 guard let summaryData = $0 as? SummaryData<Double> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint()
+//                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint()
+
                 protoDataPoint.sum = summaryData.sum
                 protoDataPoint.count = UInt64(summaryData.count)
 
@@ -115,53 +125,61 @@ struct MetricsAdapter {
                 protoDataPoint.timeUnixNano = summaryData.timestamp.timeIntervalSince1970.toNanoseconds
 
                 summaryData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.doubleSummary.dataPoints.append(protoDataPoint)
+                protoMetric.summary.dataPoints.append(protoDataPoint)
             case .intSum:
                 guard let sumData = $0 as? SumData<Int> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_IntDataPoint()
-                protoDataPoint.value = Int64(sumData.sum)
+//                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_IntDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_NumberDataPoint()
+
+                protoDataPoint.value = .asInt(Int64(sumData.sum))
                 protoDataPoint.timeUnixNano = sumData.timestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.startTimeUnixNano = sumData.startTimestamp.timeIntervalSince1970.toNanoseconds
                 sumData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+//                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
+
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.intSum.aggregationTemporality = .cumulative
-                protoMetric.intSum.dataPoints.append(protoDataPoint)
+                protoMetric.sum.aggregationTemporality = .cumulative
+                protoMetric.sum.dataPoints.append(protoDataPoint)
             case .intSummary:
                 guard let summaryData = $0 as? SummaryData<Int> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint()
+//                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint()
+
                 protoDataPoint.sum = Double(summaryData.sum)
                 protoDataPoint.count = UInt64(summaryData.count)
                 protoDataPoint.startTimeUnixNano = summaryData.startTimestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.timeUnixNano = summaryData.timestamp.timeIntervalSince1970.toNanoseconds
 
                 summaryData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.doubleSummary.dataPoints.append(protoDataPoint)
+                protoMetric.summary.dataPoints.append(protoDataPoint)
             case .intHistogram:
                 guard let histogramData = $0 as? HistogramData<Int> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint()
+//                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_HistogramDataPoint()
+
                 protoDataPoint.sum = Double(histogramData.sum)
                 protoDataPoint.count = UInt64(histogramData.count)
                 protoDataPoint.startTimeUnixNano = histogramData.startTimestamp.timeIntervalSince1970.toNanoseconds
@@ -170,19 +188,19 @@ struct MetricsAdapter {
                 protoDataPoint.bucketCounts = histogramData.buckets.counts.map { UInt64($0) }
                 
                 histogramData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
                 
-                protoMetric.doubleHistogram.aggregationTemporality = .cumulative
-                protoMetric.doubleHistogram.dataPoints.append(protoDataPoint)
+                protoMetric.histogram.aggregationTemporality = .cumulative
+                protoMetric.histogram.dataPoints.append(protoDataPoint)
             case .doubleHistogram:
                 guard let histogramData = $0 as? HistogramData<Double> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_HistogramDataPoint()
                 protoDataPoint.sum = Double(histogramData.sum)
                 protoDataPoint.count = UInt64(histogramData.count)
                 protoDataPoint.startTimeUnixNano = histogramData.startTimestamp.timeIntervalSince1970.toNanoseconds
@@ -191,14 +209,14 @@ struct MetricsAdapter {
                 protoDataPoint.bucketCounts = histogramData.buckets.counts.map { UInt64($0) }
                 
                 histogramData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
                 
-                protoMetric.doubleHistogram.aggregationTemporality = .cumulative
-                protoMetric.doubleHistogram.dataPoints.append(protoDataPoint)
+                protoMetric.histogram.aggregationTemporality = .cumulative
+                protoMetric.histogram.dataPoints.append(protoDataPoint)
             }
         }
         return protoMetric

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/common.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/common.pb.swift
@@ -43,7 +43,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
   // methods supported on all messages.
 
   /// The value is one of the listed fields. It is valid for all values to be unspecified
-  /// in which case this AnyValue is considered to be "null".
+  /// in which case this AnyValue is considered to be "empty".
   public var value: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value? = nil
 
   public var stringValue: String {
@@ -94,10 +94,18 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .kvlistValue(newValue)}
   }
 
+  public var bytesValue: Data {
+    get {
+      if case .bytesValue(let v)? = value {return v}
+      return Data()
+    }
+    set {value = .bytesValue(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The value is one of the listed fields. It is valid for all values to be unspecified
-  /// in which case this AnyValue is considered to be "null".
+  /// in which case this AnyValue is considered to be "empty".
   public enum OneOf_Value: Equatable {
     case stringValue(String)
     case boolValue(Bool)
@@ -105,6 +113,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     case doubleValue(Double)
     case arrayValue(Opentelemetry_Proto_Common_V1_ArrayValue)
     case kvlistValue(Opentelemetry_Proto_Common_V1_KeyValueList)
+    case bytesValue(Data)
 
   #if !swift(>=4.1)
     public static func ==(lhs: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value, rhs: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value) -> Bool {
@@ -134,6 +143,10 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
       }()
       case (.kvlistValue, .kvlistValue): return {
         guard case .kvlistValue(let l) = lhs, case .kvlistValue(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.bytesValue, .bytesValue): return {
+        guard case .bytesValue(let l) = lhs, case .bytesValue(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       default: return false
@@ -172,6 +185,8 @@ public struct Opentelemetry_Proto_Common_V1_KeyValueList {
 
   /// A collection of key/value pairs of key-value pairs. The list may be empty (may
   /// contain 0 elements).
+  /// The keys MUST be unique (it is not allowed to have more than one
+  /// value with the same key).
   public var values: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -204,30 +219,17 @@ public struct Opentelemetry_Proto_Common_V1_KeyValue {
   fileprivate var _value: Opentelemetry_Proto_Common_V1_AnyValue? = nil
 }
 
-/// StringKeyValue is a pair of key/value strings. This is the simpler (and faster) version
-/// of KeyValue that only supports string values.
-public struct Opentelemetry_Proto_Common_V1_StringKeyValue {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  public var key: String = String()
-
-  public var value: String = String()
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
 /// InstrumentationLibrary is a message representing the instrumentation library information
-/// such as the fully qualified name and version. 
+/// such as the fully qualified name and version.
+/// InstrumentationLibrary is wire-compatible with InstrumentationScope for binary
+/// Protobuf format.
+/// This message is deprecated and will be removed on June 15, 2022.
 public struct Opentelemetry_Proto_Common_V1_InstrumentationLibrary {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// An empty instrumentation library name means the name is unknown. 
+  /// An empty instrumentation library name means the name is unknown.
   public var name: String = String()
 
   public var version: String = String()
@@ -236,6 +238,33 @@ public struct Opentelemetry_Proto_Common_V1_InstrumentationLibrary {
 
   public init() {}
 }
+
+/// InstrumentationScope is a message representing the instrumentation scope information
+/// such as the fully qualified name and version. 
+public struct Opentelemetry_Proto_Common_V1_InstrumentationScope {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// An empty instrumentation scope name means the name is unknown.
+  public var name: String = String()
+
+  public var version: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Common_V1_AnyValue: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_ArrayValue: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_KeyValueList: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_KeyValue: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_InstrumentationLibrary: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_InstrumentationScope: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -250,6 +279,7 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
     4: .standard(proto: "double_value"),
     5: .standard(proto: "array_value"),
     6: .standard(proto: "kvlist_value"),
+    7: .standard(proto: "bytes_value"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -259,46 +289,70 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.value = .stringValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .stringValue(v)
+        }
       }()
       case 2: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: Bool?
         try decoder.decodeSingularBoolField(value: &v)
-        if let v = v {self.value = .boolValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .boolValue(v)
+        }
       }()
       case 3: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: Int64?
         try decoder.decodeSingularInt64Field(value: &v)
-        if let v = v {self.value = .intValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .intValue(v)
+        }
       }()
       case 4: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: Double?
         try decoder.decodeSingularDoubleField(value: &v)
-        if let v = v {self.value = .doubleValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .doubleValue(v)
+        }
       }()
       case 5: try {
         var v: Opentelemetry_Proto_Common_V1_ArrayValue?
+        var hadOneofValue = false
         if let current = self.value {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .arrayValue(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.value = .arrayValue(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.value = .arrayValue(v)
+        }
       }()
       case 6: try {
         var v: Opentelemetry_Proto_Common_V1_KeyValueList?
+        var hadOneofValue = false
         if let current = self.value {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .kvlistValue(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.value = .kvlistValue(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.value = .kvlistValue(v)
+        }
+      }()
+      case 7: try {
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .bytesValue(v)
+        }
       }()
       default: break
       }
@@ -307,8 +361,9 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     switch self.value {
     case .stringValue?: try {
       guard case .stringValue(let v)? = self.value else { preconditionFailure() }
@@ -333,6 +388,10 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
     case .kvlistValue?: try {
       guard case .kvlistValue(let v)? = self.value else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
+    case .bytesValue?: try {
+      guard case .bytesValue(let v)? = self.value else { preconditionFailure() }
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 7)
     }()
     case nil: break
     }
@@ -431,56 +490,22 @@ extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftPr
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.key.isEmpty {
       try visitor.visitSingularStringField(value: self.key, fieldNumber: 1)
     }
-    if let v = self._value {
+    try { if let v = self._value {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Common_V1_KeyValue, rhs: Opentelemetry_Proto_Common_V1_KeyValue) -> Bool {
     if lhs.key != rhs.key {return false}
     if lhs._value != rhs._value {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Opentelemetry_Proto_Common_V1_StringKeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".StringKeyValue"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "key"),
-    2: .same(proto: "value"),
-  ]
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.key) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self.value) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.key.isEmpty {
-      try visitor.visitSingularStringField(value: self.key, fieldNumber: 1)
-    }
-    if !self.value.isEmpty {
-      try visitor.visitSingularStringField(value: self.value, fieldNumber: 2)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Opentelemetry_Proto_Common_V1_StringKeyValue, rhs: Opentelemetry_Proto_Common_V1_StringKeyValue) -> Bool {
-    if lhs.key != rhs.key {return false}
-    if lhs.value != rhs.value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -517,6 +542,44 @@ extension Opentelemetry_Proto_Common_V1_InstrumentationLibrary: SwiftProtobuf.Me
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Common_V1_InstrumentationLibrary, rhs: Opentelemetry_Proto_Common_V1_InstrumentationLibrary) -> Bool {
+    if lhs.name != rhs.name {return false}
+    if lhs.version != rhs.version {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".InstrumentationScope"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "name"),
+    2: .same(proto: "version"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.version) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.version.isEmpty {
+      try visitor.visitSingularStringField(value: self.version, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Common_V1_InstrumentationScope, rhs: Opentelemetry_Proto_Common_V1_InstrumentationScope) -> Bool {
     if lhs.name != rhs.name {return false}
     if lhs.version != rhs.version {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/logs.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/logs.pb.swift
@@ -399,6 +399,13 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   /// it is known at the source. [Optional].
   public var severityText: String = String()
 
+  /// Short event identifier that does not contain varying parts. Name describes
+  /// what happened (e.g. "ProcessStarted"). Recommended to be no longer than 50
+  /// characters. Not guaranteed to be unique in any way. [Optional].
+  /// This deprecated field is planned to be removed March 15, 2022. Receivers can
+  /// ignore this field.
+  public var name: String = String()
+
   /// A value containing the body of the log record. Can be for example a human-readable
   /// string message (including multi-line) describing the event in a free form or it can
   /// be a structured data composed of arrays and maps of other values. [Optional].
@@ -684,6 +691,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     11: .standard(proto: "observed_time_unix_nano"),
     2: .standard(proto: "severity_number"),
     3: .standard(proto: "severity_text"),
+    4: .same(proto: "name"),
     5: .same(proto: "body"),
     6: .same(proto: "attributes"),
     7: .standard(proto: "dropped_attributes_count"),
@@ -701,6 +709,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
       case 1: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
       case 2: try { try decoder.decodeSingularEnumField(value: &self.severityNumber) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.severityText) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.name) }()
       case 5: try { try decoder.decodeSingularMessageField(value: &self._body) }()
       case 6: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
       case 7: try { try decoder.decodeSingularUInt32Field(value: &self.droppedAttributesCount) }()
@@ -726,6 +735,9 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     }
     if !self.severityText.isEmpty {
       try visitor.visitSingularStringField(value: self.severityText, fieldNumber: 3)
+    }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 4)
     }
     try { if let v = self._body {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
@@ -756,6 +768,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     if lhs.observedTimeUnixNano != rhs.observedTimeUnixNano {return false}
     if lhs.severityNumber != rhs.severityNumber {return false}
     if lhs.severityText != rhs.severityText {return false}
+    if lhs.name != rhs.name {return false}
     if lhs._body != rhs._body {return false}
     if lhs.attributes != rhs.attributes {return false}
     if lhs.droppedAttributesCount != rhs.droppedAttributesCount {return false}

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/logs.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/logs.pb.swift
@@ -210,7 +210,34 @@ extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: CaseIterable {
 
 #endif  // swift(>=4.2)
 
-/// A collection of InstrumentationLibraryLogs from a Resource.
+/// LogsData represents the logs data that can be stored in a persistent storage,
+/// OR can be embedded by other protocols that transfer OTLP logs data but do not
+/// implement the OTLP protocol.
+///
+/// The main difference between this message and collector protocol is that
+/// in this message there will not be any "control" or "metadata" specific to
+/// OTLP protocol.
+///
+/// When new fields are added into this message, the OTLP request MUST be updated
+/// as well.
+public struct Opentelemetry_Proto_Logs_V1_LogsData {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// An array of ResourceLogs.
+  /// For data coming from a single resource this array will typically contain
+  /// one element. Intermediary nodes that receive data from multiple origins
+  /// typically batch the data before forwarding further and in that case this
+  /// array will contain multiple elements.
+  public var resourceLogs: [Opentelemetry_Proto_Logs_V1_ResourceLogs] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// A collection of ScopeLogs from a Resource.
 public struct Opentelemetry_Proto_Logs_V1_ResourceLogs {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -227,8 +254,41 @@ public struct Opentelemetry_Proto_Logs_V1_ResourceLogs {
   /// Clears the value of `resource`. Subsequent reads from it will return its default value.
   public mutating func clearResource() {self._resource = nil}
 
+  /// A list of ScopeLogs that originate from a resource.
+  public var scopeLogs: [Opentelemetry_Proto_Logs_V1_ScopeLogs] = []
+
   /// A list of InstrumentationLibraryLogs that originate from a resource.
+  /// This field is deprecated and will be removed after grace period expires on June 15, 2022.
+  ///
+  /// During the grace period the following rules SHOULD be followed:
+  ///
+  /// For Binary Protobufs
+  /// ====================
+  /// Binary Protobuf senders SHOULD NOT set instrumentation_library_logs. Instead
+  /// scope_logs SHOULD be set.
+  ///
+  /// Binary Protobuf receivers SHOULD check if instrumentation_library_logs is set
+  /// and scope_logs is not set then the value in instrumentation_library_logs
+  /// SHOULD be used instead by converting InstrumentationLibraryLogs into ScopeLogs.
+  /// If scope_logs is set then instrumentation_library_logs SHOULD be ignored.
+  ///
+  /// For JSON
+  /// ========
+  /// JSON senders that set instrumentation_library_logs field MAY also set
+  /// scope_logs to carry the same logs, essentially double-publishing the same data.
+  /// Such double-publishing MAY be controlled by a user-settable option.
+  /// If double-publishing is not used then the senders SHOULD set scope_logs and
+  /// SHOULD NOT set instrumentation_library_logs.
+  ///
+  /// JSON receivers SHOULD check if instrumentation_library_logs is set and
+  /// scope_logs is not set then the value in instrumentation_library_logs
+  /// SHOULD be used instead by converting InstrumentationLibraryLogs into ScopeLogs.
+  /// If scope_logs is set then instrumentation_library_logs field SHOULD be ignored.
   public var instrumentationLibraryLogs: [Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs] = []
+
+  /// This schema_url applies to the data in the "resource" field. It does not apply
+  /// to the data in the "scope_logs" field which have their own schema_url field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -237,7 +297,41 @@ public struct Opentelemetry_Proto_Logs_V1_ResourceLogs {
   fileprivate var _resource: Opentelemetry_Proto_Resource_V1_Resource? = nil
 }
 
+/// A collection of Logs produced by a Scope.
+public struct Opentelemetry_Proto_Logs_V1_ScopeLogs {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The instrumentation scope information for the logs in this message.
+  /// Semantically when InstrumentationScope isn't set, it is equivalent with
+  /// an empty instrumentation scope name (unknown).
+  public var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
+    get {return _scope ?? Opentelemetry_Proto_Common_V1_InstrumentationScope()}
+    set {_scope = newValue}
+  }
+  /// Returns true if `scope` has been explicitly set.
+  public var hasScope: Bool {return self._scope != nil}
+  /// Clears the value of `scope`. Subsequent reads from it will return its default value.
+  public mutating func clearScope() {self._scope = nil}
+
+  /// A list of log records.
+  public var logRecords: [Opentelemetry_Proto_Logs_V1_LogRecord] = []
+
+  /// This schema_url applies to all logs in the "logs" field.
+  public var schemaURL: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _scope: Opentelemetry_Proto_Common_V1_InstrumentationScope? = nil
+}
+
 /// A collection of Logs produced by an InstrumentationLibrary.
+/// InstrumentationLibraryLogs is wire-compatible with ScopeLogs for binary
+/// Protobuf format.
+/// This message is deprecated and will be removed on June 15, 2022.
 public struct Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -255,8 +349,11 @@ public struct Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs {
   /// Clears the value of `instrumentationLibrary`. Subsequent reads from it will return its default value.
   public mutating func clearInstrumentationLibrary() {self._instrumentationLibrary = nil}
 
-  /// A list of log records.
-  public var logs: [Opentelemetry_Proto_Logs_V1_LogRecord] = []
+  /// A list of logs that originate from an instrumentation library.
+  public var logRecords: [Opentelemetry_Proto_Logs_V1_LogRecord] = []
+
+  /// This schema_url applies to all logs in the "logs" field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -266,7 +363,7 @@ public struct Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs {
 }
 
 /// A log record according to OpenTelemetry Log Data Model:
-/// https://github.com/open-telemetry/oteps/blob/master/text/logs/0097-log-data-model.md
+/// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
 public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -277,6 +374,23 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   /// Value of 0 indicates unknown or missing timestamp.
   public var timeUnixNano: UInt64 = 0
 
+  /// Time when the event was observed by the collection system.
+  /// For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
+  /// this timestamp is typically set at the generation time and is equal to Timestamp.
+  /// For events originating externally and collected by OpenTelemetry (e.g. using
+  /// Collector) this is the time when OpenTelemetry's code observed the event measured
+  /// by the clock of the OpenTelemetry code. This field MUST be set once the event is
+  /// observed by OpenTelemetry.
+  ///
+  /// For converting OpenTelemetry log data to formats that support only one timestamp or
+  /// when receiving OpenTelemetry log data by recipients that support only one timestamp
+  /// internally the following logic is recommended:
+  ///   - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
+  ///
+  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  /// Value of 0 indicates unknown or missing timestamp.
+  public var observedTimeUnixNano: UInt64 = 0
+
   /// Numerical value of the severity, normalized to values described in Log Data Model.
   /// [Optional].
   public var severityNumber: Opentelemetry_Proto_Logs_V1_SeverityNumber = .unspecified
@@ -284,11 +398,6 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   /// The severity text (also known as log level). The original string representation as
   /// it is known at the source. [Optional].
   public var severityText: String = String()
-
-  /// Short event identifier that does not contain varying parts. Name describes
-  /// what happened (e.g. "ProcessStarted"). Recommended to be no longer than 50
-  /// characters. Not guaranteed to be unique in any way. [Optional].
-  public var name: String = String()
 
   /// A value containing the body of the log record. Can be for example a human-readable
   /// string message (including multi-line) describing the event in a free form or it can
@@ -303,6 +412,8 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   public mutating func clearBody() {self._body = nil}
 
   /// Additional attributes that describe the specific event occurrence. [Optional].
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
   public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   public var droppedAttributesCount: UInt32 = 0
@@ -332,6 +443,16 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
 
   fileprivate var _body: Opentelemetry_Proto_Common_V1_AnyValue? = nil
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Logs_V1_SeverityNumber: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_LogsData: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_ResourceLogs: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_ScopeLogs: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_LogRecord: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -374,11 +495,45 @@ extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf._ProtoNamePr
   ]
 }
 
+extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".LogsData"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "resource_logs"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.resourceLogs) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.resourceLogs.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.resourceLogs, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Logs_V1_LogsData, rhs: Opentelemetry_Proto_Logs_V1_LogsData) -> Bool {
+    if lhs.resourceLogs != rhs.resourceLogs {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ResourceLogs"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "resource"),
-    2: .standard(proto: "instrumentation_library_logs"),
+    2: .standard(proto: "scope_logs"),
+    1000: .standard(proto: "instrumentation_library_logs"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -388,25 +543,87 @@ extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, Swift
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._resource) }()
-      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibraryLogs) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.scopeLogs) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      case 1000: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibraryLogs) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._resource {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._resource {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.scopeLogs.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.scopeLogs, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     if !self.instrumentationLibraryLogs.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.instrumentationLibraryLogs, fieldNumber: 2)
+      try visitor.visitRepeatedMessageField(value: self.instrumentationLibraryLogs, fieldNumber: 1000)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Logs_V1_ResourceLogs, rhs: Opentelemetry_Proto_Logs_V1_ResourceLogs) -> Bool {
     if lhs._resource != rhs._resource {return false}
+    if lhs.scopeLogs != rhs.scopeLogs {return false}
     if lhs.instrumentationLibraryLogs != rhs.instrumentationLibraryLogs {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ScopeLogs"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "scope"),
+    2: .standard(proto: "log_records"),
+    3: .standard(proto: "schema_url"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._scope) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.logRecords) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._scope {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.logRecords.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.logRecords, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Logs_V1_ScopeLogs, rhs: Opentelemetry_Proto_Logs_V1_ScopeLogs) -> Bool {
+    if lhs._scope != rhs._scope {return false}
+    if lhs.logRecords != rhs.logRecords {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -416,7 +633,8 @@ extension Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs: SwiftProtobuf.
   public static let protoMessageName: String = _protobuf_package + ".InstrumentationLibraryLogs"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "instrumentation_library"),
-    2: .same(proto: "logs"),
+    2: .standard(proto: "log_records"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -426,25 +644,34 @@ extension Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs: SwiftProtobuf.
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._instrumentationLibrary) }()
-      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.logs) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.logRecords) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._instrumentationLibrary {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._instrumentationLibrary {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.logRecords.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.logRecords, fieldNumber: 2)
     }
-    if !self.logs.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.logs, fieldNumber: 2)
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs, rhs: Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs) -> Bool {
     if lhs._instrumentationLibrary != rhs._instrumentationLibrary {return false}
-    if lhs.logs != rhs.logs {return false}
+    if lhs.logRecords != rhs.logRecords {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -454,9 +681,9 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
   public static let protoMessageName: String = _protobuf_package + ".LogRecord"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "time_unix_nano"),
+    11: .standard(proto: "observed_time_unix_nano"),
     2: .standard(proto: "severity_number"),
     3: .standard(proto: "severity_text"),
-    4: .same(proto: "name"),
     5: .same(proto: "body"),
     6: .same(proto: "attributes"),
     7: .standard(proto: "dropped_attributes_count"),
@@ -474,19 +701,23 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
       case 1: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
       case 2: try { try decoder.decodeSingularEnumField(value: &self.severityNumber) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.severityText) }()
-      case 4: try { try decoder.decodeSingularStringField(value: &self.name) }()
       case 5: try { try decoder.decodeSingularMessageField(value: &self._body) }()
       case 6: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
       case 7: try { try decoder.decodeSingularUInt32Field(value: &self.droppedAttributesCount) }()
       case 8: try { try decoder.decodeSingularFixed32Field(value: &self.flags) }()
       case 9: try { try decoder.decodeSingularBytesField(value: &self.traceID) }()
       case 10: try { try decoder.decodeSingularBytesField(value: &self.spanID) }()
+      case 11: try { try decoder.decodeSingularFixed64Field(value: &self.observedTimeUnixNano) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.timeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.timeUnixNano, fieldNumber: 1)
     }
@@ -496,12 +727,9 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     if !self.severityText.isEmpty {
       try visitor.visitSingularStringField(value: self.severityText, fieldNumber: 3)
     }
-    if !self.name.isEmpty {
-      try visitor.visitSingularStringField(value: self.name, fieldNumber: 4)
-    }
-    if let v = self._body {
+    try { if let v = self._body {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    }
+    } }()
     if !self.attributes.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 6)
     }
@@ -517,14 +745,17 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     if !self.spanID.isEmpty {
       try visitor.visitSingularBytesField(value: self.spanID, fieldNumber: 10)
     }
+    if self.observedTimeUnixNano != 0 {
+      try visitor.visitSingularFixed64Field(value: self.observedTimeUnixNano, fieldNumber: 11)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Logs_V1_LogRecord, rhs: Opentelemetry_Proto_Logs_V1_LogRecord) -> Bool {
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
+    if lhs.observedTimeUnixNano != rhs.observedTimeUnixNano {return false}
     if lhs.severityNumber != rhs.severityNumber {return false}
     if lhs.severityText != rhs.severityText {return false}
-    if lhs.name != rhs.name {return false}
     if lhs._body != rhs._body {return false}
     if lhs.attributes != rhs.attributes {return false}
     if lhs.droppedAttributesCount != rhs.droppedAttributesCount {return false}

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/logs_service.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/logs_service.pb.swift
@@ -61,6 +61,11 @@ public struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: @unchecked Sendable {}
+extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.collector.logs.v1"

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/metrics.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/metrics.pb.swift
@@ -100,7 +100,7 @@ public enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf
   ///      number of requests received over the interval of time t_1 to
   ///      t_0+1 with a value of 1.
   ///
-  /// Note: Even though, when reporting changes since last report time, using 
+  /// Note: Even though, when reporting changes since last report time, using
   /// CUMULATIVE is valid, it is not recommended. This may cause problems for
   /// systems that do not use start_time to determine when the aggregation
   /// value was reset (e.g. Prometheus).
@@ -144,7 +144,84 @@ extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: CaseIterable {
 
 #endif  // swift(>=4.2)
 
-/// A collection of InstrumentationLibraryMetrics from a Resource.
+/// DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a
+/// bit-field representing 32 distinct boolean flags.  Each flag defined in this
+/// enum is a bit-mask.  To test the presence of a single flag in the flags of
+/// a data point, for example, use an expression like:
+///
+///   (point.flags & FLAG_NO_RECORDED_VALUE) == FLAG_NO_RECORDED_VALUE
+public enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum {
+  public typealias RawValue = Int
+  case flagNone // = 0
+
+  /// This DataPoint is valid but has no recorded value.  This value
+  /// SHOULD be used to reflect explicitly missing data in a series, as
+  /// for an equivalent to the Prometheus "staleness marker".
+  case flagNoRecordedValue // = 1
+  case UNRECOGNIZED(Int)
+
+  public init() {
+    self = .flagNone
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .flagNone
+    case 1: self = .flagNoRecordedValue
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .flagNone: return 0
+    case .flagNoRecordedValue: return 1
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+}
+
+#if swift(>=4.2)
+
+extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: CaseIterable {
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static var allCases: [Opentelemetry_Proto_Metrics_V1_DataPointFlags] = [
+    .flagNone,
+    .flagNoRecordedValue,
+  ]
+}
+
+#endif  // swift(>=4.2)
+
+/// MetricsData represents the metrics data that can be stored in a persistent
+/// storage, OR can be embedded by other protocols that transfer OTLP metrics
+/// data but do not implement the OTLP protocol.
+///
+/// The main difference between this message and collector protocol is that
+/// in this message there will not be any "control" or "metadata" specific to
+/// OTLP protocol.
+///
+/// When new fields are added into this message, the OTLP request MUST be updated
+/// as well.
+public struct Opentelemetry_Proto_Metrics_V1_MetricsData {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// An array of ResourceMetrics.
+  /// For data coming from a single resource this array will typically contain
+  /// one element. Intermediary nodes that receive data from multiple origins
+  /// typically batch the data before forwarding further and in that case this
+  /// array will contain multiple elements.
+  public var resourceMetrics: [Opentelemetry_Proto_Metrics_V1_ResourceMetrics] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// A collection of ScopeMetrics from a Resource.
 public struct Opentelemetry_Proto_Metrics_V1_ResourceMetrics {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -162,7 +239,40 @@ public struct Opentelemetry_Proto_Metrics_V1_ResourceMetrics {
   public mutating func clearResource() {self._resource = nil}
 
   /// A list of metrics that originate from a resource.
+  public var scopeMetrics: [Opentelemetry_Proto_Metrics_V1_ScopeMetrics] = []
+
+  /// A list of InstrumentationLibraryMetrics that originate from a resource.
+  /// This field is deprecated and will be removed after grace period expires on June 15, 2022.
+  ///
+  /// During the grace period the following rules SHOULD be followed:
+  ///
+  /// For Binary Protobufs
+  /// ====================
+  /// Binary Protobuf senders SHOULD NOT set instrumentation_library_metrics. Instead
+  /// scope_metrics SHOULD be set.
+  ///
+  /// Binary Protobuf receivers SHOULD check if instrumentation_library_metrics is set
+  /// and scope_metrics is not set then the value in instrumentation_library_metrics
+  /// SHOULD be used instead by converting InstrumentationLibraryMetrics into ScopeMetrics.
+  /// If scope_metrics is set then instrumentation_library_metrics SHOULD be ignored.
+  ///
+  /// For JSON
+  /// ========
+  /// JSON senders that set instrumentation_library_metrics field MAY also set
+  /// scope_metrics to carry the same metrics, essentially double-publishing the same data.
+  /// Such double-publishing MAY be controlled by a user-settable option.
+  /// If double-publishing is not used then the senders SHOULD set scope_metrics and
+  /// SHOULD NOT set instrumentation_library_metrics.
+  ///
+  /// JSON receivers SHOULD check if instrumentation_library_metrics is set and
+  /// scope_metrics is not set then the value in instrumentation_library_metrics
+  /// SHOULD be used instead by converting InstrumentationLibraryMetrics into ScopeMetrics.
+  /// If scope_metrics is set then instrumentation_library_metrics field SHOULD be ignored.
   public var instrumentationLibraryMetrics: [Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics] = []
+
+  /// This schema_url applies to the data in the "resource" field. It does not apply
+  /// to the data in the "scope_metrics" field which have their own schema_url field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -171,7 +281,41 @@ public struct Opentelemetry_Proto_Metrics_V1_ResourceMetrics {
   fileprivate var _resource: Opentelemetry_Proto_Resource_V1_Resource? = nil
 }
 
+/// A collection of Metrics produced by an Scope.
+public struct Opentelemetry_Proto_Metrics_V1_ScopeMetrics {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The instrumentation scope information for the metrics in this message.
+  /// Semantically when InstrumentationScope isn't set, it is equivalent with
+  /// an empty instrumentation scope name (unknown).
+  public var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
+    get {return _scope ?? Opentelemetry_Proto_Common_V1_InstrumentationScope()}
+    set {_scope = newValue}
+  }
+  /// Returns true if `scope` has been explicitly set.
+  public var hasScope: Bool {return self._scope != nil}
+  /// Clears the value of `scope`. Subsequent reads from it will return its default value.
+  public mutating func clearScope() {self._scope = nil}
+
+  /// A list of metrics that originate from an instrumentation library.
+  public var metrics: [Opentelemetry_Proto_Metrics_V1_Metric] = []
+
+  /// This schema_url applies to all metrics in the "metrics" field.
+  public var schemaURL: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _scope: Opentelemetry_Proto_Common_V1_InstrumentationScope? = nil
+}
+
 /// A collection of Metrics produced by an InstrumentationLibrary.
+/// InstrumentationLibraryMetrics is wire-compatible with ScopeMetrics for binary
+/// Protobuf format.
+/// This message is deprecated and will be removed on June 15, 2022.
 public struct Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -192,6 +336,9 @@ public struct Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics {
   /// A list of metrics that originate from an instrumentation library.
   public var metrics: [Opentelemetry_Proto_Metrics_V1_Metric] = []
 
+  /// This schema_url applies to all metrics in the "metrics" field.
+  public var schemaURL: String = String()
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -199,7 +346,11 @@ public struct Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics {
   fileprivate var _instrumentationLibrary: Opentelemetry_Proto_Common_V1_InstrumentationLibrary? = nil
 }
 
-/// Defines a Metric which has one or more timeseries.
+/// Defines a Metric which has one or more timeseries.  The following is a
+/// brief summary of the Metric data model.  For more details, see:
+///
+///   https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md
+///
 ///
 /// The data model and relation between entities is shown in the
 /// diagram below. Here, "DataPoint" is the term used to refer to any
@@ -208,8 +359,8 @@ public struct Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics {
 ///
 /// - Metric is composed of a metadata and data.
 /// - Metadata part contains a name, description, unit.
-/// - Data is one of the possible types (Gauge, Sum, Histogram, etc.).
-/// - DataPoint contains timestamps, labels, and one of the possible value type
+/// - Data is one of the possible types (Sum, Gauge, Histogram, Summary).
+/// - DataPoint contains timestamps, attributes, and one of the possible value type
 ///   fields.
 ///
 ///     Metric
@@ -249,14 +400,37 @@ public struct Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics {
 ///                        |+-----+                    |
 ///                        +---------------------------+
 ///
+/// Each distinct type of DataPoint represents the output of a specific
+/// aggregation function, the result of applying the DataPoint's
+/// associated function of to one or more measurements.
+///
 /// All DataPoint types have three common fields:
-/// - Labels zero or more key-value pairs associated with the data point.
-/// - StartTimeUnixNano MUST be set to the start of the interval when the data's
-///   type includes an AggregationTemporality. This field is not set otherwise.
-/// - TimeUnixNano MUST be set to:
-///   - the moment when an aggregation is reported (independent of the
-///     aggregation temporality).
-///   - the instantaneous time of the event.
+/// - Attributes includes key-value pairs associated with the data point
+/// - TimeUnixNano is required, set to the end time of the aggregation
+/// - StartTimeUnixNano is optional, but strongly encouraged for DataPoints
+///   having an AggregationTemporality field, as discussed below.
+///
+/// Both TimeUnixNano and StartTimeUnixNano values are expressed as
+/// UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+///
+/// # TimeUnixNano
+///
+/// This field is required, having consistent interpretation across
+/// DataPoint types.  TimeUnixNano is the moment corresponding to when
+/// the data point's aggregate value was captured.
+///
+/// Data points with the 0 value for TimeUnixNano SHOULD be rejected
+/// by consumers.
+///
+/// # StartTimeUnixNano
+///
+/// StartTimeUnixNano in general allows detecting when a sequence of
+/// observations is unbroken.  This field indicates to consumers the
+/// start time for points with cumulative and delta
+/// AggregationTemporality, and it should be included whenever possible
+/// to support correct rate calculation.  Although it may be omitted
+/// when the start time is truly unknown, setting StartTimeUnixNano is
+/// strongly encouraged.
 public struct Opentelemetry_Proto_Metrics_V1_Metric {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -275,76 +449,46 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
   /// Data determines the aggregation type (if any) of the metric, what is the
   /// reported value type for the data points, as well as the relatationship to
   /// the time interval over which they are reported.
-  ///
-  /// TODO: Update table after the decision on:
-  /// https://github.com/open-telemetry/opentelemetry-specification/issues/731.
-  /// By default, metrics recording using the OpenTelemetry API are exported as
-  /// (the table does not include MeasurementValueType to avoid extra rows):
-  ///
-  ///   Instrument         Type
-  ///   ----------------------------------------------
-  ///   Counter            Sum(aggregation_temporality=delta;is_monotonic=true)
-  ///   UpDownCounter      Sum(aggregation_temporality=delta;is_monotonic=false)
-  ///   ValueRecorder      TBD
-  ///   SumObserver        Sum(aggregation_temporality=cumulative;is_monotonic=true)
-  ///   UpDownSumObserver  Sum(aggregation_temporality=cumulative;is_monotonic=false)
-  ///   ValueObserver      Gauge()
   public var data: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data? = nil
 
-  public var intGauge: Opentelemetry_Proto_Metrics_V1_IntGauge {
+  public var gauge: Opentelemetry_Proto_Metrics_V1_Gauge {
     get {
-      if case .intGauge(let v)? = data {return v}
-      return Opentelemetry_Proto_Metrics_V1_IntGauge()
+      if case .gauge(let v)? = data {return v}
+      return Opentelemetry_Proto_Metrics_V1_Gauge()
     }
-    set {data = .intGauge(newValue)}
+    set {data = .gauge(newValue)}
   }
 
-  public var doubleGauge: Opentelemetry_Proto_Metrics_V1_DoubleGauge {
+  public var sum: Opentelemetry_Proto_Metrics_V1_Sum {
     get {
-      if case .doubleGauge(let v)? = data {return v}
-      return Opentelemetry_Proto_Metrics_V1_DoubleGauge()
+      if case .sum(let v)? = data {return v}
+      return Opentelemetry_Proto_Metrics_V1_Sum()
     }
-    set {data = .doubleGauge(newValue)}
+    set {data = .sum(newValue)}
   }
 
-  public var intSum: Opentelemetry_Proto_Metrics_V1_IntSum {
+  public var histogram: Opentelemetry_Proto_Metrics_V1_Histogram {
     get {
-      if case .intSum(let v)? = data {return v}
-      return Opentelemetry_Proto_Metrics_V1_IntSum()
+      if case .histogram(let v)? = data {return v}
+      return Opentelemetry_Proto_Metrics_V1_Histogram()
     }
-    set {data = .intSum(newValue)}
+    set {data = .histogram(newValue)}
   }
 
-  public var doubleSum: Opentelemetry_Proto_Metrics_V1_DoubleSum {
+  public var exponentialHistogram: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram {
     get {
-      if case .doubleSum(let v)? = data {return v}
-      return Opentelemetry_Proto_Metrics_V1_DoubleSum()
+      if case .exponentialHistogram(let v)? = data {return v}
+      return Opentelemetry_Proto_Metrics_V1_ExponentialHistogram()
     }
-    set {data = .doubleSum(newValue)}
+    set {data = .exponentialHistogram(newValue)}
   }
 
-  public var intHistogram: Opentelemetry_Proto_Metrics_V1_IntHistogram {
+  public var summary: Opentelemetry_Proto_Metrics_V1_Summary {
     get {
-      if case .intHistogram(let v)? = data {return v}
-      return Opentelemetry_Proto_Metrics_V1_IntHistogram()
+      if case .summary(let v)? = data {return v}
+      return Opentelemetry_Proto_Metrics_V1_Summary()
     }
-    set {data = .intHistogram(newValue)}
-  }
-
-  public var doubleHistogram: Opentelemetry_Proto_Metrics_V1_DoubleHistogram {
-    get {
-      if case .doubleHistogram(let v)? = data {return v}
-      return Opentelemetry_Proto_Metrics_V1_DoubleHistogram()
-    }
-    set {data = .doubleHistogram(newValue)}
-  }
-
-  public var doubleSummary: Opentelemetry_Proto_Metrics_V1_DoubleSummary {
-    get {
-      if case .doubleSummary(let v)? = data {return v}
-      return Opentelemetry_Proto_Metrics_V1_DoubleSummary()
-    }
-    set {data = .doubleSummary(newValue)}
+    set {data = .summary(newValue)}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -352,28 +496,12 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
   /// Data determines the aggregation type (if any) of the metric, what is the
   /// reported value type for the data points, as well as the relatationship to
   /// the time interval over which they are reported.
-  ///
-  /// TODO: Update table after the decision on:
-  /// https://github.com/open-telemetry/opentelemetry-specification/issues/731.
-  /// By default, metrics recording using the OpenTelemetry API are exported as
-  /// (the table does not include MeasurementValueType to avoid extra rows):
-  ///
-  ///   Instrument         Type
-  ///   ----------------------------------------------
-  ///   Counter            Sum(aggregation_temporality=delta;is_monotonic=true)
-  ///   UpDownCounter      Sum(aggregation_temporality=delta;is_monotonic=false)
-  ///   ValueRecorder      TBD
-  ///   SumObserver        Sum(aggregation_temporality=cumulative;is_monotonic=true)
-  ///   UpDownSumObserver  Sum(aggregation_temporality=cumulative;is_monotonic=false)
-  ///   ValueObserver      Gauge()
   public enum OneOf_Data: Equatable {
-    case intGauge(Opentelemetry_Proto_Metrics_V1_IntGauge)
-    case doubleGauge(Opentelemetry_Proto_Metrics_V1_DoubleGauge)
-    case intSum(Opentelemetry_Proto_Metrics_V1_IntSum)
-    case doubleSum(Opentelemetry_Proto_Metrics_V1_DoubleSum)
-    case intHistogram(Opentelemetry_Proto_Metrics_V1_IntHistogram)
-    case doubleHistogram(Opentelemetry_Proto_Metrics_V1_DoubleHistogram)
-    case doubleSummary(Opentelemetry_Proto_Metrics_V1_DoubleSummary)
+    case gauge(Opentelemetry_Proto_Metrics_V1_Gauge)
+    case sum(Opentelemetry_Proto_Metrics_V1_Sum)
+    case histogram(Opentelemetry_Proto_Metrics_V1_Histogram)
+    case exponentialHistogram(Opentelemetry_Proto_Metrics_V1_ExponentialHistogram)
+    case summary(Opentelemetry_Proto_Metrics_V1_Summary)
 
   #if !swift(>=4.1)
     public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data, rhs: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data) -> Bool {
@@ -381,32 +509,24 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch (lhs, rhs) {
-      case (.intGauge, .intGauge): return {
-        guard case .intGauge(let l) = lhs, case .intGauge(let r) = rhs else { preconditionFailure() }
+      case (.gauge, .gauge): return {
+        guard case .gauge(let l) = lhs, case .gauge(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
-      case (.doubleGauge, .doubleGauge): return {
-        guard case .doubleGauge(let l) = lhs, case .doubleGauge(let r) = rhs else { preconditionFailure() }
+      case (.sum, .sum): return {
+        guard case .sum(let l) = lhs, case .sum(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
-      case (.intSum, .intSum): return {
-        guard case .intSum(let l) = lhs, case .intSum(let r) = rhs else { preconditionFailure() }
+      case (.histogram, .histogram): return {
+        guard case .histogram(let l) = lhs, case .histogram(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
-      case (.doubleSum, .doubleSum): return {
-        guard case .doubleSum(let l) = lhs, case .doubleSum(let r) = rhs else { preconditionFailure() }
+      case (.exponentialHistogram, .exponentialHistogram): return {
+        guard case .exponentialHistogram(let l) = lhs, case .exponentialHistogram(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
-      case (.intHistogram, .intHistogram): return {
-        guard case .intHistogram(let l) = lhs, case .intHistogram(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.doubleHistogram, .doubleHistogram): return {
-        guard case .doubleHistogram(let l) = lhs, case .doubleHistogram(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.doubleSummary, .doubleSummary): return {
-        guard case .doubleSummary(let l) = lhs, case .doubleSummary(let r) = rhs else { preconditionFailure() }
+      case (.summary, .summary): return {
+        guard case .summary(let l) = lhs, case .summary(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       default: return false
@@ -418,56 +538,35 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
   public init() {}
 }
 
-/// Gauge represents the type of a int scalar metric that always exports the
+/// Gauge represents the type of a scalar metric that always exports the
 /// "current value" for every data point. It should be used for an "unknown"
 /// aggregation.
-/// 
+///
 /// A Gauge does not support different aggregation temporalities. Given the
 /// aggregation is unknown, points cannot be combined using the same
 /// aggregation, regardless of aggregation temporalities. Therefore,
 /// AggregationTemporality is not included. Consequently, this also means
 /// "StartTimeUnixNano" is ignored for all data points.
-public struct Opentelemetry_Proto_Metrics_V1_IntGauge {
+public struct Opentelemetry_Proto_Metrics_V1_Gauge {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_IntDataPoint] = []
+  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_NumberDataPoint] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 }
 
-/// Gauge represents the type of a double scalar metric that always exports the
-/// "current value" for every data point. It should be used for an "unknown"
-/// aggregation.
-/// 
-/// A Gauge does not support different aggregation temporalities. Given the
-/// aggregation is unknown, points cannot be combined using the same
-/// aggregation, regardless of aggregation temporalities. Therefore,
-/// AggregationTemporality is not included. Consequently, this also means
-/// "StartTimeUnixNano" is ignored for all data points.
-public struct Opentelemetry_Proto_Metrics_V1_DoubleGauge {
+/// Sum represents the type of a scalar metric that is calculated as a sum of all
+/// reported measurements over a time interval.
+public struct Opentelemetry_Proto_Metrics_V1_Sum {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_DoubleDataPoint] = []
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
-/// Sum represents the type of a numeric int scalar metric that is calculated as
-/// a sum of all reported measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_IntSum {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_IntDataPoint] = []
+  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_NumberDataPoint] = []
 
   /// aggregation_temporality describes if the aggregator reports delta changes
   /// since last report time, or cumulative changes since a fixed start time.
@@ -481,35 +580,14 @@ public struct Opentelemetry_Proto_Metrics_V1_IntSum {
   public init() {}
 }
 
-/// Sum represents the type of a numeric double scalar metric that is calculated
-/// as a sum of all reported measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_DoubleSum {
+/// Histogram represents the type of a metric that is calculated by aggregating
+/// as a Histogram of all reported measurements over a time interval.
+public struct Opentelemetry_Proto_Metrics_V1_Histogram {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_DoubleDataPoint] = []
-
-  /// aggregation_temporality describes if the aggregator reports delta changes
-  /// since last report time, or cumulative changes since a fixed start time.
-  public var aggregationTemporality: Opentelemetry_Proto_Metrics_V1_AggregationTemporality = .unspecified
-
-  /// If "true" means that the sum is monotonic.
-  public var isMonotonic: Bool = false
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
-/// Represents the type of a metric that is calculated by aggregating as a
-/// Histogram of all reported int measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_IntHistogram {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint] = []
+  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_HistogramDataPoint] = []
 
   /// aggregation_temporality describes if the aggregator reports delta changes
   /// since last report time, or cumulative changes since a fixed start time.
@@ -520,14 +598,14 @@ public struct Opentelemetry_Proto_Metrics_V1_IntHistogram {
   public init() {}
 }
 
-/// Represents the type of a metric that is calculated by aggregating as a
-/// Histogram of all reported double measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_DoubleHistogram {
+/// ExponentialHistogram represents the type of a metric that is calculated by aggregating
+/// as a ExponentialHistogram of all reported double measurements over a time interval.
+public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogram {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint] = []
+  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint] = []
 
   /// aggregation_temporality describes if the aggregator reports delta changes
   /// since last report time, or cumulative changes since a fixed start time.
@@ -538,212 +616,139 @@ public struct Opentelemetry_Proto_Metrics_V1_DoubleHistogram {
   public init() {}
 }
 
-/// DoubleSummary metric data are used to convey quantile summaries,
+/// Summary metric data are used to convey quantile summaries,
 /// a Prometheus (see: https://prometheus.io/docs/concepts/metric_types/#summary)
 /// and OpenMetrics (see: https://github.com/OpenObservability/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45)
 /// data type. These data points cannot always be merged in a meaningful way.
 /// While they can be useful in some applications, histogram data points are
 /// recommended for new applications.
-public struct Opentelemetry_Proto_Metrics_V1_DoubleSummary {
+public struct Opentelemetry_Proto_Metrics_V1_Summary {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint] = []
+  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_SummaryDataPoint] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 }
 
-/// IntDataPoint is a single data point in a timeseries that describes the
-/// time-varying values of a int64 metric.
-public struct Opentelemetry_Proto_Metrics_V1_IntDataPoint {
+/// NumberDataPoint is a single data point in a timeseries that describes the
+/// time-varying scalar value of a metric.
+public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// The set of labels that uniquely identify this timeseries.
-  public var labels: [Opentelemetry_Proto_Common_V1_StringKeyValue] = []
+  /// The set of key/value pairs that uniquely identify the timeseries from
+  /// where this point belongs. The list may be empty (may contain 0 elements).
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
+  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
-  /// start_time_unix_nano is the last time when the aggregation value was reset
-  /// to "zero". For some metric types this is ignored, see data types for more
-  /// details.
+  /// StartTimeUnixNano is optional but strongly encouraged, see the
+  /// the detailed comments above Metric.
   ///
-  /// The aggregation value is over the time interval (start_time_unix_nano,
-  /// time_unix_nano].
-  /// 
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  ///
-  /// Value of 0 indicates that the timestamp is unspecified. In that case the
-  /// timestamp may be decided by the backend.
   public var startTimeUnixNano: UInt64 = 0
 
-  /// time_unix_nano is the moment when this aggregation value was reported.
-  /// 
+  /// TimeUnixNano is required, see the detailed comments above Metric.
+  ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
   public var timeUnixNano: UInt64 = 0
 
-  /// value itself.
-  public var value: Int64 = 0
+  /// The value itself.  A point is considered invalid when one of the recognized
+  /// value fields is not present inside this oneof.
+  public var value: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value? = nil
+
+  public var asDouble: Double {
+    get {
+      if case .asDouble(let v)? = value {return v}
+      return 0
+    }
+    set {value = .asDouble(newValue)}
+  }
+
+  public var asInt: Int64 {
+    get {
+      if case .asInt(let v)? = value {return v}
+      return 0
+    }
+    set {value = .asInt(newValue)}
+  }
 
   /// (Optional) List of exemplars collected from
   /// measurements that were used to form the data point
-  public var exemplars: [Opentelemetry_Proto_Metrics_V1_IntExemplar] = []
+  public var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
+
+  /// Flags that apply to this specific data point.  See DataPointFlags
+  /// for the available flags and their meaning.
+  public var flags: UInt32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
-}
+  /// The value itself.  A point is considered invalid when one of the recognized
+  /// value fields is not present inside this oneof.
+  public enum OneOf_Value: Equatable {
+    case asDouble(Double)
+    case asInt(Int64)
 
-/// DoubleDataPoint is a single data point in a timeseries that describes the
-/// time-varying value of a double metric.
-public struct Opentelemetry_Proto_Metrics_V1_DoubleDataPoint {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  /// The set of labels that uniquely identify this timeseries.
-  public var labels: [Opentelemetry_Proto_Common_V1_StringKeyValue] = []
-
-  /// start_time_unix_nano is the last time when the aggregation value was reset
-  /// to "zero". For some metric types this is ignored, see data types for more
-  /// details.
-  ///
-  /// The aggregation value is over the time interval (start_time_unix_nano,
-  /// time_unix_nano].
-  /// 
-  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  /// 1970.
-  ///
-  /// Value of 0 indicates that the timestamp is unspecified. In that case the
-  /// timestamp may be decided by the backend.
-  public var startTimeUnixNano: UInt64 = 0
-
-  /// time_unix_nano is the moment when this aggregation value was reported.
-  /// 
-  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  /// 1970.
-  public var timeUnixNano: UInt64 = 0
-
-  /// value itself.
-  public var value: Double = 0
-
-  /// (Optional) List of exemplars collected from
-  /// measurements that were used to form the data point
-  public var exemplars: [Opentelemetry_Proto_Metrics_V1_DoubleExemplar] = []
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
-/// IntHistogramDataPoint is a single data point in a timeseries that describes
-/// the time-varying values of a Histogram of int values. A Histogram contains
-/// summary statistics for a population of values, it may optionally contain
-/// the distribution of those values across a set of buckets.
-public struct Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  /// The set of labels that uniquely identify this timeseries.
-  public var labels: [Opentelemetry_Proto_Common_V1_StringKeyValue] = []
-
-  /// start_time_unix_nano is the last time when the aggregation value was reset
-  /// to "zero". For some metric types this is ignored, see data types for more
-  /// details.
-  ///
-  /// The aggregation value is over the time interval (start_time_unix_nano,
-  /// time_unix_nano].
-  /// 
-  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  /// 1970.
-  ///
-  /// Value of 0 indicates that the timestamp is unspecified. In that case the
-  /// timestamp may be decided by the backend.
-  public var startTimeUnixNano: UInt64 = 0
-
-  /// time_unix_nano is the moment when this aggregation value was reported.
-  /// 
-  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  /// 1970.
-  public var timeUnixNano: UInt64 = 0
-
-  /// count is the number of values in the population. Must be non-negative. This
-  /// value must be equal to the sum of the "count" fields in buckets if a
-  /// histogram is provided.
-  public var count: UInt64 = 0
-
-  /// sum of the values in the population. If count is zero then this field
-  /// must be zero. This value must be equal to the sum of the "sum" fields in
-  /// buckets if a histogram is provided.
-  public var sum: Int64 = 0
-
-  /// bucket_counts is an optional field contains the count values of histogram
-  /// for each bucket.
-  ///
-  /// The sum of the bucket_counts must equal the value in the count field.
-  ///
-  /// The number of elements in bucket_counts array must be by one greater than
-  /// the number of elements in explicit_bounds array.
-  public var bucketCounts: [UInt64] = []
-
-  /// explicit_bounds specifies buckets with explicitly defined bounds for values.
-  /// The bucket boundaries are described by "bounds" field.
-  ///
-  /// This defines size(bounds) + 1 (= N) buckets. The boundaries for bucket
-  /// at index i are:
-  ///
-  /// (-infinity, bounds[i]) for i == 0
-  /// [bounds[i-1], bounds[i]) for 0 < i < N-1
-  /// [bounds[i], +infinity) for i == N-1
-  /// The values in bounds array must be strictly increasing.
-  ///
-  /// Note: only [a, b) intervals are currently supported for each bucket except the first one.
-  /// If we decide to also support (a, b] intervals we should add support for these by defining
-  /// a boolean value which decides what type of intervals to use.
-  public var explicitBounds: [Double] = []
-
-  /// (Optional) List of exemplars collected from
-  /// measurements that were used to form the data point
-  public var exemplars: [Opentelemetry_Proto_Metrics_V1_IntExemplar] = []
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  #if !swift(>=4.1)
+    public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value, rhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value) -> Bool {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch (lhs, rhs) {
+      case (.asDouble, .asDouble): return {
+        guard case .asDouble(let l) = lhs, case .asDouble(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.asInt, .asInt): return {
+        guard case .asInt(let l) = lhs, case .asInt(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      default: return false
+      }
+    }
+  #endif
+  }
 
   public init() {}
 }
 
 /// HistogramDataPoint is a single data point in a timeseries that describes the
-/// time-varying values of a Histogram of double values. A Histogram contains
-/// summary statistics for a population of values, it may optionally contain the
-/// distribution of those values across a set of buckets.
-public struct Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint {
+/// time-varying values of a Histogram. A Histogram contains summary statistics
+/// for a population of values, it may optionally contain the distribution of
+/// those values across a set of buckets.
+///
+/// If the histogram contains the distribution of values, then both
+/// "explicit_bounds" and "bucket counts" fields must be defined.
+/// If the histogram does not contain the distribution of values, then both
+/// "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
+/// "sum" are known.
+public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// The set of labels that uniquely identify this timeseries.
-  public var labels: [Opentelemetry_Proto_Common_V1_StringKeyValue] = []
+  /// The set of key/value pairs that uniquely identify the timeseries from
+  /// where this point belongs. The list may be empty (may contain 0 elements).
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
+  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
-  /// start_time_unix_nano is the last time when the aggregation value was reset
-  /// to "zero". For some metric types this is ignored, see data types for more
-  /// details.
+  /// StartTimeUnixNano is optional but strongly encouraged, see the
+  /// the detailed comments above Metric.
   ///
-  /// The aggregation value is over the time interval (start_time_unix_nano,
-  /// time_unix_nano].
-  /// 
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  ///
-  /// Value of 0 indicates that the timestamp is unspecified. In that case the
-  /// timestamp may be decided by the backend.
   public var startTimeUnixNano: UInt64 = 0
 
-  /// time_unix_nano is the moment when this aggregation value was reported.
-  /// 
+  /// TimeUnixNano is required, see the detailed comments above Metric.
+  ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
   public var timeUnixNano: UInt64 = 0
@@ -754,9 +759,21 @@ public struct Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint {
   public var count: UInt64 = 0
 
   /// sum of the values in the population. If count is zero then this field
-  /// must be zero. This value must be equal to the sum of the "sum" fields in
-  /// buckets if a histogram is provided.
-  public var sum: Double = 0
+  /// must be zero.
+  ///
+  /// Note: Sum should only be filled out when measuring non-negative discrete
+  /// events, and is assumed to be monotonic over the values of these events.
+  /// Negative events *can* be recorded, but sum should not be filled out when
+  /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  public var sum: Double {
+    get {return _sum ?? 0}
+    set {_sum = newValue}
+  }
+  /// Returns true if `sum` has been explicitly set.
+  public var hasSum: Bool {return self._sum != nil}
+  /// Clears the value of `sum`. Subsequent reads from it will return its default value.
+  public mutating func clearSum() {self._sum = nil}
 
   /// bucket_counts is an optional field contains the count values of histogram
   /// for each bucket.
@@ -768,55 +785,234 @@ public struct Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint {
   public var bucketCounts: [UInt64] = []
 
   /// explicit_bounds specifies buckets with explicitly defined bounds for values.
-  /// The bucket boundaries are described by "bounds" field.
   ///
-  /// This defines size(bounds) + 1 (= N) buckets. The boundaries for bucket
-  /// at index i are:
+  /// The boundaries for bucket at index i are:
   ///
-  /// (-infinity, bounds[i]) for i == 0
-  /// [bounds[i-1], bounds[i]) for 0 < i < N-1
-  /// [bounds[i], +infinity) for i == N-1
-  /// The values in bounds array must be strictly increasing.
+  /// (-infinity, explicit_bounds[i]] for i == 0
+  /// (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+  /// (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
   ///
-  /// Note: only [a, b) intervals are currently supported for each bucket except the first one.
-  /// If we decide to also support (a, b] intervals we should add support for these by defining
-  /// a boolean value which decides what type of intervals to use.
+  /// The values in the explicit_bounds array must be strictly increasing.
+  ///
+  /// Histogram buckets are inclusive of their upper boundary, except the last
+  /// bucket where the boundary is at infinity. This format is intentionally
+  /// compatible with the OpenMetrics histogram definition.
   public var explicitBounds: [Double] = []
 
   /// (Optional) List of exemplars collected from
   /// measurements that were used to form the data point
-  public var exemplars: [Opentelemetry_Proto_Metrics_V1_DoubleExemplar] = []
+  public var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
+
+  /// Flags that apply to this specific data point.  See DataPointFlags
+  /// for the available flags and their meaning.
+  public var flags: UInt32 = 0
+
+  /// min is the minimum value over (start_time, end_time].
+  public var min: Double {
+    get {return _min ?? 0}
+    set {_min = newValue}
+  }
+  /// Returns true if `min` has been explicitly set.
+  public var hasMin: Bool {return self._min != nil}
+  /// Clears the value of `min`. Subsequent reads from it will return its default value.
+  public mutating func clearMin() {self._min = nil}
+
+  /// max is the maximum value over (start_time, end_time].
+  public var max: Double {
+    get {return _max ?? 0}
+    set {_max = newValue}
+  }
+  /// Returns true if `max` has been explicitly set.
+  public var hasMax: Bool {return self._max != nil}
+  /// Clears the value of `max`. Subsequent reads from it will return its default value.
+  public mutating func clearMax() {self._max = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _sum: Double? = nil
+  fileprivate var _min: Double? = nil
+  fileprivate var _max: Double? = nil
 }
 
-/// DoubleSummaryDataPoint is a single data point in a timeseries that describes the
-/// time-varying values of a Summary metric.
-public struct Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint {
+/// ExponentialHistogramDataPoint is a single data point in a timeseries that describes the
+/// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
+/// summary statistics for a population of values, it may optionally contain the
+/// distribution of those values across a set of buckets.
+public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// The set of labels that uniquely identify this timeseries.
-  public var labels: [Opentelemetry_Proto_Common_V1_StringKeyValue] = []
+  /// The set of key/value pairs that uniquely identify the timeseries from
+  /// where this point belongs. The list may be empty (may contain 0 elements).
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
+  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
-  /// start_time_unix_nano is the last time when the aggregation value was reset
-  /// to "zero". For some metric types this is ignored, see data types for more
-  /// details.
-  ///
-  /// The aggregation value is over the time interval (start_time_unix_nano,
-  /// time_unix_nano].
+  /// StartTimeUnixNano is optional but strongly encouraged, see the
+  /// the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  ///
-  /// Value of 0 indicates that the timestamp is unspecified. In that case the
-  /// timestamp may be decided by the backend.
   public var startTimeUnixNano: UInt64 = 0
 
-  /// time_unix_nano is the moment when this aggregation value was reported.
+  /// TimeUnixNano is required, see the detailed comments above Metric.
+  ///
+  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  /// 1970.
+  public var timeUnixNano: UInt64 = 0
+
+  /// count is the number of values in the population. Must be
+  /// non-negative. This value must be equal to the sum of the "bucket_counts"
+  /// values in the positive and negative Buckets plus the "zero_count" field.
+  public var count: UInt64 = 0
+
+  /// sum of the values in the population. If count is zero then this field
+  /// must be zero.
+  ///
+  /// Note: Sum should only be filled out when measuring non-negative discrete
+  /// events, and is assumed to be monotonic over the values of these events.
+  /// Negative events *can* be recorded, but sum should not be filled out when
+  /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  public var sum: Double = 0
+
+  /// scale describes the resolution of the histogram.  Boundaries are
+  /// located at powers of the base, where:
+  ///
+  ///   base = (2^(2^-scale))
+  ///
+  /// The histogram bucket identified by `index`, a signed integer,
+  /// contains values that are greater than or equal to (base^index) and
+  /// less than (base^(index+1)).
+  ///
+  /// The positive and negative ranges of the histogram are expressed
+  /// separately.  Negative values are mapped by their absolute value
+  /// into the negative range using the same scale as the positive range.
+  ///
+  /// scale is not restricted by the protocol, as the permissible
+  /// values depend on the range of the data.
+  public var scale: Int32 = 0
+
+  /// zero_count is the count of values that are either exactly zero or
+  /// within the region considered zero by the instrumentation at the
+  /// tolerated degree of precision.  This bucket stores values that
+  /// cannot be expressed using the standard exponential formula as
+  /// well as values that have been rounded to zero.
+  ///
+  /// Implementations MAY consider the zero bucket to have probability
+  /// mass equal to (zero_count / count).
+  public var zeroCount: UInt64 = 0
+
+  /// positive carries the positive range of exponential bucket counts.
+  public var positive: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets {
+    get {return _positive ?? Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets()}
+    set {_positive = newValue}
+  }
+  /// Returns true if `positive` has been explicitly set.
+  public var hasPositive: Bool {return self._positive != nil}
+  /// Clears the value of `positive`. Subsequent reads from it will return its default value.
+  public mutating func clearPositive() {self._positive = nil}
+
+  /// negative carries the negative range of exponential bucket counts.
+  public var negative: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets {
+    get {return _negative ?? Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets()}
+    set {_negative = newValue}
+  }
+  /// Returns true if `negative` has been explicitly set.
+  public var hasNegative: Bool {return self._negative != nil}
+  /// Clears the value of `negative`. Subsequent reads from it will return its default value.
+  public mutating func clearNegative() {self._negative = nil}
+
+  /// Flags that apply to this specific data point.  See DataPointFlags
+  /// for the available flags and their meaning.
+  public var flags: UInt32 = 0
+
+  /// (Optional) List of exemplars collected from
+  /// measurements that were used to form the data point
+  public var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
+
+  /// min is the minimum value over (start_time, end_time].
+  public var min: Double {
+    get {return _min ?? 0}
+    set {_min = newValue}
+  }
+  /// Returns true if `min` has been explicitly set.
+  public var hasMin: Bool {return self._min != nil}
+  /// Clears the value of `min`. Subsequent reads from it will return its default value.
+  public mutating func clearMin() {self._min = nil}
+
+  /// max is the maximum value over (start_time, end_time].
+  public var max: Double {
+    get {return _max ?? 0}
+    set {_max = newValue}
+  }
+  /// Returns true if `max` has been explicitly set.
+  public var hasMax: Bool {return self._max != nil}
+  /// Clears the value of `max`. Subsequent reads from it will return its default value.
+  public mutating func clearMax() {self._max = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  /// Buckets are a set of bucket counts, encoded in a contiguous array
+  /// of counts.
+  public struct Buckets {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    /// Offset is the bucket index of the first entry in the bucket_counts array.
+    /// 
+    /// Note: This uses a varint encoding as a simple form of compression.
+    public var offset: Int32 = 0
+
+    /// Count is an array of counts, where count[i] carries the count
+    /// of the bucket at index (offset+i).  count[i] is the count of
+    /// values greater than or equal to base^(offset+i) and less than
+    /// base^(offset+i+1).
+    ///
+    /// Note: By contrast, the explicit HistogramDataPoint uses
+    /// fixed64.  This field is expected to have many buckets,
+    /// especially zeros, so uint64 has been selected to ensure
+    /// varint encoding.
+    public var bucketCounts: [UInt64] = []
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  public init() {}
+
+  fileprivate var _positive: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets? = nil
+  fileprivate var _negative: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets? = nil
+  fileprivate var _min: Double? = nil
+  fileprivate var _max: Double? = nil
+}
+
+/// SummaryDataPoint is a single data point in a timeseries that describes the
+/// time-varying values of a Summary metric.
+public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The set of key/value pairs that uniquely identify the timeseries from
+  /// where this point belongs. The list may be empty (may contain 0 elements).
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
+  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+
+  /// StartTimeUnixNano is optional but strongly encouraged, see the
+  /// the detailed comments above Metric.
+  ///
+  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  /// 1970.
+  public var startTimeUnixNano: UInt64 = 0
+
+  /// TimeUnixNano is required, see the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
@@ -827,11 +1023,21 @@ public struct Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint {
 
   /// sum of the values in the population. If count is zero then this field
   /// must be zero.
+  ///
+  /// Note: Sum should only be filled out when measuring non-negative discrete
+  /// events, and is assumed to be monotonic over the values of these events.
+  /// Negative events *can* be recorded, but sum should not be filled out when
+  /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
   public var sum: Double = 0
 
   /// (Optional) list of values at different quantiles of the distribution calculated
   /// from the current snapshot. The quantiles must be strictly increasing.
-  public var quantileValues: [Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint.ValueAtQuantile] = []
+  public var quantileValues: [Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile] = []
+
+  /// Flags that apply to this specific data point.  See DataPointFlags
+  /// for the available flags and their meaning.
+  public var flags: UInt32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -853,6 +1059,8 @@ public struct Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint {
     public var quantile: Double = 0
 
     /// The value at the given quantile of a distribution.
+    ///
+    /// Quantile values must NOT be negative.
     public var value: Double = 0
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -863,19 +1071,19 @@ public struct Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint {
   public init() {}
 }
 
-/// A representation of an exemplar, which is a sample input int measurement.
+/// A representation of an exemplar, which is a sample input measurement.
 /// Exemplars also hold information about the environment when the measurement
 /// was recorded, for example the span and trace ID of the active span when the
 /// exemplar was recorded.
-public struct Opentelemetry_Proto_Metrics_V1_IntExemplar {
+public struct Opentelemetry_Proto_Metrics_V1_Exemplar {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// The set of labels that were filtered out by the aggregator, but recorded
-  /// alongside the original measurement. Only labels that were filtered out
-  /// by the aggregator should be included
-  public var filteredLabels: [Opentelemetry_Proto_Common_V1_StringKeyValue] = []
+  /// The set of key/value pairs that were filtered out by the aggregator, but
+  /// recorded alongside the original measurement. Only key/value pairs that were
+  /// filtered out by the aggregator should be included
+  public var filteredAttributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// time_unix_nano is the exact time when this exemplar was recorded
   ///
@@ -883,8 +1091,26 @@ public struct Opentelemetry_Proto_Metrics_V1_IntExemplar {
   /// 1970.
   public var timeUnixNano: UInt64 = 0
 
-  /// Numerical int value of the measurement that was recorded.
-  public var value: Int64 = 0
+  /// The value of the measurement that was recorded. An exemplar is
+  /// considered invalid when one of the recognized value fields is not present
+  /// inside this oneof.
+  public var value: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value? = nil
+
+  public var asDouble: Double {
+    get {
+      if case .asDouble(let v)? = value {return v}
+      return 0
+    }
+    set {value = .asDouble(newValue)}
+  }
+
+  public var asInt: Int64 {
+    get {
+      if case .asInt(let v)? = value {return v}
+      return 0
+    }
+    set {value = .asInt(newValue)}
+  }
 
   /// (Optional) Span ID of the exemplar trace.
   /// span_id may be missing if the measurement is not recorded inside a trace
@@ -898,46 +1124,60 @@ public struct Opentelemetry_Proto_Metrics_V1_IntExemplar {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
-}
+  /// The value of the measurement that was recorded. An exemplar is
+  /// considered invalid when one of the recognized value fields is not present
+  /// inside this oneof.
+  public enum OneOf_Value: Equatable {
+    case asDouble(Double)
+    case asInt(Int64)
 
-/// A representation of an exemplar, which is a sample input double measurement.
-/// Exemplars also hold information about the environment when the measurement
-/// was recorded, for example the span and trace ID of the active span when the
-/// exemplar was recorded.
-public struct Opentelemetry_Proto_Metrics_V1_DoubleExemplar {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  /// The set of labels that were filtered out by the aggregator, but recorded
-  /// alongside the original measurement. Only labels that were filtered out
-  /// by the aggregator should be included
-  public var filteredLabels: [Opentelemetry_Proto_Common_V1_StringKeyValue] = []
-
-  /// time_unix_nano is the exact time when this exemplar was recorded
-  ///
-  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  /// 1970.
-  public var timeUnixNano: UInt64 = 0
-
-  /// Numerical double value of the measurement that was recorded.
-  public var value: Double = 0
-
-  /// (Optional) Span ID of the exemplar trace.
-  /// span_id may be missing if the measurement is not recorded inside a trace
-  /// or if the trace is not sampled.
-  public var spanID: Data = Data()
-
-  /// (Optional) Trace ID of the exemplar trace.
-  /// trace_id may be missing if the measurement is not recorded inside a trace
-  /// or if the trace is not sampled.
-  public var traceID: Data = Data()
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  #if !swift(>=4.1)
+    public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value, rhs: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value) -> Bool {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch (lhs, rhs) {
+      case (.asDouble, .asDouble): return {
+        guard case .asDouble(let l) = lhs, case .asDouble(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.asInt, .asInt): return {
+        guard case .asInt(let l) = lhs, case .asInt(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      default: return false
+      }
+    }
+  #endif
+  }
 
   public init() {}
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_MetricsData: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_Metric: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_Gauge: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_Sum: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_Histogram: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_Summary: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_Exemplar: @unchecked Sendable {}
+extension Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -951,11 +1191,52 @@ extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf._
   ]
 }
 
+extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FLAG_NONE"),
+    1: .same(proto: "FLAG_NO_RECORDED_VALUE"),
+  ]
+}
+
+extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".MetricsData"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "resource_metrics"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.resourceMetrics) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.resourceMetrics.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.resourceMetrics, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_MetricsData, rhs: Opentelemetry_Proto_Metrics_V1_MetricsData) -> Bool {
+    if lhs.resourceMetrics != rhs.resourceMetrics {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ResourceMetrics"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "resource"),
-    2: .standard(proto: "instrumentation_library_metrics"),
+    2: .standard(proto: "scope_metrics"),
+    1000: .standard(proto: "instrumentation_library_metrics"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -965,25 +1246,87 @@ extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message,
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._resource) }()
-      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibraryMetrics) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.scopeMetrics) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      case 1000: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibraryMetrics) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._resource {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._resource {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.scopeMetrics.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.scopeMetrics, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     if !self.instrumentationLibraryMetrics.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.instrumentationLibraryMetrics, fieldNumber: 2)
+      try visitor.visitRepeatedMessageField(value: self.instrumentationLibraryMetrics, fieldNumber: 1000)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ResourceMetrics, rhs: Opentelemetry_Proto_Metrics_V1_ResourceMetrics) -> Bool {
     if lhs._resource != rhs._resource {return false}
+    if lhs.scopeMetrics != rhs.scopeMetrics {return false}
     if lhs.instrumentationLibraryMetrics != rhs.instrumentationLibraryMetrics {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ScopeMetrics"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "scope"),
+    2: .same(proto: "metrics"),
+    3: .standard(proto: "schema_url"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._scope) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.metrics) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._scope {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.metrics.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.metrics, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ScopeMetrics, rhs: Opentelemetry_Proto_Metrics_V1_ScopeMetrics) -> Bool {
+    if lhs._scope != rhs._scope {return false}
+    if lhs.metrics != rhs.metrics {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -994,6 +1337,7 @@ extension Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics: SwiftPro
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "instrumentation_library"),
     2: .same(proto: "metrics"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1004,17 +1348,25 @@ extension Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics: SwiftPro
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._instrumentationLibrary) }()
       case 2: try { try decoder.decodeRepeatedMessageField(value: &self.metrics) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._instrumentationLibrary {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._instrumentationLibrary {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.metrics.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.metrics, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1022,6 +1374,7 @@ extension Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics: SwiftPro
   public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics, rhs: Opentelemetry_Proto_Metrics_V1_InstrumentationLibraryMetrics) -> Bool {
     if lhs._instrumentationLibrary != rhs._instrumentationLibrary {return false}
     if lhs.metrics != rhs.metrics {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1033,13 +1386,11 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
     1: .same(proto: "name"),
     2: .same(proto: "description"),
     3: .same(proto: "unit"),
-    4: .standard(proto: "int_gauge"),
-    5: .standard(proto: "double_gauge"),
-    6: .standard(proto: "int_sum"),
-    7: .standard(proto: "double_sum"),
-    8: .standard(proto: "int_histogram"),
-    9: .standard(proto: "double_histogram"),
-    11: .standard(proto: "double_summary"),
+    5: .same(proto: "gauge"),
+    7: .same(proto: "sum"),
+    9: .same(proto: "histogram"),
+    10: .standard(proto: "exponential_histogram"),
+    11: .same(proto: "summary"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1051,68 +1402,70 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
       case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.description_p) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.unit) }()
-      case 4: try {
-        var v: Opentelemetry_Proto_Metrics_V1_IntGauge?
-        if let current = self.data {
-          try decoder.handleConflictingOneOf()
-          if case .intGauge(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.data = .intGauge(v)}
-      }()
       case 5: try {
-        var v: Opentelemetry_Proto_Metrics_V1_DoubleGauge?
+        var v: Opentelemetry_Proto_Metrics_V1_Gauge?
+        var hadOneofValue = false
         if let current = self.data {
-          try decoder.handleConflictingOneOf()
-          if case .doubleGauge(let m) = current {v = m}
+          hadOneofValue = true
+          if case .gauge(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.data = .doubleGauge(v)}
-      }()
-      case 6: try {
-        var v: Opentelemetry_Proto_Metrics_V1_IntSum?
-        if let current = self.data {
-          try decoder.handleConflictingOneOf()
-          if case .intSum(let m) = current {v = m}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.data = .gauge(v)
         }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.data = .intSum(v)}
       }()
       case 7: try {
-        var v: Opentelemetry_Proto_Metrics_V1_DoubleSum?
+        var v: Opentelemetry_Proto_Metrics_V1_Sum?
+        var hadOneofValue = false
         if let current = self.data {
-          try decoder.handleConflictingOneOf()
-          if case .doubleSum(let m) = current {v = m}
+          hadOneofValue = true
+          if case .sum(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.data = .doubleSum(v)}
-      }()
-      case 8: try {
-        var v: Opentelemetry_Proto_Metrics_V1_IntHistogram?
-        if let current = self.data {
-          try decoder.handleConflictingOneOf()
-          if case .intHistogram(let m) = current {v = m}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.data = .sum(v)
         }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.data = .intHistogram(v)}
       }()
       case 9: try {
-        var v: Opentelemetry_Proto_Metrics_V1_DoubleHistogram?
+        var v: Opentelemetry_Proto_Metrics_V1_Histogram?
+        var hadOneofValue = false
         if let current = self.data {
-          try decoder.handleConflictingOneOf()
-          if case .doubleHistogram(let m) = current {v = m}
+          hadOneofValue = true
+          if case .histogram(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.data = .doubleHistogram(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.data = .histogram(v)
+        }
+      }()
+      case 10: try {
+        var v: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram?
+        var hadOneofValue = false
+        if let current = self.data {
+          hadOneofValue = true
+          if case .exponentialHistogram(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.data = .exponentialHistogram(v)
+        }
       }()
       case 11: try {
-        var v: Opentelemetry_Proto_Metrics_V1_DoubleSummary?
+        var v: Opentelemetry_Proto_Metrics_V1_Summary?
+        var hadOneofValue = false
         if let current = self.data {
-          try decoder.handleConflictingOneOf()
-          if case .doubleSummary(let m) = current {v = m}
+          hadOneofValue = true
+          if case .summary(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.data = .doubleSummary(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.data = .summary(v)
+        }
       }()
       default: break
       }
@@ -1120,6 +1473,10 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
@@ -1129,36 +1486,25 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
     if !self.unit.isEmpty {
       try visitor.visitSingularStringField(value: self.unit, fieldNumber: 3)
     }
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
     switch self.data {
-    case .intGauge?: try {
-      guard case .intGauge(let v)? = self.data else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-    }()
-    case .doubleGauge?: try {
-      guard case .doubleGauge(let v)? = self.data else { preconditionFailure() }
+    case .gauge?: try {
+      guard case .gauge(let v)? = self.data else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
     }()
-    case .intSum?: try {
-      guard case .intSum(let v)? = self.data else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }()
-    case .doubleSum?: try {
-      guard case .doubleSum(let v)? = self.data else { preconditionFailure() }
+    case .sum?: try {
+      guard case .sum(let v)? = self.data else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
     }()
-    case .intHistogram?: try {
-      guard case .intHistogram(let v)? = self.data else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    }()
-    case .doubleHistogram?: try {
-      guard case .doubleHistogram(let v)? = self.data else { preconditionFailure() }
+    case .histogram?: try {
+      guard case .histogram(let v)? = self.data else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
     }()
-    case .doubleSummary?: try {
-      guard case .doubleSummary(let v)? = self.data else { preconditionFailure() }
+    case .exponentialHistogram?: try {
+      guard case .exponentialHistogram(let v)? = self.data else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    }()
+    case .summary?: try {
+      guard case .summary(let v)? = self.data else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }()
     case nil: break
@@ -1176,8 +1522,8 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_IntGauge: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".IntGauge"
+extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Gauge"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
   ]
@@ -1201,47 +1547,15 @@ extension Opentelemetry_Proto_Metrics_V1_IntGauge: SwiftProtobuf.Message, SwiftP
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_IntGauge, rhs: Opentelemetry_Proto_Metrics_V1_IntGauge) -> Bool {
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Gauge, rhs: Opentelemetry_Proto_Metrics_V1_Gauge) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DoubleGauge: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".DoubleGauge"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "data_points"),
-  ]
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.dataPoints) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.dataPoints.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.dataPoints, fieldNumber: 1)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleGauge, rhs: Opentelemetry_Proto_Metrics_V1_DoubleGauge) -> Bool {
-    if lhs.dataPoints != rhs.dataPoints {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Opentelemetry_Proto_Metrics_V1_IntSum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".IntSum"
+extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Sum"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
     2: .standard(proto: "aggregation_temporality"),
@@ -1275,7 +1589,7 @@ extension Opentelemetry_Proto_Metrics_V1_IntSum: SwiftProtobuf.Message, SwiftPro
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_IntSum, rhs: Opentelemetry_Proto_Metrics_V1_IntSum) -> Bool {
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Sum, rhs: Opentelemetry_Proto_Metrics_V1_Sum) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.aggregationTemporality != rhs.aggregationTemporality {return false}
     if lhs.isMonotonic != rhs.isMonotonic {return false}
@@ -1284,52 +1598,8 @@ extension Opentelemetry_Proto_Metrics_V1_IntSum: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DoubleSum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".DoubleSum"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "data_points"),
-    2: .standard(proto: "aggregation_temporality"),
-    3: .standard(proto: "is_monotonic"),
-  ]
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.dataPoints) }()
-      case 2: try { try decoder.decodeSingularEnumField(value: &self.aggregationTemporality) }()
-      case 3: try { try decoder.decodeSingularBoolField(value: &self.isMonotonic) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.dataPoints.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.dataPoints, fieldNumber: 1)
-    }
-    if self.aggregationTemporality != .unspecified {
-      try visitor.visitSingularEnumField(value: self.aggregationTemporality, fieldNumber: 2)
-    }
-    if self.isMonotonic != false {
-      try visitor.visitSingularBoolField(value: self.isMonotonic, fieldNumber: 3)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleSum, rhs: Opentelemetry_Proto_Metrics_V1_DoubleSum) -> Bool {
-    if lhs.dataPoints != rhs.dataPoints {return false}
-    if lhs.aggregationTemporality != rhs.aggregationTemporality {return false}
-    if lhs.isMonotonic != rhs.isMonotonic {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Opentelemetry_Proto_Metrics_V1_IntHistogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".IntHistogram"
+extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Histogram"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
     2: .standard(proto: "aggregation_temporality"),
@@ -1358,7 +1628,7 @@ extension Opentelemetry_Proto_Metrics_V1_IntHistogram: SwiftProtobuf.Message, Sw
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_IntHistogram, rhs: Opentelemetry_Proto_Metrics_V1_IntHistogram) -> Bool {
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Histogram, rhs: Opentelemetry_Proto_Metrics_V1_Histogram) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.aggregationTemporality != rhs.aggregationTemporality {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -1366,8 +1636,8 @@ extension Opentelemetry_Proto_Metrics_V1_IntHistogram: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DoubleHistogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".DoubleHistogram"
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ExponentialHistogram"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
     2: .standard(proto: "aggregation_temporality"),
@@ -1396,7 +1666,7 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleHistogram: SwiftProtobuf.Message,
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleHistogram, rhs: Opentelemetry_Proto_Metrics_V1_DoubleHistogram) -> Bool {
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.aggregationTemporality != rhs.aggregationTemporality {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -1404,8 +1674,8 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleHistogram: SwiftProtobuf.Message,
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DoubleSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".DoubleSummary"
+extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Summary"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
   ]
@@ -1429,21 +1699,23 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleSummary: SwiftProtobuf.Message, S
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleSummary, rhs: Opentelemetry_Proto_Metrics_V1_DoubleSummary) -> Bool {
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Summary, rhs: Opentelemetry_Proto_Metrics_V1_Summary) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_IntDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".IntDataPoint"
+extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".NumberDataPoint"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "labels"),
+    7: .same(proto: "attributes"),
     2: .standard(proto: "start_time_unix_nano"),
     3: .standard(proto: "time_unix_nano"),
-    4: .same(proto: "value"),
+    4: .standard(proto: "as_double"),
+    6: .standard(proto: "as_int"),
     5: .same(proto: "exemplars"),
+    8: .same(proto: "flags"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1452,106 +1724,77 @@ extension Opentelemetry_Proto_Metrics_V1_IntDataPoint: SwiftProtobuf.Message, Sw
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.labels) }()
       case 2: try { try decoder.decodeSingularFixed64Field(value: &self.startTimeUnixNano) }()
       case 3: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
-      case 4: try { try decoder.decodeSingularSFixed64Field(value: &self.value) }()
+      case 4: try {
+        var v: Double?
+        try decoder.decodeSingularDoubleField(value: &v)
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .asDouble(v)
+        }
+      }()
       case 5: try { try decoder.decodeRepeatedMessageField(value: &self.exemplars) }()
+      case 6: try {
+        var v: Int64?
+        try decoder.decodeSingularSFixed64Field(value: &v)
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .asInt(v)
+        }
+      }()
+      case 7: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
+      case 8: try { try decoder.decodeSingularUInt32Field(value: &self.flags) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.labels.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.labels, fieldNumber: 1)
-    }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.startTimeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.startTimeUnixNano, fieldNumber: 2)
     }
     if self.timeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.timeUnixNano, fieldNumber: 3)
     }
-    if self.value != 0 {
-      try visitor.visitSingularSFixed64Field(value: self.value, fieldNumber: 4)
-    }
+    try { if case .asDouble(let v)? = self.value {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 4)
+    } }()
     if !self.exemplars.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.exemplars, fieldNumber: 5)
+    }
+    try { if case .asInt(let v)? = self.value {
+      try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 6)
+    } }()
+    if !self.attributes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 7)
+    }
+    if self.flags != 0 {
+      try visitor.visitSingularUInt32Field(value: self.flags, fieldNumber: 8)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_IntDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_IntDataPoint) -> Bool {
-    if lhs.labels != rhs.labels {return false}
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint) -> Bool {
+    if lhs.attributes != rhs.attributes {return false}
     if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
     if lhs.value != rhs.value {return false}
     if lhs.exemplars != rhs.exemplars {return false}
+    if lhs.flags != rhs.flags {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DoubleDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".DoubleDataPoint"
+extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".HistogramDataPoint"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "labels"),
-    2: .standard(proto: "start_time_unix_nano"),
-    3: .standard(proto: "time_unix_nano"),
-    4: .same(proto: "value"),
-    5: .same(proto: "exemplars"),
-  ]
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.labels) }()
-      case 2: try { try decoder.decodeSingularFixed64Field(value: &self.startTimeUnixNano) }()
-      case 3: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
-      case 4: try { try decoder.decodeSingularDoubleField(value: &self.value) }()
-      case 5: try { try decoder.decodeRepeatedMessageField(value: &self.exemplars) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.labels.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.labels, fieldNumber: 1)
-    }
-    if self.startTimeUnixNano != 0 {
-      try visitor.visitSingularFixed64Field(value: self.startTimeUnixNano, fieldNumber: 2)
-    }
-    if self.timeUnixNano != 0 {
-      try visitor.visitSingularFixed64Field(value: self.timeUnixNano, fieldNumber: 3)
-    }
-    if self.value != 0 {
-      try visitor.visitSingularDoubleField(value: self.value, fieldNumber: 4)
-    }
-    if !self.exemplars.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.exemplars, fieldNumber: 5)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_DoubleDataPoint) -> Bool {
-    if lhs.labels != rhs.labels {return false}
-    if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
-    if lhs.timeUnixNano != rhs.timeUnixNano {return false}
-    if lhs.value != rhs.value {return false}
-    if lhs.exemplars != rhs.exemplars {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".IntHistogramDataPoint"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "labels"),
+    9: .same(proto: "attributes"),
     2: .standard(proto: "start_time_unix_nano"),
     3: .standard(proto: "time_unix_nano"),
     4: .same(proto: "count"),
@@ -1559,6 +1802,9 @@ extension Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint: SwiftProtobuf.Me
     6: .standard(proto: "bucket_counts"),
     7: .standard(proto: "explicit_bounds"),
     8: .same(proto: "exemplars"),
+    10: .same(proto: "flags"),
+    11: .same(proto: "min"),
+    12: .same(proto: "max"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1567,23 +1813,27 @@ extension Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint: SwiftProtobuf.Me
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.labels) }()
       case 2: try { try decoder.decodeSingularFixed64Field(value: &self.startTimeUnixNano) }()
       case 3: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
       case 4: try { try decoder.decodeSingularFixed64Field(value: &self.count) }()
-      case 5: try { try decoder.decodeSingularSFixed64Field(value: &self.sum) }()
+      case 5: try { try decoder.decodeSingularDoubleField(value: &self._sum) }()
       case 6: try { try decoder.decodeRepeatedFixed64Field(value: &self.bucketCounts) }()
       case 7: try { try decoder.decodeRepeatedDoubleField(value: &self.explicitBounds) }()
       case 8: try { try decoder.decodeRepeatedMessageField(value: &self.exemplars) }()
+      case 9: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
+      case 10: try { try decoder.decodeSingularUInt32Field(value: &self.flags) }()
+      case 11: try { try decoder.decodeSingularDoubleField(value: &self._min) }()
+      case 12: try { try decoder.decodeSingularDoubleField(value: &self._max) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.labels.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.labels, fieldNumber: 1)
-    }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.startTimeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.startTimeUnixNano, fieldNumber: 2)
     }
@@ -1593,9 +1843,9 @@ extension Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint: SwiftProtobuf.Me
     if self.count != 0 {
       try visitor.visitSingularFixed64Field(value: self.count, fieldNumber: 4)
     }
-    if self.sum != 0 {
-      try visitor.visitSingularSFixed64Field(value: self.sum, fieldNumber: 5)
-    }
+    try { if let v = self._sum {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 5)
+    } }()
     if !self.bucketCounts.isEmpty {
       try visitor.visitPackedFixed64Field(value: self.bucketCounts, fieldNumber: 6)
     }
@@ -1605,34 +1855,54 @@ extension Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint: SwiftProtobuf.Me
     if !self.exemplars.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.exemplars, fieldNumber: 8)
     }
+    if !self.attributes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 9)
+    }
+    if self.flags != 0 {
+      try visitor.visitSingularUInt32Field(value: self.flags, fieldNumber: 10)
+    }
+    try { if let v = self._min {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 11)
+    } }()
+    try { if let v = self._max {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 12)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_IntHistogramDataPoint) -> Bool {
-    if lhs.labels != rhs.labels {return false}
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_HistogramDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_HistogramDataPoint) -> Bool {
+    if lhs.attributes != rhs.attributes {return false}
     if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
     if lhs.count != rhs.count {return false}
-    if lhs.sum != rhs.sum {return false}
+    if lhs._sum != rhs._sum {return false}
     if lhs.bucketCounts != rhs.bucketCounts {return false}
     if lhs.explicitBounds != rhs.explicitBounds {return false}
     if lhs.exemplars != rhs.exemplars {return false}
+    if lhs.flags != rhs.flags {return false}
+    if lhs._min != rhs._min {return false}
+    if lhs._max != rhs._max {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".DoubleHistogramDataPoint"
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ExponentialHistogramDataPoint"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "labels"),
+    1: .same(proto: "attributes"),
     2: .standard(proto: "start_time_unix_nano"),
     3: .standard(proto: "time_unix_nano"),
     4: .same(proto: "count"),
     5: .same(proto: "sum"),
-    6: .standard(proto: "bucket_counts"),
-    7: .standard(proto: "explicit_bounds"),
-    8: .same(proto: "exemplars"),
+    6: .same(proto: "scale"),
+    7: .standard(proto: "zero_count"),
+    8: .same(proto: "positive"),
+    9: .same(proto: "negative"),
+    10: .same(proto: "flags"),
+    11: .same(proto: "exemplars"),
+    12: .same(proto: "min"),
+    13: .same(proto: "max"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1641,22 +1911,31 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint: SwiftProtobuf
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.labels) }()
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
       case 2: try { try decoder.decodeSingularFixed64Field(value: &self.startTimeUnixNano) }()
       case 3: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
       case 4: try { try decoder.decodeSingularFixed64Field(value: &self.count) }()
       case 5: try { try decoder.decodeSingularDoubleField(value: &self.sum) }()
-      case 6: try { try decoder.decodeRepeatedFixed64Field(value: &self.bucketCounts) }()
-      case 7: try { try decoder.decodeRepeatedDoubleField(value: &self.explicitBounds) }()
-      case 8: try { try decoder.decodeRepeatedMessageField(value: &self.exemplars) }()
+      case 6: try { try decoder.decodeSingularSInt32Field(value: &self.scale) }()
+      case 7: try { try decoder.decodeSingularFixed64Field(value: &self.zeroCount) }()
+      case 8: try { try decoder.decodeSingularMessageField(value: &self._positive) }()
+      case 9: try { try decoder.decodeSingularMessageField(value: &self._negative) }()
+      case 10: try { try decoder.decodeSingularUInt32Field(value: &self.flags) }()
+      case 11: try { try decoder.decodeRepeatedMessageField(value: &self.exemplars) }()
+      case 12: try { try decoder.decodeSingularDoubleField(value: &self._min) }()
+      case 13: try { try decoder.decodeSingularDoubleField(value: &self._max) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.labels.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.labels, fieldNumber: 1)
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if !self.attributes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 1)
     }
     if self.startTimeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.startTimeUnixNano, fieldNumber: 2)
@@ -1670,41 +1949,57 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint: SwiftProtobuf
     if self.sum != 0 {
       try visitor.visitSingularDoubleField(value: self.sum, fieldNumber: 5)
     }
-    if !self.bucketCounts.isEmpty {
-      try visitor.visitPackedFixed64Field(value: self.bucketCounts, fieldNumber: 6)
+    if self.scale != 0 {
+      try visitor.visitSingularSInt32Field(value: self.scale, fieldNumber: 6)
     }
-    if !self.explicitBounds.isEmpty {
-      try visitor.visitPackedDoubleField(value: self.explicitBounds, fieldNumber: 7)
+    if self.zeroCount != 0 {
+      try visitor.visitSingularFixed64Field(value: self.zeroCount, fieldNumber: 7)
+    }
+    try { if let v = self._positive {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    } }()
+    try { if let v = self._negative {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    } }()
+    if self.flags != 0 {
+      try visitor.visitSingularUInt32Field(value: self.flags, fieldNumber: 10)
     }
     if !self.exemplars.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.exemplars, fieldNumber: 8)
+      try visitor.visitRepeatedMessageField(value: self.exemplars, fieldNumber: 11)
     }
+    try { if let v = self._min {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 12)
+    } }()
+    try { if let v = self._max {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 13)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint) -> Bool {
-    if lhs.labels != rhs.labels {return false}
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint) -> Bool {
+    if lhs.attributes != rhs.attributes {return false}
     if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
     if lhs.count != rhs.count {return false}
     if lhs.sum != rhs.sum {return false}
-    if lhs.bucketCounts != rhs.bucketCounts {return false}
-    if lhs.explicitBounds != rhs.explicitBounds {return false}
+    if lhs.scale != rhs.scale {return false}
+    if lhs.zeroCount != rhs.zeroCount {return false}
+    if lhs._positive != rhs._positive {return false}
+    if lhs._negative != rhs._negative {return false}
+    if lhs.flags != rhs.flags {return false}
     if lhs.exemplars != rhs.exemplars {return false}
+    if lhs._min != rhs._min {return false}
+    if lhs._max != rhs._max {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".DoubleSummaryDataPoint"
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.protoMessageName + ".Buckets"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "labels"),
-    2: .standard(proto: "start_time_unix_nano"),
-    3: .standard(proto: "time_unix_nano"),
-    4: .same(proto: "count"),
-    5: .same(proto: "sum"),
-    6: .standard(proto: "quantile_values"),
+    1: .same(proto: "offset"),
+    2: .standard(proto: "bucket_counts"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1713,21 +2008,62 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint: SwiftProtobuf.M
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.labels) }()
-      case 2: try { try decoder.decodeSingularFixed64Field(value: &self.startTimeUnixNano) }()
-      case 3: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
-      case 4: try { try decoder.decodeSingularFixed64Field(value: &self.count) }()
-      case 5: try { try decoder.decodeSingularDoubleField(value: &self.sum) }()
-      case 6: try { try decoder.decodeRepeatedMessageField(value: &self.quantileValues) }()
+      case 1: try { try decoder.decodeSingularSInt32Field(value: &self.offset) }()
+      case 2: try { try decoder.decodeRepeatedUInt64Field(value: &self.bucketCounts) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.labels.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.labels, fieldNumber: 1)
+    if self.offset != 0 {
+      try visitor.visitSingularSInt32Field(value: self.offset, fieldNumber: 1)
     }
+    if !self.bucketCounts.isEmpty {
+      try visitor.visitPackedUInt64Field(value: self.bucketCounts, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets) -> Bool {
+    if lhs.offset != rhs.offset {return false}
+    if lhs.bucketCounts != rhs.bucketCounts {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SummaryDataPoint"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    7: .same(proto: "attributes"),
+    2: .standard(proto: "start_time_unix_nano"),
+    3: .standard(proto: "time_unix_nano"),
+    4: .same(proto: "count"),
+    5: .same(proto: "sum"),
+    6: .standard(proto: "quantile_values"),
+    8: .same(proto: "flags"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 2: try { try decoder.decodeSingularFixed64Field(value: &self.startTimeUnixNano) }()
+      case 3: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
+      case 4: try { try decoder.decodeSingularFixed64Field(value: &self.count) }()
+      case 5: try { try decoder.decodeSingularDoubleField(value: &self.sum) }()
+      case 6: try { try decoder.decodeRepeatedMessageField(value: &self.quantileValues) }()
+      case 7: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
+      case 8: try { try decoder.decodeSingularUInt32Field(value: &self.flags) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if self.startTimeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.startTimeUnixNano, fieldNumber: 2)
     }
@@ -1743,23 +2079,30 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint: SwiftProtobuf.M
     if !self.quantileValues.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.quantileValues, fieldNumber: 6)
     }
+    if !self.attributes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 7)
+    }
+    if self.flags != 0 {
+      try visitor.visitSingularUInt32Field(value: self.flags, fieldNumber: 8)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint) -> Bool {
-    if lhs.labels != rhs.labels {return false}
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint) -> Bool {
+    if lhs.attributes != rhs.attributes {return false}
     if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
     if lhs.count != rhs.count {return false}
     if lhs.sum != rhs.sum {return false}
     if lhs.quantileValues != rhs.quantileValues {return false}
+    if lhs.flags != rhs.flags {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint.ValueAtQuantile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint.protoMessageName + ".ValueAtQuantile"
+extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.protoMessageName + ".ValueAtQuantile"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "quantile"),
     2: .same(proto: "value"),
@@ -1788,7 +2131,7 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint.ValueAtQuantile:
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint.ValueAtQuantile, rhs: Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint.ValueAtQuantile) -> Bool {
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile, rhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile) -> Bool {
     if lhs.quantile != rhs.quantile {return false}
     if lhs.value != rhs.value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -1796,12 +2139,13 @@ extension Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint.ValueAtQuantile:
   }
 }
 
-extension Opentelemetry_Proto_Metrics_V1_IntExemplar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".IntExemplar"
+extension Opentelemetry_Proto_Metrics_V1_Exemplar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".Exemplar"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "filtered_labels"),
+    7: .standard(proto: "filtered_attributes"),
     2: .standard(proto: "time_unix_nano"),
-    3: .same(proto: "value"),
+    3: .standard(proto: "as_double"),
+    6: .standard(proto: "as_int"),
     4: .standard(proto: "span_id"),
     5: .standard(proto: "trace_id"),
   ]
@@ -1812,93 +2156,59 @@ extension Opentelemetry_Proto_Metrics_V1_IntExemplar: SwiftProtobuf.Message, Swi
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.filteredLabels) }()
       case 2: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
-      case 3: try { try decoder.decodeSingularSFixed64Field(value: &self.value) }()
+      case 3: try {
+        var v: Double?
+        try decoder.decodeSingularDoubleField(value: &v)
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .asDouble(v)
+        }
+      }()
       case 4: try { try decoder.decodeSingularBytesField(value: &self.spanID) }()
       case 5: try { try decoder.decodeSingularBytesField(value: &self.traceID) }()
+      case 6: try {
+        var v: Int64?
+        try decoder.decodeSingularSFixed64Field(value: &v)
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .asInt(v)
+        }
+      }()
+      case 7: try { try decoder.decodeRepeatedMessageField(value: &self.filteredAttributes) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.filteredLabels.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.filteredLabels, fieldNumber: 1)
-    }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.timeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.timeUnixNano, fieldNumber: 2)
     }
-    if self.value != 0 {
-      try visitor.visitSingularSFixed64Field(value: self.value, fieldNumber: 3)
-    }
+    try { if case .asDouble(let v)? = self.value {
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 3)
+    } }()
     if !self.spanID.isEmpty {
       try visitor.visitSingularBytesField(value: self.spanID, fieldNumber: 4)
     }
     if !self.traceID.isEmpty {
       try visitor.visitSingularBytesField(value: self.traceID, fieldNumber: 5)
     }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_IntExemplar, rhs: Opentelemetry_Proto_Metrics_V1_IntExemplar) -> Bool {
-    if lhs.filteredLabels != rhs.filteredLabels {return false}
-    if lhs.timeUnixNano != rhs.timeUnixNano {return false}
-    if lhs.value != rhs.value {return false}
-    if lhs.spanID != rhs.spanID {return false}
-    if lhs.traceID != rhs.traceID {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Opentelemetry_Proto_Metrics_V1_DoubleExemplar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".DoubleExemplar"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "filtered_labels"),
-    2: .standard(proto: "time_unix_nano"),
-    3: .same(proto: "value"),
-    4: .standard(proto: "span_id"),
-    5: .standard(proto: "trace_id"),
-  ]
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.filteredLabels) }()
-      case 2: try { try decoder.decodeSingularFixed64Field(value: &self.timeUnixNano) }()
-      case 3: try { try decoder.decodeSingularDoubleField(value: &self.value) }()
-      case 4: try { try decoder.decodeSingularBytesField(value: &self.spanID) }()
-      case 5: try { try decoder.decodeSingularBytesField(value: &self.traceID) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.filteredLabels.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.filteredLabels, fieldNumber: 1)
-    }
-    if self.timeUnixNano != 0 {
-      try visitor.visitSingularFixed64Field(value: self.timeUnixNano, fieldNumber: 2)
-    }
-    if self.value != 0 {
-      try visitor.visitSingularDoubleField(value: self.value, fieldNumber: 3)
-    }
-    if !self.spanID.isEmpty {
-      try visitor.visitSingularBytesField(value: self.spanID, fieldNumber: 4)
-    }
-    if !self.traceID.isEmpty {
-      try visitor.visitSingularBytesField(value: self.traceID, fieldNumber: 5)
+    try { if case .asInt(let v)? = self.value {
+      try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 6)
+    } }()
+    if !self.filteredAttributes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.filteredAttributes, fieldNumber: 7)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_DoubleExemplar, rhs: Opentelemetry_Proto_Metrics_V1_DoubleExemplar) -> Bool {
-    if lhs.filteredLabels != rhs.filteredLabels {return false}
+  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Exemplar, rhs: Opentelemetry_Proto_Metrics_V1_Exemplar) -> Bool {
+    if lhs.filteredAttributes != rhs.filteredAttributes {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
     if lhs.value != rhs.value {return false}
     if lhs.spanID != rhs.spanID {return false}

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/metrics.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/metrics.pb.swift
@@ -807,33 +807,11 @@ public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
   /// for the available flags and their meaning.
   public var flags: UInt32 = 0
 
-  /// min is the minimum value over (start_time, end_time].
-  public var min: Double {
-    get {return _min ?? 0}
-    set {_min = newValue}
-  }
-  /// Returns true if `min` has been explicitly set.
-  public var hasMin: Bool {return self._min != nil}
-  /// Clears the value of `min`. Subsequent reads from it will return its default value.
-  public mutating func clearMin() {self._min = nil}
-
-  /// max is the maximum value over (start_time, end_time].
-  public var max: Double {
-    get {return _max ?? 0}
-    set {_max = newValue}
-  }
-  /// Returns true if `max` has been explicitly set.
-  public var hasMax: Bool {return self._max != nil}
-  /// Clears the value of `max`. Subsequent reads from it will return its default value.
-  public mutating func clearMax() {self._max = nil}
-
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _sum: Double? = nil
-  fileprivate var _min: Double? = nil
-  fileprivate var _max: Double? = nil
 }
 
 /// ExponentialHistogramDataPoint is a single data point in a timeseries that describes the
@@ -934,26 +912,6 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   /// measurements that were used to form the data point
   public var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
 
-  /// min is the minimum value over (start_time, end_time].
-  public var min: Double {
-    get {return _min ?? 0}
-    set {_min = newValue}
-  }
-  /// Returns true if `min` has been explicitly set.
-  public var hasMin: Bool {return self._min != nil}
-  /// Clears the value of `min`. Subsequent reads from it will return its default value.
-  public mutating func clearMin() {self._min = nil}
-
-  /// max is the maximum value over (start_time, end_time].
-  public var max: Double {
-    get {return _max ?? 0}
-    set {_max = newValue}
-  }
-  /// Returns true if `max` has been explicitly set.
-  public var hasMax: Bool {return self._max != nil}
-  /// Clears the value of `max`. Subsequent reads from it will return its default value.
-  public mutating func clearMax() {self._max = nil}
-
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Buckets are a set of bucket counts, encoded in a contiguous array
@@ -988,8 +946,6 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
 
   fileprivate var _positive: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets? = nil
   fileprivate var _negative: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets? = nil
-  fileprivate var _min: Double? = nil
-  fileprivate var _max: Double? = nil
 }
 
 /// SummaryDataPoint is a single data point in a timeseries that describes the
@@ -1803,8 +1759,6 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
     7: .standard(proto: "explicit_bounds"),
     8: .same(proto: "exemplars"),
     10: .same(proto: "flags"),
-    11: .same(proto: "min"),
-    12: .same(proto: "max"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1822,8 +1776,6 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
       case 8: try { try decoder.decodeRepeatedMessageField(value: &self.exemplars) }()
       case 9: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
       case 10: try { try decoder.decodeSingularUInt32Field(value: &self.flags) }()
-      case 11: try { try decoder.decodeSingularDoubleField(value: &self._min) }()
-      case 12: try { try decoder.decodeSingularDoubleField(value: &self._max) }()
       default: break
       }
     }
@@ -1861,12 +1813,6 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
     if self.flags != 0 {
       try visitor.visitSingularUInt32Field(value: self.flags, fieldNumber: 10)
     }
-    try { if let v = self._min {
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 11)
-    } }()
-    try { if let v = self._max {
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 12)
-    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1880,8 +1826,6 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
     if lhs.explicitBounds != rhs.explicitBounds {return false}
     if lhs.exemplars != rhs.exemplars {return false}
     if lhs.flags != rhs.flags {return false}
-    if lhs._min != rhs._min {return false}
-    if lhs._max != rhs._max {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1901,8 +1845,6 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
     9: .same(proto: "negative"),
     10: .same(proto: "flags"),
     11: .same(proto: "exemplars"),
-    12: .same(proto: "min"),
-    13: .same(proto: "max"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1922,8 +1864,6 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
       case 9: try { try decoder.decodeSingularMessageField(value: &self._negative) }()
       case 10: try { try decoder.decodeSingularUInt32Field(value: &self.flags) }()
       case 11: try { try decoder.decodeRepeatedMessageField(value: &self.exemplars) }()
-      case 12: try { try decoder.decodeSingularDoubleField(value: &self._min) }()
-      case 13: try { try decoder.decodeSingularDoubleField(value: &self._max) }()
       default: break
       }
     }
@@ -1967,12 +1907,6 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
     if !self.exemplars.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.exemplars, fieldNumber: 11)
     }
-    try { if let v = self._min {
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 12)
-    } }()
-    try { if let v = self._max {
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 13)
-    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1988,8 +1922,6 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
     if lhs._negative != rhs._negative {return false}
     if lhs.flags != rhs.flags {return false}
     if lhs.exemplars != rhs.exemplars {return false}
-    if lhs._min != rhs._min {return false}
-    if lhs._max != rhs._max {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/metrics_service.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/metrics_service.pb.swift
@@ -61,6 +61,11 @@ public struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRespo
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: @unchecked Sendable {}
+extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.collector.metrics.v1"

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/resource.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/resource.pb.swift
@@ -40,7 +40,9 @@ public struct Opentelemetry_Proto_Resource_V1_Resource {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// Set of labels that describe the resource.
+  /// Set of attributes that describe the resource.
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
   public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// dropped_attributes_count is the number of dropped attributes. If the value is 0, then
@@ -51,6 +53,10 @@ public struct Opentelemetry_Proto_Resource_V1_Resource {
 
   public init() {}
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Resource_V1_Resource: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/trace.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/trace.pb.swift
@@ -34,7 +34,34 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-/// A collection of InstrumentationLibrarySpans from a Resource.
+/// TracesData represents the traces data that can be stored in a persistent storage,
+/// OR can be embedded by other protocols that transfer OTLP traces data but do
+/// not implement the OTLP protocol.
+///
+/// The main difference between this message and collector protocol is that
+/// in this message there will not be any "control" or "metadata" specific to
+/// OTLP protocol.
+///
+/// When new fields are added into this message, the OTLP request MUST be updated
+/// as well.
+public struct Opentelemetry_Proto_Trace_V1_TracesData {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// An array of ResourceSpans.
+  /// For data coming from a single resource this array will typically contain
+  /// one element. Intermediary nodes that receive data from multiple origins
+  /// typically batch the data before forwarding further and in that case this
+  /// array will contain multiple elements.
+  public var resourceSpans: [Opentelemetry_Proto_Trace_V1_ResourceSpans] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// A collection of ScopeSpans from a Resource.
 public struct Opentelemetry_Proto_Trace_V1_ResourceSpans {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -51,8 +78,41 @@ public struct Opentelemetry_Proto_Trace_V1_ResourceSpans {
   /// Clears the value of `resource`. Subsequent reads from it will return its default value.
   public mutating func clearResource() {self._resource = nil}
 
+  /// A list of ScopeSpans that originate from a resource.
+  public var scopeSpans: [Opentelemetry_Proto_Trace_V1_ScopeSpans] = []
+
   /// A list of InstrumentationLibrarySpans that originate from a resource.
+  /// This field is deprecated and will be removed after grace period expires on June 15, 2022.
+  ///
+  /// During the grace period the following rules SHOULD be followed:
+  ///
+  /// For Binary Protobufs
+  /// ====================
+  /// Binary Protobuf senders SHOULD NOT set instrumentation_library_spans. Instead
+  /// scope_spans SHOULD be set.
+  ///
+  /// Binary Protobuf receivers SHOULD check if instrumentation_library_spans is set
+  /// and scope_spans is not set then the value in instrumentation_library_spans
+  /// SHOULD be used instead by converting InstrumentationLibrarySpans into ScopeSpans.
+  /// If scope_spans is set then instrumentation_library_spans SHOULD be ignored.
+  ///
+  /// For JSON
+  /// ========
+  /// JSON senders that set instrumentation_library_spans field MAY also set
+  /// scope_spans to carry the same spans, essentially double-publishing the same data.
+  /// Such double-publishing MAY be controlled by a user-settable option.
+  /// If double-publishing is not used then the senders SHOULD set scope_spans and
+  /// SHOULD NOT set instrumentation_library_spans.
+  ///
+  /// JSON receivers SHOULD check if instrumentation_library_spans is set and
+  /// scope_spans is not set then the value in instrumentation_library_spans
+  /// SHOULD be used instead by converting InstrumentationLibrarySpans into ScopeSpans.
+  /// If scope_spans is set then instrumentation_library_spans field SHOULD be ignored.
   public var instrumentationLibrarySpans: [Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans] = []
+
+  /// This schema_url applies to the data in the "resource" field. It does not apply
+  /// to the data in the "scope_spans" field which have their own schema_url field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -61,7 +121,41 @@ public struct Opentelemetry_Proto_Trace_V1_ResourceSpans {
   fileprivate var _resource: Opentelemetry_Proto_Resource_V1_Resource? = nil
 }
 
+/// A collection of Spans produced by an InstrumentationScope.
+public struct Opentelemetry_Proto_Trace_V1_ScopeSpans {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The instrumentation scope information for the spans in this message.
+  /// Semantically when InstrumentationScope isn't set, it is equivalent with
+  /// an empty instrumentation scope name (unknown).
+  public var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
+    get {return _scope ?? Opentelemetry_Proto_Common_V1_InstrumentationScope()}
+    set {_scope = newValue}
+  }
+  /// Returns true if `scope` has been explicitly set.
+  public var hasScope: Bool {return self._scope != nil}
+  /// Clears the value of `scope`. Subsequent reads from it will return its default value.
+  public mutating func clearScope() {self._scope = nil}
+
+  /// A list of Spans that originate from an instrumentation scope.
+  public var spans: [Opentelemetry_Proto_Trace_V1_Span] = []
+
+  /// This schema_url applies to all spans and span events in the "spans" field.
+  public var schemaURL: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _scope: Opentelemetry_Proto_Common_V1_InstrumentationScope? = nil
+}
+
 /// A collection of Spans produced by an InstrumentationLibrary.
+/// InstrumentationLibrarySpans is wire-compatible with ScopeSpans for binary
+/// Protobuf format.
+/// This message is deprecated and will be removed on June 15, 2022.
 public struct Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -81,6 +175,9 @@ public struct Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans {
 
   /// A list of Spans that originate from an instrumentation library.
   public var spans: [Opentelemetry_Proto_Trace_V1_Span] = []
+
+  /// This schema_url applies to all spans and span events in the "spans" field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -111,10 +208,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// random trace_id if empty or invalid trace_id was received.
   ///
   /// This field is required.
-  public var traceID: Data {
-    get {return _storage._traceID}
-    set {_uniqueStorage()._traceID = newValue}
-  }
+  public var traceID: Data = Data()
 
   /// A unique identifier for a span within a trace, assigned when the span
   /// is created. The ID is an 8-byte array. An ID with all zeroes is considered
@@ -124,25 +218,16 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// random span_id if empty or invalid span_id was received.
   ///
   /// This field is required.
-  public var spanID: Data {
-    get {return _storage._spanID}
-    set {_uniqueStorage()._spanID = newValue}
-  }
+  public var spanID: Data = Data()
 
   /// trace_state conveys information about request position in multiple distributed tracing graphs.
   /// It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
   /// See also https://github.com/w3c/distributed-tracing for more details about this field.
-  public var traceState: String {
-    get {return _storage._traceState}
-    set {_uniqueStorage()._traceState = newValue}
-  }
+  public var traceState: String = String()
 
   /// The `span_id` of this span's parent span. If this is a root span, then this
   /// field must be empty. The ID is an 8-byte array.
-  public var parentSpanID: Data {
-    get {return _storage._parentSpanID}
-    set {_uniqueStorage()._parentSpanID = newValue}
-  }
+  public var parentSpanID: Data = Data()
 
   /// A description of the span's operation.
   ///
@@ -152,23 +237,15 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// This makes it easier to correlate spans in different traces.
   ///
   /// This field is semantically required to be set to non-empty string.
-  /// When null or empty string received - receiver may use string "name"
-  /// as a replacement. There might be smarted algorithms implemented by
-  /// receiver to fix the empty span name.
+  /// Empty value is equivalent to an unknown span name.
   ///
   /// This field is required.
-  public var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  public var name: String = String()
 
   /// Distinguishes between spans generated in a particular context. For example,
   /// two spans with the same name may be distinguished using `CLIENT` (caller)
   /// and `SERVER` (callee) to identify queueing latency associated with the span.
-  public var kind: Opentelemetry_Proto_Trace_V1_Span.SpanKind {
-    get {return _storage._kind}
-    set {_uniqueStorage()._kind = newValue}
-  }
+  public var kind: Opentelemetry_Proto_Trace_V1_Span.SpanKind = .unspecified
 
   /// start_time_unix_nano is the start time of the span. On the client side, this is the time
   /// kept by the local machine where the span execution starts. On the server side, this
@@ -176,10 +253,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   ///
   /// This field is semantically required and it is expected that end_time >= start_time.
-  public var startTimeUnixNano: UInt64 {
-    get {return _storage._startTimeUnixNano}
-    set {_uniqueStorage()._startTimeUnixNano = newValue}
-  }
+  public var startTimeUnixNano: UInt64 = 0
 
   /// end_time_unix_nano is the end time of the span. On the client side, this is the time
   /// kept by the local machine where the span execution ends. On the server side, this
@@ -187,69 +261,52 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   ///
   /// This field is semantically required and it is expected that end_time >= start_time.
-  public var endTimeUnixNano: UInt64 {
-    get {return _storage._endTimeUnixNano}
-    set {_uniqueStorage()._endTimeUnixNano = newValue}
-  }
+  public var endTimeUnixNano: UInt64 = 0
 
-  /// attributes is a collection of key/value pairs. The value can be a string,
-  /// an integer, a double or the Boolean values `true` or `false`. Note, global attributes
+  /// attributes is a collection of key/value pairs. Note, global attributes
   /// like server name can be set using the resource API. Examples of attributes:
   ///
   ///     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
   ///     "/http/server_latency": 300
   ///     "abc.com/myattribute": true
   ///     "abc.com/score": 10.239
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] {
-    get {return _storage._attributes}
-    set {_uniqueStorage()._attributes = newValue}
-  }
+  ///
+  /// The OpenTelemetry API specification further restricts the allowed value types:
+  /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
+  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// dropped_attributes_count is the number of attributes that were discarded. Attributes
   /// can be discarded because their keys are too long or because there are too many
   /// attributes. If this value is 0, then no attributes were dropped.
-  public var droppedAttributesCount: UInt32 {
-    get {return _storage._droppedAttributesCount}
-    set {_uniqueStorage()._droppedAttributesCount = newValue}
-  }
+  public var droppedAttributesCount: UInt32 = 0
 
   /// events is a collection of Event items.
-  public var events: [Opentelemetry_Proto_Trace_V1_Span.Event] {
-    get {return _storage._events}
-    set {_uniqueStorage()._events = newValue}
-  }
+  public var events: [Opentelemetry_Proto_Trace_V1_Span.Event] = []
 
   /// dropped_events_count is the number of dropped events. If the value is 0, then no
   /// events were dropped.
-  public var droppedEventsCount: UInt32 {
-    get {return _storage._droppedEventsCount}
-    set {_uniqueStorage()._droppedEventsCount = newValue}
-  }
+  public var droppedEventsCount: UInt32 = 0
 
   /// links is a collection of Links, which are references from this span to a span
   /// in the same or different trace.
-  public var links: [Opentelemetry_Proto_Trace_V1_Span.Link] {
-    get {return _storage._links}
-    set {_uniqueStorage()._links = newValue}
-  }
+  public var links: [Opentelemetry_Proto_Trace_V1_Span.Link] = []
 
   /// dropped_links_count is the number of dropped links after the maximum size was
   /// enforced. If this value is 0, then no links were dropped.
-  public var droppedLinksCount: UInt32 {
-    get {return _storage._droppedLinksCount}
-    set {_uniqueStorage()._droppedLinksCount = newValue}
-  }
+  public var droppedLinksCount: UInt32 = 0
 
   /// An optional final status for this span. Semantically when Status isn't set, it means
   /// span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
   public var status: Opentelemetry_Proto_Trace_V1_Status {
-    get {return _storage._status ?? Opentelemetry_Proto_Trace_V1_Status()}
-    set {_uniqueStorage()._status = newValue}
+    get {return _status ?? Opentelemetry_Proto_Trace_V1_Status()}
+    set {_status = newValue}
   }
   /// Returns true if `status` has been explicitly set.
-  public var hasStatus: Bool {return _storage._status != nil}
+  public var hasStatus: Bool {return self._status != nil}
   /// Clears the value of `status`. Subsequent reads from it will return its default value.
-  public mutating func clearStatus() {_uniqueStorage()._status = nil}
+  public mutating func clearStatus() {self._status = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -263,7 +320,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
     case unspecified // = 0
 
     /// Indicates that the span represents an internal operation within an application,
-    /// as opposed to an operations happening at the boundaries. Default value.
+    /// as opposed to an operation happening at the boundaries. Default value.
     case `internal` // = 1
 
     /// Indicates that the span covers server-side handling of an RPC or other
@@ -330,6 +387,8 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
     public var name: String = String()
 
     /// attributes is a collection of attribute key/value pairs on the event.
+    /// Attribute keys MUST be unique (it is not allowed to have more than one
+    /// attribute with the same key).
     public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
     /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
@@ -361,6 +420,8 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
     public var traceState: String = String()
 
     /// attributes is a collection of attribute key/value pairs on the link.
+    /// Attribute keys MUST be unique (it is not allowed to have more than one
+    /// attribute with the same key).
     public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
     /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
@@ -374,7 +435,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _status: Opentelemetry_Proto_Trace_V1_Status? = nil
 }
 
 #if swift(>=4.2)
@@ -400,14 +461,6 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// The deprecated status code. This is an optional field.
-  ///
-  /// This field is deprecated and is replaced by the `code` field below. See backward
-  /// compatibility notes below. According to our stability guarantees this field
-  /// will be removed in 12 months, on Oct 22, 2021. All usage of old senders and
-  /// receivers that do not understand the `code` field MUST be phased out by then.
-  public var deprecatedCode: Opentelemetry_Proto_Trace_V1_Status.DeprecatedStatusCode = .ok
-
   /// A developer-facing human readable error message.
   public var message: String = String()
 
@@ -416,81 +469,8 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum DeprecatedStatusCode: SwiftProtobuf.Enum {
-    public typealias RawValue = Int
-    case ok // = 0
-    case cancelled // = 1
-    case unknownError // = 2
-    case invalidArgument // = 3
-    case deadlineExceeded // = 4
-    case notFound // = 5
-    case alreadyExists // = 6
-    case permissionDenied // = 7
-    case resourceExhausted // = 8
-    case failedPrecondition // = 9
-    case aborted // = 10
-    case outOfRange // = 11
-    case unimplemented // = 12
-    case internalError // = 13
-    case unavailable // = 14
-    case dataLoss // = 15
-    case unauthenticated // = 16
-    case UNRECOGNIZED(Int)
-
-    public init() {
-      self = .ok
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ok
-      case 1: self = .cancelled
-      case 2: self = .unknownError
-      case 3: self = .invalidArgument
-      case 4: self = .deadlineExceeded
-      case 5: self = .notFound
-      case 6: self = .alreadyExists
-      case 7: self = .permissionDenied
-      case 8: self = .resourceExhausted
-      case 9: self = .failedPrecondition
-      case 10: self = .aborted
-      case 11: self = .outOfRange
-      case 12: self = .unimplemented
-      case 13: self = .internalError
-      case 14: self = .unavailable
-      case 15: self = .dataLoss
-      case 16: self = .unauthenticated
-      default: self = .UNRECOGNIZED(rawValue)
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .ok: return 0
-      case .cancelled: return 1
-      case .unknownError: return 2
-      case .invalidArgument: return 3
-      case .deadlineExceeded: return 4
-      case .notFound: return 5
-      case .alreadyExists: return 6
-      case .permissionDenied: return 7
-      case .resourceExhausted: return 8
-      case .failedPrecondition: return 9
-      case .aborted: return 10
-      case .outOfRange: return 11
-      case .unimplemented: return 12
-      case .internalError: return 13
-      case .unavailable: return 14
-      case .dataLoss: return 15
-      case .unauthenticated: return 16
-      case .UNRECOGNIZED(let i): return i
-      }
-    }
-
-  }
-
   /// For the semantics of status codes see
-  /// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status
+  /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
   public enum StatusCode: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
@@ -534,29 +514,6 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
 
 #if swift(>=4.2)
 
-extension Opentelemetry_Proto_Trace_V1_Status.DeprecatedStatusCode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static var allCases: [Opentelemetry_Proto_Trace_V1_Status.DeprecatedStatusCode] = [
-    .ok,
-    .cancelled,
-    .unknownError,
-    .invalidArgument,
-    .deadlineExceeded,
-    .notFound,
-    .alreadyExists,
-    .permissionDenied,
-    .resourceExhausted,
-    .failedPrecondition,
-    .aborted,
-    .outOfRange,
-    .unimplemented,
-    .internalError,
-    .unavailable,
-    .dataLoss,
-    .unauthenticated,
-  ]
-}
-
 extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static var allCases: [Opentelemetry_Proto_Trace_V1_Status.StatusCode] = [
@@ -568,15 +525,62 @@ extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: CaseIterable {
 
 #endif  // swift(>=4.2)
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Trace_V1_TracesData: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_ResourceSpans: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_ScopeSpans: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Span.Event: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Span.Link: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Status: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.trace.v1"
+
+extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".TracesData"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "resource_spans"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.resourceSpans) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.resourceSpans.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.resourceSpans, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_TracesData, rhs: Opentelemetry_Proto_Trace_V1_TracesData) -> Bool {
+    if lhs.resourceSpans != rhs.resourceSpans {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
 
 extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ResourceSpans"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "resource"),
-    2: .standard(proto: "instrumentation_library_spans"),
+    2: .standard(proto: "scope_spans"),
+    1000: .standard(proto: "instrumentation_library_spans"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -586,25 +590,87 @@ extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, Swi
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._resource) }()
-      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibrarySpans) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.scopeSpans) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      case 1000: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibrarySpans) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._resource {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._resource {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.scopeSpans.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.scopeSpans, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     if !self.instrumentationLibrarySpans.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.instrumentationLibrarySpans, fieldNumber: 2)
+      try visitor.visitRepeatedMessageField(value: self.instrumentationLibrarySpans, fieldNumber: 1000)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Trace_V1_ResourceSpans, rhs: Opentelemetry_Proto_Trace_V1_ResourceSpans) -> Bool {
     if lhs._resource != rhs._resource {return false}
+    if lhs.scopeSpans != rhs.scopeSpans {return false}
     if lhs.instrumentationLibrarySpans != rhs.instrumentationLibrarySpans {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ScopeSpans"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "scope"),
+    2: .same(proto: "spans"),
+    3: .standard(proto: "schema_url"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._scope) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.spans) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._scope {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.spans.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.spans, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_ScopeSpans, rhs: Opentelemetry_Proto_Trace_V1_ScopeSpans) -> Bool {
+    if lhs._scope != rhs._scope {return false}
+    if lhs.spans != rhs.spans {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -615,6 +681,7 @@ extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans: SwiftProtobu
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "instrumentation_library"),
     2: .same(proto: "spans"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -625,17 +692,25 @@ extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans: SwiftProtobu
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._instrumentationLibrary) }()
       case 2: try { try decoder.decodeRepeatedMessageField(value: &self.spans) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._instrumentationLibrary {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._instrumentationLibrary {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.spans.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.spans, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -643,6 +718,7 @@ extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans: SwiftProtobu
   public static func ==(lhs: Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans, rhs: Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans) -> Bool {
     if lhs._instrumentationLibrary != rhs._instrumentationLibrary {return false}
     if lhs.spans != rhs.spans {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -668,157 +744,101 @@ extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobu
     15: .same(proto: "status"),
   ]
 
-  fileprivate class _StorageClass {
-    var _traceID: Data = Data()
-    var _spanID: Data = Data()
-    var _traceState: String = String()
-    var _parentSpanID: Data = Data()
-    var _name: String = String()
-    var _kind: Opentelemetry_Proto_Trace_V1_Span.SpanKind = .unspecified
-    var _startTimeUnixNano: UInt64 = 0
-    var _endTimeUnixNano: UInt64 = 0
-    var _attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
-    var _droppedAttributesCount: UInt32 = 0
-    var _events: [Opentelemetry_Proto_Trace_V1_Span.Event] = []
-    var _droppedEventsCount: UInt32 = 0
-    var _links: [Opentelemetry_Proto_Trace_V1_Span.Link] = []
-    var _droppedLinksCount: UInt32 = 0
-    var _status: Opentelemetry_Proto_Trace_V1_Status? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _traceID = source._traceID
-      _spanID = source._spanID
-      _traceState = source._traceState
-      _parentSpanID = source._parentSpanID
-      _name = source._name
-      _kind = source._kind
-      _startTimeUnixNano = source._startTimeUnixNano
-      _endTimeUnixNano = source._endTimeUnixNano
-      _attributes = source._attributes
-      _droppedAttributesCount = source._droppedAttributesCount
-      _events = source._events
-      _droppedEventsCount = source._droppedEventsCount
-      _links = source._links
-      _droppedLinksCount = source._droppedLinksCount
-      _status = source._status
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try { try decoder.decodeSingularBytesField(value: &_storage._traceID) }()
-        case 2: try { try decoder.decodeSingularBytesField(value: &_storage._spanID) }()
-        case 3: try { try decoder.decodeSingularStringField(value: &_storage._traceState) }()
-        case 4: try { try decoder.decodeSingularBytesField(value: &_storage._parentSpanID) }()
-        case 5: try { try decoder.decodeSingularStringField(value: &_storage._name) }()
-        case 6: try { try decoder.decodeSingularEnumField(value: &_storage._kind) }()
-        case 7: try { try decoder.decodeSingularFixed64Field(value: &_storage._startTimeUnixNano) }()
-        case 8: try { try decoder.decodeSingularFixed64Field(value: &_storage._endTimeUnixNano) }()
-        case 9: try { try decoder.decodeRepeatedMessageField(value: &_storage._attributes) }()
-        case 10: try { try decoder.decodeSingularUInt32Field(value: &_storage._droppedAttributesCount) }()
-        case 11: try { try decoder.decodeRepeatedMessageField(value: &_storage._events) }()
-        case 12: try { try decoder.decodeSingularUInt32Field(value: &_storage._droppedEventsCount) }()
-        case 13: try { try decoder.decodeRepeatedMessageField(value: &_storage._links) }()
-        case 14: try { try decoder.decodeSingularUInt32Field(value: &_storage._droppedLinksCount) }()
-        case 15: try { try decoder.decodeSingularMessageField(value: &_storage._status) }()
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBytesField(value: &self.traceID) }()
+      case 2: try { try decoder.decodeSingularBytesField(value: &self.spanID) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.traceState) }()
+      case 4: try { try decoder.decodeSingularBytesField(value: &self.parentSpanID) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 6: try { try decoder.decodeSingularEnumField(value: &self.kind) }()
+      case 7: try { try decoder.decodeSingularFixed64Field(value: &self.startTimeUnixNano) }()
+      case 8: try { try decoder.decodeSingularFixed64Field(value: &self.endTimeUnixNano) }()
+      case 9: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
+      case 10: try { try decoder.decodeSingularUInt32Field(value: &self.droppedAttributesCount) }()
+      case 11: try { try decoder.decodeRepeatedMessageField(value: &self.events) }()
+      case 12: try { try decoder.decodeSingularUInt32Field(value: &self.droppedEventsCount) }()
+      case 13: try { try decoder.decodeRepeatedMessageField(value: &self.links) }()
+      case 14: try { try decoder.decodeSingularUInt32Field(value: &self.droppedLinksCount) }()
+      case 15: try { try decoder.decodeSingularMessageField(value: &self._status) }()
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._traceID.isEmpty {
-        try visitor.visitSingularBytesField(value: _storage._traceID, fieldNumber: 1)
-      }
-      if !_storage._spanID.isEmpty {
-        try visitor.visitSingularBytesField(value: _storage._spanID, fieldNumber: 2)
-      }
-      if !_storage._traceState.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._traceState, fieldNumber: 3)
-      }
-      if !_storage._parentSpanID.isEmpty {
-        try visitor.visitSingularBytesField(value: _storage._parentSpanID, fieldNumber: 4)
-      }
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 5)
-      }
-      if _storage._kind != .unspecified {
-        try visitor.visitSingularEnumField(value: _storage._kind, fieldNumber: 6)
-      }
-      if _storage._startTimeUnixNano != 0 {
-        try visitor.visitSingularFixed64Field(value: _storage._startTimeUnixNano, fieldNumber: 7)
-      }
-      if _storage._endTimeUnixNano != 0 {
-        try visitor.visitSingularFixed64Field(value: _storage._endTimeUnixNano, fieldNumber: 8)
-      }
-      if !_storage._attributes.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._attributes, fieldNumber: 9)
-      }
-      if _storage._droppedAttributesCount != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._droppedAttributesCount, fieldNumber: 10)
-      }
-      if !_storage._events.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._events, fieldNumber: 11)
-      }
-      if _storage._droppedEventsCount != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._droppedEventsCount, fieldNumber: 12)
-      }
-      if !_storage._links.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._links, fieldNumber: 13)
-      }
-      if _storage._droppedLinksCount != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._droppedLinksCount, fieldNumber: 14)
-      }
-      if let v = _storage._status {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if !self.traceID.isEmpty {
+      try visitor.visitSingularBytesField(value: self.traceID, fieldNumber: 1)
     }
+    if !self.spanID.isEmpty {
+      try visitor.visitSingularBytesField(value: self.spanID, fieldNumber: 2)
+    }
+    if !self.traceState.isEmpty {
+      try visitor.visitSingularStringField(value: self.traceState, fieldNumber: 3)
+    }
+    if !self.parentSpanID.isEmpty {
+      try visitor.visitSingularBytesField(value: self.parentSpanID, fieldNumber: 4)
+    }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 5)
+    }
+    if self.kind != .unspecified {
+      try visitor.visitSingularEnumField(value: self.kind, fieldNumber: 6)
+    }
+    if self.startTimeUnixNano != 0 {
+      try visitor.visitSingularFixed64Field(value: self.startTimeUnixNano, fieldNumber: 7)
+    }
+    if self.endTimeUnixNano != 0 {
+      try visitor.visitSingularFixed64Field(value: self.endTimeUnixNano, fieldNumber: 8)
+    }
+    if !self.attributes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 9)
+    }
+    if self.droppedAttributesCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.droppedAttributesCount, fieldNumber: 10)
+    }
+    if !self.events.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.events, fieldNumber: 11)
+    }
+    if self.droppedEventsCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.droppedEventsCount, fieldNumber: 12)
+    }
+    if !self.links.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.links, fieldNumber: 13)
+    }
+    if self.droppedLinksCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.droppedLinksCount, fieldNumber: 14)
+    }
+    try { if let v = self._status {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Trace_V1_Span, rhs: Opentelemetry_Proto_Trace_V1_Span) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._traceID != rhs_storage._traceID {return false}
-        if _storage._spanID != rhs_storage._spanID {return false}
-        if _storage._traceState != rhs_storage._traceState {return false}
-        if _storage._parentSpanID != rhs_storage._parentSpanID {return false}
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._kind != rhs_storage._kind {return false}
-        if _storage._startTimeUnixNano != rhs_storage._startTimeUnixNano {return false}
-        if _storage._endTimeUnixNano != rhs_storage._endTimeUnixNano {return false}
-        if _storage._attributes != rhs_storage._attributes {return false}
-        if _storage._droppedAttributesCount != rhs_storage._droppedAttributesCount {return false}
-        if _storage._events != rhs_storage._events {return false}
-        if _storage._droppedEventsCount != rhs_storage._droppedEventsCount {return false}
-        if _storage._links != rhs_storage._links {return false}
-        if _storage._droppedLinksCount != rhs_storage._droppedLinksCount {return false}
-        if _storage._status != rhs_storage._status {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.traceID != rhs.traceID {return false}
+    if lhs.spanID != rhs.spanID {return false}
+    if lhs.traceState != rhs.traceState {return false}
+    if lhs.parentSpanID != rhs.parentSpanID {return false}
+    if lhs.name != rhs.name {return false}
+    if lhs.kind != rhs.kind {return false}
+    if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
+    if lhs.endTimeUnixNano != rhs.endTimeUnixNano {return false}
+    if lhs.attributes != rhs.attributes {return false}
+    if lhs.droppedAttributesCount != rhs.droppedAttributesCount {return false}
+    if lhs.events != rhs.events {return false}
+    if lhs.droppedEventsCount != rhs.droppedEventsCount {return false}
+    if lhs.links != rhs.links {return false}
+    if lhs.droppedLinksCount != rhs.droppedLinksCount {return false}
+    if lhs._status != rhs._status {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -944,7 +964,6 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftPr
 extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Status"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "deprecated_code"),
     2: .same(proto: "message"),
     3: .same(proto: "code"),
   ]
@@ -955,7 +974,6 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularEnumField(value: &self.deprecatedCode) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.message) }()
       case 3: try { try decoder.decodeSingularEnumField(value: &self.code) }()
       default: break
@@ -964,9 +982,6 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.deprecatedCode != .ok {
-      try visitor.visitSingularEnumField(value: self.deprecatedCode, fieldNumber: 1)
-    }
     if !self.message.isEmpty {
       try visitor.visitSingularStringField(value: self.message, fieldNumber: 2)
     }
@@ -977,34 +992,11 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Trace_V1_Status, rhs: Opentelemetry_Proto_Trace_V1_Status) -> Bool {
-    if lhs.deprecatedCode != rhs.deprecatedCode {return false}
     if lhs.message != rhs.message {return false}
     if lhs.code != rhs.code {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
-}
-
-extension Opentelemetry_Proto_Trace_V1_Status.DeprecatedStatusCode: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "DEPRECATED_STATUS_CODE_OK"),
-    1: .same(proto: "DEPRECATED_STATUS_CODE_CANCELLED"),
-    2: .same(proto: "DEPRECATED_STATUS_CODE_UNKNOWN_ERROR"),
-    3: .same(proto: "DEPRECATED_STATUS_CODE_INVALID_ARGUMENT"),
-    4: .same(proto: "DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED"),
-    5: .same(proto: "DEPRECATED_STATUS_CODE_NOT_FOUND"),
-    6: .same(proto: "DEPRECATED_STATUS_CODE_ALREADY_EXISTS"),
-    7: .same(proto: "DEPRECATED_STATUS_CODE_PERMISSION_DENIED"),
-    8: .same(proto: "DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED"),
-    9: .same(proto: "DEPRECATED_STATUS_CODE_FAILED_PRECONDITION"),
-    10: .same(proto: "DEPRECATED_STATUS_CODE_ABORTED"),
-    11: .same(proto: "DEPRECATED_STATUS_CODE_OUT_OF_RANGE"),
-    12: .same(proto: "DEPRECATED_STATUS_CODE_UNIMPLEMENTED"),
-    13: .same(proto: "DEPRECATED_STATUS_CODE_INTERNAL_ERROR"),
-    14: .same(proto: "DEPRECATED_STATUS_CODE_UNAVAILABLE"),
-    15: .same(proto: "DEPRECATED_STATUS_CODE_DATA_LOSS"),
-    16: .same(proto: "DEPRECATED_STATUS_CODE_UNAUTHENTICATED"),
-  ]
 }
 
 extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: SwiftProtobuf._ProtoNameProviding {

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/trace_config.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/trace_config.pb.swift
@@ -208,6 +208,15 @@ public struct Opentelemetry_Proto_Trace_V1_RateLimitingSampler {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Trace_V1_TraceConfig: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_TraceConfig.OneOf_Sampler: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_ConstantSampler: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_ConstantSampler.ConstantDecision: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_TraceIdRatioBased: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_RateLimitingSampler: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.trace.v1"
@@ -233,30 +242,42 @@ extension Opentelemetry_Proto_Trace_V1_TraceConfig: SwiftProtobuf.Message, Swift
       switch fieldNumber {
       case 1: try {
         var v: Opentelemetry_Proto_Trace_V1_ConstantSampler?
+        var hadOneofValue = false
         if let current = self.sampler {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .constantSampler(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.sampler = .constantSampler(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.sampler = .constantSampler(v)
+        }
       }()
       case 2: try {
         var v: Opentelemetry_Proto_Trace_V1_TraceIdRatioBased?
+        var hadOneofValue = false
         if let current = self.sampler {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .traceIDRatioBased(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.sampler = .traceIDRatioBased(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.sampler = .traceIDRatioBased(v)
+        }
       }()
       case 3: try {
         var v: Opentelemetry_Proto_Trace_V1_RateLimitingSampler?
+        var hadOneofValue = false
         if let current = self.sampler {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .rateLimitingSampler(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.sampler = .rateLimitingSampler(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.sampler = .rateLimitingSampler(v)
+        }
       }()
       case 4: try { try decoder.decodeSingularInt64Field(value: &self.maxNumberOfAttributes) }()
       case 5: try { try decoder.decodeSingularInt64Field(value: &self.maxNumberOfTimedEvents) }()
@@ -270,8 +291,9 @@ extension Opentelemetry_Proto_Trace_V1_TraceConfig: SwiftProtobuf.Message, Swift
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     switch self.sampler {
     case .constantSampler?: try {
       guard case .constantSampler(let v)? = self.sampler else { preconditionFailure() }

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/trace_service.grpc.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/trace_service.grpc.swift
@@ -26,7 +26,7 @@ import SwiftProtobuf
 
 
 /// Service that can be used to push spans between one Application instrumented with
-/// OpenTelemetry and an collector, or between an collector and a central collector (in this
+/// OpenTelemetry and a collector, or between a collector and a central collector (in this
 /// case spans are sent/received to/from multiple Applications).
 ///
 /// Usage: instantiate `Opentelemetry_Proto_Collector_Trace_V1_TraceServiceClient`, then call methods of this protocol to make API calls.
@@ -94,7 +94,7 @@ public final class Opentelemetry_Proto_Collector_Trace_V1_TraceServiceClient: Op
 }
 
 /// Service that can be used to push spans between one Application instrumented with
-/// OpenTelemetry and an collector, or between an collector and a central collector (in this
+/// OpenTelemetry and a collector, or between a collector and a central collector (in this
 /// case spans are sent/received to/from multiple Applications).
 ///
 /// To build a server, implement a class that conforms to this protocol.

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/trace_service.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/trace_service.pb.swift
@@ -61,6 +61,11 @@ public struct Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse 
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: @unchecked Sendable {}
+extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.collector.trace.v1"

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
@@ -49,12 +49,11 @@ class OtlpMetricExproterTests: XCTestCase {
         XCTAssertEqual(fakeCollector.receivedMetrics.count, 1)
         let otlpMetric = fakeCollector.receivedMetrics[0].instrumentationLibraryMetrics[0].metrics[0]
         XCTAssertEqual(metric.name, otlpMetric.name)
-        XCTAssertEqual(otlpMetric.intGauge.dataPoints.count, 1)
-        let dataPoint = otlpMetric.intGauge.dataPoints[0]
+        XCTAssertEqual(otlpMetric.gauge.dataPoints.count, 1)
+        let dataPoint = otlpMetric.gauge.dataPoints[0]
         let sum = metric.data[0] as! SumData<Int>
         XCTAssertEqual(sum.timestamp.timeIntervalSince1970.toNanoseconds, dataPoint.timeUnixNano)
         XCTAssertEqual(sum.startTimestamp.timeIntervalSince1970.toNanoseconds, dataPoint.startTimeUnixNano)
-        XCTAssertEqual(sum.sum, Int(dataPoint.value))
     }
 
     func testExportMultipleMetrics() {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
@@ -54,6 +54,7 @@ class OtlpMetricExproterTests: XCTestCase {
         let sum = metric.data[0] as! SumData<Int>
         XCTAssertEqual(sum.timestamp.timeIntervalSince1970.toNanoseconds, dataPoint.timeUnixNano)
         XCTAssertEqual(sum.startTimestamp.timeIntervalSince1970.toNanoseconds, dataPoint.startTimeUnixNano)
+        XCTAssertEqual(sum.sum, Int(dataPoint.asInt))
     }
 
     func testExportMultipleMetrics() {


### PR DESCRIPTION
labels has been deprecated in [otel-proto](https://github.com/open-telemetry/opentelemetry-proto/pull/342) and attributes are now used in it's place. This was reported by @trevor-dialpad and the OTLP Exporter needed this change if a user uses opentelemetry-swift with along other otel sdk's or uses it with newer version of the otel-collector