### PR TITLE
update OTEL proto files and  OTLP Exporter to match the changes in the metrics specifications

### DIFF
--- a/Examples/OTLP Exporter/collector-config.yaml
+++ b/Examples/OTLP Exporter/collector-config.yaml
@@ -3,13 +3,12 @@ receivers:
     protocols:
       grpc:
       http:
-        cors_allowed_origins:
-        - http://*
-        - https://*
+        cors:
+          allowed_origins:
+            - http://*
+            - https://*
 
 exporters:
-  logging:
-    loglevel: debug
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
   prometheus:
@@ -24,10 +23,13 @@ processors:
   batch:
 
 service:
+  telemetry:
+    logs:
+      level: "debug"
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [zipkin, logging]
+      exporters: [zipkin]
       processors: [resource, batch]
     metrics:
       receivers: [otlp]

--- a/Examples/OTLP Exporter/docker-compose.yaml
+++ b/Examples/OTLP Exporter/docker-compose.yaml
@@ -2,9 +2,9 @@ version: "3"
 services:
   # Collector
   collector:
-    image: otel/opentelemetry-collector:0.25.0
+    image: otel/opentelemetry-collector:0.50.0
 #    image: otel/opentelemetry-collector:latest
-    command: ["--config=/conf/collector-config.yaml", "--log-level=DEBUG"]
+    command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml
     ports:

--- a/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/MetricsAdapter.swift
@@ -54,60 +54,63 @@ struct MetricsAdapter {
                 guard let gaugeData = $0 as? SumData<Double> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_NumberDataPoint()
+
                 protoDataPoint.timeUnixNano = gaugeData.timestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.startTimeUnixNano = gaugeData.startTimestamp.timeIntervalSince1970.toNanoseconds
-                protoDataPoint.value = gaugeData.sum
+                protoDataPoint.value = .asDouble(gaugeData.sum)
                 gaugeData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.doubleGauge.dataPoints.append(protoDataPoint)
+                protoMetric.gauge.dataPoints.append(protoDataPoint)
             case .intGauge:
                 guard let gaugeData = $0 as? SumData<Int> else {
                     break
                 }
 
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_IntDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_NumberDataPoint()
 
-                protoDataPoint.value = Int64(gaugeData.sum)
+                protoDataPoint.value = .asInt(Int64(exactly: gaugeData.sum)!)
                 protoDataPoint.timeUnixNano = gaugeData.timestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.startTimeUnixNano = gaugeData.startTimestamp.timeIntervalSince1970.toNanoseconds
                 gaugeData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.intGauge.dataPoints.append(protoDataPoint)
+                protoMetric.gauge.dataPoints.append(protoDataPoint)
             case .doubleSum:
                 guard let sumData = $0 as? SumData<Double> else {
                     break
                 }
 
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleDataPoint()
-                protoDataPoint.value = sumData.sum
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_NumberDataPoint()
+
+                protoDataPoint.value = .asDouble(sumData.sum)
                 protoDataPoint.timeUnixNano = sumData.timestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.startTimeUnixNano = sumData.startTimestamp.timeIntervalSince1970.toNanoseconds
                 sumData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.doubleSum.aggregationTemporality = .cumulative
-                protoMetric.doubleSum.dataPoints.append(protoDataPoint)
+                protoMetric.sum.aggregationTemporality = .cumulative
+                protoMetric.sum.dataPoints.append(protoDataPoint)
             case .doubleSummary:
 
                 guard let summaryData = $0 as? SummaryData<Double> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint()
+
                 protoDataPoint.sum = summaryData.sum
                 protoDataPoint.count = UInt64(summaryData.count)
 
@@ -115,53 +118,57 @@ struct MetricsAdapter {
                 protoDataPoint.timeUnixNano = summaryData.timestamp.timeIntervalSince1970.toNanoseconds
 
                 summaryData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.doubleSummary.dataPoints.append(protoDataPoint)
+                protoMetric.summary.dataPoints.append(protoDataPoint)
             case .intSum:
                 guard let sumData = $0 as? SumData<Int> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_IntDataPoint()
-                protoDataPoint.value = Int64(sumData.sum)
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_NumberDataPoint()
+
+                protoDataPoint.value = .asInt(Int64(sumData.sum))
                 protoDataPoint.timeUnixNano = sumData.timestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.startTimeUnixNano = sumData.startTimestamp.timeIntervalSince1970.toNanoseconds
                 sumData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
+
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.intSum.aggregationTemporality = .cumulative
-                protoMetric.intSum.dataPoints.append(protoDataPoint)
+                protoMetric.sum.aggregationTemporality = .cumulative
+                protoMetric.sum.dataPoints.append(protoDataPoint)
             case .intSummary:
                 guard let summaryData = $0 as? SummaryData<Int> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleSummaryDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint()
+
                 protoDataPoint.sum = Double(summaryData.sum)
                 protoDataPoint.count = UInt64(summaryData.count)
                 protoDataPoint.startTimeUnixNano = summaryData.startTimestamp.timeIntervalSince1970.toNanoseconds
                 protoDataPoint.timeUnixNano = summaryData.timestamp.timeIntervalSince1970.toNanoseconds
 
                 summaryData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
 
-                protoMetric.doubleSummary.dataPoints.append(protoDataPoint)
+                protoMetric.summary.dataPoints.append(protoDataPoint)
             case .intHistogram:
                 guard let histogramData = $0 as? HistogramData<Int> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_HistogramDataPoint()
+
                 protoDataPoint.sum = Double(histogramData.sum)
                 protoDataPoint.count = UInt64(histogramData.count)
                 protoDataPoint.startTimeUnixNano = histogramData.startTimestamp.timeIntervalSince1970.toNanoseconds
@@ -170,19 +177,19 @@ struct MetricsAdapter {
                 protoDataPoint.bucketCounts = histogramData.buckets.counts.map { UInt64($0) }
                 
                 histogramData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
                 
-                protoMetric.doubleHistogram.aggregationTemporality = .cumulative
-                protoMetric.doubleHistogram.dataPoints.append(protoDataPoint)
+                protoMetric.histogram.aggregationTemporality = .cumulative
+                protoMetric.histogram.dataPoints.append(protoDataPoint)
             case .doubleHistogram:
                 guard let histogramData = $0 as? HistogramData<Double> else {
                     break
                 }
-                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_DoubleHistogramDataPoint()
+                var protoDataPoint = Opentelemetry_Proto_Metrics_V1_HistogramDataPoint()
                 protoDataPoint.sum = Double(histogramData.sum)
                 protoDataPoint.count = UInt64(histogramData.count)
                 protoDataPoint.startTimeUnixNano = histogramData.startTimestamp.timeIntervalSince1970.toNanoseconds
@@ -191,14 +198,14 @@ struct MetricsAdapter {
                 protoDataPoint.bucketCounts = histogramData.buckets.counts.map { UInt64($0) }
                 
                 histogramData.labels.forEach {
-                    var kvp = Opentelemetry_Proto_Common_V1_StringKeyValue()
+                    var kvp = Opentelemetry_Proto_Common_V1_KeyValue()
                     kvp.key = $0.key
-                    kvp.value = $0.value
-                    protoDataPoint.labels.append(kvp)
+                    kvp.value.stringValue = $0.value
+                    protoDataPoint.attributes.append(kvp)
                 }
                 
-                protoMetric.doubleHistogram.aggregationTemporality = .cumulative
-                protoMetric.doubleHistogram.dataPoints.append(protoDataPoint)
+                protoMetric.histogram.aggregationTemporality = .cumulative
+                protoMetric.histogram.dataPoints.append(protoDataPoint)
             }
         }
         return protoMetric

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/common.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/common.pb.swift
@@ -43,7 +43,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
   // methods supported on all messages.
 
   /// The value is one of the listed fields. It is valid for all values to be unspecified
-  /// in which case this AnyValue is considered to be "null".
+  /// in which case this AnyValue is considered to be "empty".
   public var value: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value? = nil
 
   public var stringValue: String {
@@ -94,10 +94,18 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .kvlistValue(newValue)}
   }
 
+  public var bytesValue: Data {
+    get {
+      if case .bytesValue(let v)? = value {return v}
+      return Data()
+    }
+    set {value = .bytesValue(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The value is one of the listed fields. It is valid for all values to be unspecified
-  /// in which case this AnyValue is considered to be "null".
+  /// in which case this AnyValue is considered to be "empty".
   public enum OneOf_Value: Equatable {
     case stringValue(String)
     case boolValue(Bool)
@@ -105,6 +113,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     case doubleValue(Double)
     case arrayValue(Opentelemetry_Proto_Common_V1_ArrayValue)
     case kvlistValue(Opentelemetry_Proto_Common_V1_KeyValueList)
+    case bytesValue(Data)
 
   #if !swift(>=4.1)
     public static func ==(lhs: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value, rhs: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value) -> Bool {
@@ -134,6 +143,10 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
       }()
       case (.kvlistValue, .kvlistValue): return {
         guard case .kvlistValue(let l) = lhs, case .kvlistValue(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.bytesValue, .bytesValue): return {
+        guard case .bytesValue(let l) = lhs, case .bytesValue(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       default: return false
@@ -172,6 +185,8 @@ public struct Opentelemetry_Proto_Common_V1_KeyValueList {
 
   /// A collection of key/value pairs of key-value pairs. The list may be empty (may
   /// contain 0 elements).
+  /// The keys MUST be unique (it is not allowed to have more than one
+  /// value with the same key).
   public var values: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -204,30 +219,17 @@ public struct Opentelemetry_Proto_Common_V1_KeyValue {
   fileprivate var _value: Opentelemetry_Proto_Common_V1_AnyValue? = nil
 }
 
-/// StringKeyValue is a pair of key/value strings. This is the simpler (and faster) version
-/// of KeyValue that only supports string values.
-public struct Opentelemetry_Proto_Common_V1_StringKeyValue {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  public var key: String = String()
-
-  public var value: String = String()
-
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  public init() {}
-}
-
 /// InstrumentationLibrary is a message representing the instrumentation library information
-/// such as the fully qualified name and version. 
+/// such as the fully qualified name and version.
+/// InstrumentationLibrary is wire-compatible with InstrumentationScope for binary
+/// Protobuf format.
+/// This message is deprecated and will be removed on June 15, 2022.
 public struct Opentelemetry_Proto_Common_V1_InstrumentationLibrary {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// An empty instrumentation library name means the name is unknown. 
+  /// An empty instrumentation library name means the name is unknown.
   public var name: String = String()
 
   public var version: String = String()
@@ -236,6 +238,33 @@ public struct Opentelemetry_Proto_Common_V1_InstrumentationLibrary {
 
   public init() {}
 }
+
+/// InstrumentationScope is a message representing the instrumentation scope information
+/// such as the fully qualified name and version. 
+public struct Opentelemetry_Proto_Common_V1_InstrumentationScope {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// An empty instrumentation scope name means the name is unknown.
+  public var name: String = String()
+
+  public var version: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Common_V1_AnyValue: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_ArrayValue: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_KeyValueList: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_KeyValue: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_InstrumentationLibrary: @unchecked Sendable {}
+extension Opentelemetry_Proto_Common_V1_InstrumentationScope: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -250,6 +279,7 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
     4: .standard(proto: "double_value"),
     5: .standard(proto: "array_value"),
     6: .standard(proto: "kvlist_value"),
+    7: .standard(proto: "bytes_value"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -259,46 +289,70 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.value = .stringValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .stringValue(v)
+        }
       }()
       case 2: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: Bool?
         try decoder.decodeSingularBoolField(value: &v)
-        if let v = v {self.value = .boolValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .boolValue(v)
+        }
       }()
       case 3: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: Int64?
         try decoder.decodeSingularInt64Field(value: &v)
-        if let v = v {self.value = .intValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .intValue(v)
+        }
       }()
       case 4: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: Double?
         try decoder.decodeSingularDoubleField(value: &v)
-        if let v = v {self.value = .doubleValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .doubleValue(v)
+        }
       }()
       case 5: try {
         var v: Opentelemetry_Proto_Common_V1_ArrayValue?
+        var hadOneofValue = false
         if let current = self.value {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .arrayValue(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.value = .arrayValue(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.value = .arrayValue(v)
+        }
       }()
       case 6: try {
         var v: Opentelemetry_Proto_Common_V1_KeyValueList?
+        var hadOneofValue = false
         if let current = self.value {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .kvlistValue(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.value = .kvlistValue(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.value = .kvlistValue(v)
+        }
+      }()
+      case 7: try {
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .bytesValue(v)
+        }
       }()
       default: break
       }
@@ -307,8 +361,9 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     switch self.value {
     case .stringValue?: try {
       guard case .stringValue(let v)? = self.value else { preconditionFailure() }
@@ -333,6 +388,10 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
     case .kvlistValue?: try {
       guard case .kvlistValue(let v)? = self.value else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
+    case .bytesValue?: try {
+      guard case .bytesValue(let v)? = self.value else { preconditionFailure() }
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 7)
     }()
     case nil: break
     }
@@ -431,56 +490,22 @@ extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftPr
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.key.isEmpty {
       try visitor.visitSingularStringField(value: self.key, fieldNumber: 1)
     }
-    if let v = self._value {
+    try { if let v = self._value {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Common_V1_KeyValue, rhs: Opentelemetry_Proto_Common_V1_KeyValue) -> Bool {
     if lhs.key != rhs.key {return false}
     if lhs._value != rhs._value {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-extension Opentelemetry_Proto_Common_V1_StringKeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".StringKeyValue"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "key"),
-    2: .same(proto: "value"),
-  ]
-
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.key) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self.value) }()
-      default: break
-      }
-    }
-  }
-
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.key.isEmpty {
-      try visitor.visitSingularStringField(value: self.key, fieldNumber: 1)
-    }
-    if !self.value.isEmpty {
-      try visitor.visitSingularStringField(value: self.value, fieldNumber: 2)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  public static func ==(lhs: Opentelemetry_Proto_Common_V1_StringKeyValue, rhs: Opentelemetry_Proto_Common_V1_StringKeyValue) -> Bool {
-    if lhs.key != rhs.key {return false}
-    if lhs.value != rhs.value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -517,6 +542,44 @@ extension Opentelemetry_Proto_Common_V1_InstrumentationLibrary: SwiftProtobuf.Me
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Common_V1_InstrumentationLibrary, rhs: Opentelemetry_Proto_Common_V1_InstrumentationLibrary) -> Bool {
+    if lhs.name != rhs.name {return false}
+    if lhs.version != rhs.version {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".InstrumentationScope"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "name"),
+    2: .same(proto: "version"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.version) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.version.isEmpty {
+      try visitor.visitSingularStringField(value: self.version, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Common_V1_InstrumentationScope, rhs: Opentelemetry_Proto_Common_V1_InstrumentationScope) -> Bool {
     if lhs.name != rhs.name {return false}
     if lhs.version != rhs.version {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/logs.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/logs.pb.swift
@@ -210,7 +210,34 @@ extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: CaseIterable {
 
 #endif  // swift(>=4.2)
 
-/// A collection of InstrumentationLibraryLogs from a Resource.
+/// LogsData represents the logs data that can be stored in a persistent storage,
+/// OR can be embedded by other protocols that transfer OTLP logs data but do not
+/// implement the OTLP protocol.
+///
+/// The main difference between this message and collector protocol is that
+/// in this message there will not be any "control" or "metadata" specific to
+/// OTLP protocol.
+///
+/// When new fields are added into this message, the OTLP request MUST be updated
+/// as well.
+public struct Opentelemetry_Proto_Logs_V1_LogsData {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// An array of ResourceLogs.
+  /// For data coming from a single resource this array will typically contain
+  /// one element. Intermediary nodes that receive data from multiple origins
+  /// typically batch the data before forwarding further and in that case this
+  /// array will contain multiple elements.
+  public var resourceLogs: [Opentelemetry_Proto_Logs_V1_ResourceLogs] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// A collection of ScopeLogs from a Resource.
 public struct Opentelemetry_Proto_Logs_V1_ResourceLogs {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -227,8 +254,41 @@ public struct Opentelemetry_Proto_Logs_V1_ResourceLogs {
   /// Clears the value of `resource`. Subsequent reads from it will return its default value.
   public mutating func clearResource() {self._resource = nil}
 
+  /// A list of ScopeLogs that originate from a resource.
+  public var scopeLogs: [Opentelemetry_Proto_Logs_V1_ScopeLogs] = []
+
   /// A list of InstrumentationLibraryLogs that originate from a resource.
+  /// This field is deprecated and will be removed after grace period expires on June 15, 2022.
+  ///
+  /// During the grace period the following rules SHOULD be followed:
+  ///
+  /// For Binary Protobufs
+  /// ====================
+  /// Binary Protobuf senders SHOULD NOT set instrumentation_library_logs. Instead
+  /// scope_logs SHOULD be set.
+  ///
+  /// Binary Protobuf receivers SHOULD check if instrumentation_library_logs is set
+  /// and scope_logs is not set then the value in instrumentation_library_logs
+  /// SHOULD be used instead by converting InstrumentationLibraryLogs into ScopeLogs.
+  /// If scope_logs is set then instrumentation_library_logs SHOULD be ignored.
+  ///
+  /// For JSON
+  /// ========
+  /// JSON senders that set instrumentation_library_logs field MAY also set
+  /// scope_logs to carry the same logs, essentially double-publishing the same data.
+  /// Such double-publishing MAY be controlled by a user-settable option.
+  /// If double-publishing is not used then the senders SHOULD set scope_logs and
+  /// SHOULD NOT set instrumentation_library_logs.
+  ///
+  /// JSON receivers SHOULD check if instrumentation_library_logs is set and
+  /// scope_logs is not set then the value in instrumentation_library_logs
+  /// SHOULD be used instead by converting InstrumentationLibraryLogs into ScopeLogs.
+  /// If scope_logs is set then instrumentation_library_logs field SHOULD be ignored.
   public var instrumentationLibraryLogs: [Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs] = []
+
+  /// This schema_url applies to the data in the "resource" field. It does not apply
+  /// to the data in the "scope_logs" field which have their own schema_url field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -237,7 +297,41 @@ public struct Opentelemetry_Proto_Logs_V1_ResourceLogs {
   fileprivate var _resource: Opentelemetry_Proto_Resource_V1_Resource? = nil
 }
 
+/// A collection of Logs produced by a Scope.
+public struct Opentelemetry_Proto_Logs_V1_ScopeLogs {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The instrumentation scope information for the logs in this message.
+  /// Semantically when InstrumentationScope isn't set, it is equivalent with
+  /// an empty instrumentation scope name (unknown).
+  public var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
+    get {return _scope ?? Opentelemetry_Proto_Common_V1_InstrumentationScope()}
+    set {_scope = newValue}
+  }
+  /// Returns true if `scope` has been explicitly set.
+  public var hasScope: Bool {return self._scope != nil}
+  /// Clears the value of `scope`. Subsequent reads from it will return its default value.
+  public mutating func clearScope() {self._scope = nil}
+
+  /// A list of log records.
+  public var logRecords: [Opentelemetry_Proto_Logs_V1_LogRecord] = []
+
+  /// This schema_url applies to all logs in the "logs" field.
+  public var schemaURL: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _scope: Opentelemetry_Proto_Common_V1_InstrumentationScope? = nil
+}
+
 /// A collection of Logs produced by an InstrumentationLibrary.
+/// InstrumentationLibraryLogs is wire-compatible with ScopeLogs for binary
+/// Protobuf format.
+/// This message is deprecated and will be removed on June 15, 2022.
 public struct Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -255,8 +349,11 @@ public struct Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs {
   /// Clears the value of `instrumentationLibrary`. Subsequent reads from it will return its default value.
   public mutating func clearInstrumentationLibrary() {self._instrumentationLibrary = nil}
 
-  /// A list of log records.
-  public var logs: [Opentelemetry_Proto_Logs_V1_LogRecord] = []
+  /// A list of logs that originate from an instrumentation library.
+  public var logRecords: [Opentelemetry_Proto_Logs_V1_LogRecord] = []
+
+  /// This schema_url applies to all logs in the "logs" field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -266,7 +363,7 @@ public struct Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs {
 }
 
 /// A log record according to OpenTelemetry Log Data Model:
-/// https://github.com/open-telemetry/oteps/blob/master/text/logs/0097-log-data-model.md
+/// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
 public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -276,6 +373,23 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   /// Value of 0 indicates unknown or missing timestamp.
   public var timeUnixNano: UInt64 = 0
+
+  /// Time when the event was observed by the collection system.
+  /// For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
+  /// this timestamp is typically set at the generation time and is equal to Timestamp.
+  /// For events originating externally and collected by OpenTelemetry (e.g. using
+  /// Collector) this is the time when OpenTelemetry's code observed the event measured
+  /// by the clock of the OpenTelemetry code. This field MUST be set once the event is
+  /// observed by OpenTelemetry.
+  ///
+  /// For converting OpenTelemetry log data to formats that support only one timestamp or
+  /// when receiving OpenTelemetry log data by recipients that support only one timestamp
+  /// internally the following logic is recommended:
+  ///   - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
+  ///
+  /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  /// Value of 0 indicates unknown or missing timestamp.
+  public var observedTimeUnixNano: UInt64 = 0
 
   /// Numerical value of the severity, normalized to values described in Log Data Model.
   /// [Optional].
@@ -288,6 +402,8 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   /// Short event identifier that does not contain varying parts. Name describes
   /// what happened (e.g. "ProcessStarted"). Recommended to be no longer than 50
   /// characters. Not guaranteed to be unique in any way. [Optional].
+  /// This deprecated field is planned to be removed March 15, 2022. Receivers can
+  /// ignore this field.
   public var name: String = String()
 
   /// A value containing the body of the log record. Can be for example a human-readable
@@ -303,6 +419,8 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   public mutating func clearBody() {self._body = nil}
 
   /// Additional attributes that describe the specific event occurrence. [Optional].
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
   public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   public var droppedAttributesCount: UInt32 = 0
@@ -332,6 +450,16 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
 
   fileprivate var _body: Opentelemetry_Proto_Common_V1_AnyValue? = nil
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Logs_V1_SeverityNumber: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_LogsData: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_ResourceLogs: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_ScopeLogs: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs: @unchecked Sendable {}
+extension Opentelemetry_Proto_Logs_V1_LogRecord: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -374,11 +502,45 @@ extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf._ProtoNamePr
   ]
 }
 
+extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".LogsData"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "resource_logs"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.resourceLogs) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.resourceLogs.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.resourceLogs, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Logs_V1_LogsData, rhs: Opentelemetry_Proto_Logs_V1_LogsData) -> Bool {
+    if lhs.resourceLogs != rhs.resourceLogs {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ResourceLogs"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "resource"),
-    2: .standard(proto: "instrumentation_library_logs"),
+    2: .standard(proto: "scope_logs"),
+    1000: .standard(proto: "instrumentation_library_logs"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -388,25 +550,87 @@ extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, Swift
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._resource) }()
-      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibraryLogs) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.scopeLogs) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      case 1000: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibraryLogs) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._resource {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._resource {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.scopeLogs.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.scopeLogs, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     if !self.instrumentationLibraryLogs.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.instrumentationLibraryLogs, fieldNumber: 2)
+      try visitor.visitRepeatedMessageField(value: self.instrumentationLibraryLogs, fieldNumber: 1000)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Logs_V1_ResourceLogs, rhs: Opentelemetry_Proto_Logs_V1_ResourceLogs) -> Bool {
     if lhs._resource != rhs._resource {return false}
+    if lhs.scopeLogs != rhs.scopeLogs {return false}
     if lhs.instrumentationLibraryLogs != rhs.instrumentationLibraryLogs {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ScopeLogs"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "scope"),
+    2: .standard(proto: "log_records"),
+    3: .standard(proto: "schema_url"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._scope) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.logRecords) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._scope {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.logRecords.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.logRecords, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Logs_V1_ScopeLogs, rhs: Opentelemetry_Proto_Logs_V1_ScopeLogs) -> Bool {
+    if lhs._scope != rhs._scope {return false}
+    if lhs.logRecords != rhs.logRecords {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -416,7 +640,8 @@ extension Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs: SwiftProtobuf.
   public static let protoMessageName: String = _protobuf_package + ".InstrumentationLibraryLogs"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "instrumentation_library"),
-    2: .same(proto: "logs"),
+    2: .standard(proto: "log_records"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -426,25 +651,34 @@ extension Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs: SwiftProtobuf.
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._instrumentationLibrary) }()
-      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.logs) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.logRecords) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._instrumentationLibrary {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._instrumentationLibrary {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.logRecords.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.logRecords, fieldNumber: 2)
     }
-    if !self.logs.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.logs, fieldNumber: 2)
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs, rhs: Opentelemetry_Proto_Logs_V1_InstrumentationLibraryLogs) -> Bool {
     if lhs._instrumentationLibrary != rhs._instrumentationLibrary {return false}
-    if lhs.logs != rhs.logs {return false}
+    if lhs.logRecords != rhs.logRecords {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -454,6 +688,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
   public static let protoMessageName: String = _protobuf_package + ".LogRecord"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "time_unix_nano"),
+    11: .standard(proto: "observed_time_unix_nano"),
     2: .standard(proto: "severity_number"),
     3: .standard(proto: "severity_text"),
     4: .same(proto: "name"),
@@ -481,12 +716,17 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
       case 8: try { try decoder.decodeSingularFixed32Field(value: &self.flags) }()
       case 9: try { try decoder.decodeSingularBytesField(value: &self.traceID) }()
       case 10: try { try decoder.decodeSingularBytesField(value: &self.spanID) }()
+      case 11: try { try decoder.decodeSingularFixed64Field(value: &self.observedTimeUnixNano) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.timeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.timeUnixNano, fieldNumber: 1)
     }
@@ -499,9 +739,9 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 4)
     }
-    if let v = self._body {
+    try { if let v = self._body {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    }
+    } }()
     if !self.attributes.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 6)
     }
@@ -517,11 +757,15 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     if !self.spanID.isEmpty {
       try visitor.visitSingularBytesField(value: self.spanID, fieldNumber: 10)
     }
+    if self.observedTimeUnixNano != 0 {
+      try visitor.visitSingularFixed64Field(value: self.observedTimeUnixNano, fieldNumber: 11)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Logs_V1_LogRecord, rhs: Opentelemetry_Proto_Logs_V1_LogRecord) -> Bool {
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
+    if lhs.observedTimeUnixNano != rhs.observedTimeUnixNano {return false}
     if lhs.severityNumber != rhs.severityNumber {return false}
     if lhs.severityText != rhs.severityText {return false}
     if lhs.name != rhs.name {return false}

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/logs_service.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/logs_service.pb.swift
@@ -61,6 +61,11 @@ public struct Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: @unchecked Sendable {}
+extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.collector.logs.v1"

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/metrics_service.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/metrics_service.pb.swift
@@ -61,6 +61,11 @@ public struct Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRespo
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: @unchecked Sendable {}
+extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.collector.metrics.v1"

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/resource.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/resource.pb.swift
@@ -40,7 +40,9 @@ public struct Opentelemetry_Proto_Resource_V1_Resource {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// Set of labels that describe the resource.
+  /// Set of attributes that describe the resource.
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
   public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// dropped_attributes_count is the number of dropped attributes. If the value is 0, then
@@ -51,6 +53,10 @@ public struct Opentelemetry_Proto_Resource_V1_Resource {
 
   public init() {}
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Resource_V1_Resource: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/trace.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/trace.pb.swift
@@ -34,7 +34,34 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-/// A collection of InstrumentationLibrarySpans from a Resource.
+/// TracesData represents the traces data that can be stored in a persistent storage,
+/// OR can be embedded by other protocols that transfer OTLP traces data but do
+/// not implement the OTLP protocol.
+///
+/// The main difference between this message and collector protocol is that
+/// in this message there will not be any "control" or "metadata" specific to
+/// OTLP protocol.
+///
+/// When new fields are added into this message, the OTLP request MUST be updated
+/// as well.
+public struct Opentelemetry_Proto_Trace_V1_TracesData {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// An array of ResourceSpans.
+  /// For data coming from a single resource this array will typically contain
+  /// one element. Intermediary nodes that receive data from multiple origins
+  /// typically batch the data before forwarding further and in that case this
+  /// array will contain multiple elements.
+  public var resourceSpans: [Opentelemetry_Proto_Trace_V1_ResourceSpans] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// A collection of ScopeSpans from a Resource.
 public struct Opentelemetry_Proto_Trace_V1_ResourceSpans {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -51,8 +78,41 @@ public struct Opentelemetry_Proto_Trace_V1_ResourceSpans {
   /// Clears the value of `resource`. Subsequent reads from it will return its default value.
   public mutating func clearResource() {self._resource = nil}
 
+  /// A list of ScopeSpans that originate from a resource.
+  public var scopeSpans: [Opentelemetry_Proto_Trace_V1_ScopeSpans] = []
+
   /// A list of InstrumentationLibrarySpans that originate from a resource.
+  /// This field is deprecated and will be removed after grace period expires on June 15, 2022.
+  ///
+  /// During the grace period the following rules SHOULD be followed:
+  ///
+  /// For Binary Protobufs
+  /// ====================
+  /// Binary Protobuf senders SHOULD NOT set instrumentation_library_spans. Instead
+  /// scope_spans SHOULD be set.
+  ///
+  /// Binary Protobuf receivers SHOULD check if instrumentation_library_spans is set
+  /// and scope_spans is not set then the value in instrumentation_library_spans
+  /// SHOULD be used instead by converting InstrumentationLibrarySpans into ScopeSpans.
+  /// If scope_spans is set then instrumentation_library_spans SHOULD be ignored.
+  ///
+  /// For JSON
+  /// ========
+  /// JSON senders that set instrumentation_library_spans field MAY also set
+  /// scope_spans to carry the same spans, essentially double-publishing the same data.
+  /// Such double-publishing MAY be controlled by a user-settable option.
+  /// If double-publishing is not used then the senders SHOULD set scope_spans and
+  /// SHOULD NOT set instrumentation_library_spans.
+  ///
+  /// JSON receivers SHOULD check if instrumentation_library_spans is set and
+  /// scope_spans is not set then the value in instrumentation_library_spans
+  /// SHOULD be used instead by converting InstrumentationLibrarySpans into ScopeSpans.
+  /// If scope_spans is set then instrumentation_library_spans field SHOULD be ignored.
   public var instrumentationLibrarySpans: [Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans] = []
+
+  /// This schema_url applies to the data in the "resource" field. It does not apply
+  /// to the data in the "scope_spans" field which have their own schema_url field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -61,7 +121,41 @@ public struct Opentelemetry_Proto_Trace_V1_ResourceSpans {
   fileprivate var _resource: Opentelemetry_Proto_Resource_V1_Resource? = nil
 }
 
+/// A collection of Spans produced by an InstrumentationScope.
+public struct Opentelemetry_Proto_Trace_V1_ScopeSpans {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// The instrumentation scope information for the spans in this message.
+  /// Semantically when InstrumentationScope isn't set, it is equivalent with
+  /// an empty instrumentation scope name (unknown).
+  public var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
+    get {return _scope ?? Opentelemetry_Proto_Common_V1_InstrumentationScope()}
+    set {_scope = newValue}
+  }
+  /// Returns true if `scope` has been explicitly set.
+  public var hasScope: Bool {return self._scope != nil}
+  /// Clears the value of `scope`. Subsequent reads from it will return its default value.
+  public mutating func clearScope() {self._scope = nil}
+
+  /// A list of Spans that originate from an instrumentation scope.
+  public var spans: [Opentelemetry_Proto_Trace_V1_Span] = []
+
+  /// This schema_url applies to all spans and span events in the "spans" field.
+  public var schemaURL: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _scope: Opentelemetry_Proto_Common_V1_InstrumentationScope? = nil
+}
+
 /// A collection of Spans produced by an InstrumentationLibrary.
+/// InstrumentationLibrarySpans is wire-compatible with ScopeSpans for binary
+/// Protobuf format.
+/// This message is deprecated and will be removed on June 15, 2022.
 public struct Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -81,6 +175,9 @@ public struct Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans {
 
   /// A list of Spans that originate from an instrumentation library.
   public var spans: [Opentelemetry_Proto_Trace_V1_Span] = []
+
+  /// This schema_url applies to all spans and span events in the "spans" field.
+  public var schemaURL: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -111,10 +208,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// random trace_id if empty or invalid trace_id was received.
   ///
   /// This field is required.
-  public var traceID: Data {
-    get {return _storage._traceID}
-    set {_uniqueStorage()._traceID = newValue}
-  }
+  public var traceID: Data = Data()
 
   /// A unique identifier for a span within a trace, assigned when the span
   /// is created. The ID is an 8-byte array. An ID with all zeroes is considered
@@ -124,25 +218,16 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// random span_id if empty or invalid span_id was received.
   ///
   /// This field is required.
-  public var spanID: Data {
-    get {return _storage._spanID}
-    set {_uniqueStorage()._spanID = newValue}
-  }
+  public var spanID: Data = Data()
 
   /// trace_state conveys information about request position in multiple distributed tracing graphs.
   /// It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
   /// See also https://github.com/w3c/distributed-tracing for more details about this field.
-  public var traceState: String {
-    get {return _storage._traceState}
-    set {_uniqueStorage()._traceState = newValue}
-  }
+  public var traceState: String = String()
 
   /// The `span_id` of this span's parent span. If this is a root span, then this
   /// field must be empty. The ID is an 8-byte array.
-  public var parentSpanID: Data {
-    get {return _storage._parentSpanID}
-    set {_uniqueStorage()._parentSpanID = newValue}
-  }
+  public var parentSpanID: Data = Data()
 
   /// A description of the span's operation.
   ///
@@ -152,23 +237,15 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// This makes it easier to correlate spans in different traces.
   ///
   /// This field is semantically required to be set to non-empty string.
-  /// When null or empty string received - receiver may use string "name"
-  /// as a replacement. There might be smarted algorithms implemented by
-  /// receiver to fix the empty span name.
+  /// Empty value is equivalent to an unknown span name.
   ///
   /// This field is required.
-  public var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  public var name: String = String()
 
   /// Distinguishes between spans generated in a particular context. For example,
   /// two spans with the same name may be distinguished using `CLIENT` (caller)
   /// and `SERVER` (callee) to identify queueing latency associated with the span.
-  public var kind: Opentelemetry_Proto_Trace_V1_Span.SpanKind {
-    get {return _storage._kind}
-    set {_uniqueStorage()._kind = newValue}
-  }
+  public var kind: Opentelemetry_Proto_Trace_V1_Span.SpanKind = .unspecified
 
   /// start_time_unix_nano is the start time of the span. On the client side, this is the time
   /// kept by the local machine where the span execution starts. On the server side, this
@@ -176,10 +253,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   ///
   /// This field is semantically required and it is expected that end_time >= start_time.
-  public var startTimeUnixNano: UInt64 {
-    get {return _storage._startTimeUnixNano}
-    set {_uniqueStorage()._startTimeUnixNano = newValue}
-  }
+  public var startTimeUnixNano: UInt64 = 0
 
   /// end_time_unix_nano is the end time of the span. On the client side, this is the time
   /// kept by the local machine where the span execution ends. On the server side, this
@@ -187,69 +261,52 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   ///
   /// This field is semantically required and it is expected that end_time >= start_time.
-  public var endTimeUnixNano: UInt64 {
-    get {return _storage._endTimeUnixNano}
-    set {_uniqueStorage()._endTimeUnixNano = newValue}
-  }
+  public var endTimeUnixNano: UInt64 = 0
 
-  /// attributes is a collection of key/value pairs. The value can be a string,
-  /// an integer, a double or the Boolean values `true` or `false`. Note, global attributes
+  /// attributes is a collection of key/value pairs. Note, global attributes
   /// like server name can be set using the resource API. Examples of attributes:
   ///
   ///     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
   ///     "/http/server_latency": 300
   ///     "abc.com/myattribute": true
   ///     "abc.com/score": 10.239
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] {
-    get {return _storage._attributes}
-    set {_uniqueStorage()._attributes = newValue}
-  }
+  ///
+  /// The OpenTelemetry API specification further restricts the allowed value types:
+  /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
+  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// dropped_attributes_count is the number of attributes that were discarded. Attributes
   /// can be discarded because their keys are too long or because there are too many
   /// attributes. If this value is 0, then no attributes were dropped.
-  public var droppedAttributesCount: UInt32 {
-    get {return _storage._droppedAttributesCount}
-    set {_uniqueStorage()._droppedAttributesCount = newValue}
-  }
+  public var droppedAttributesCount: UInt32 = 0
 
   /// events is a collection of Event items.
-  public var events: [Opentelemetry_Proto_Trace_V1_Span.Event] {
-    get {return _storage._events}
-    set {_uniqueStorage()._events = newValue}
-  }
+  public var events: [Opentelemetry_Proto_Trace_V1_Span.Event] = []
 
   /// dropped_events_count is the number of dropped events. If the value is 0, then no
   /// events were dropped.
-  public var droppedEventsCount: UInt32 {
-    get {return _storage._droppedEventsCount}
-    set {_uniqueStorage()._droppedEventsCount = newValue}
-  }
+  public var droppedEventsCount: UInt32 = 0
 
   /// links is a collection of Links, which are references from this span to a span
   /// in the same or different trace.
-  public var links: [Opentelemetry_Proto_Trace_V1_Span.Link] {
-    get {return _storage._links}
-    set {_uniqueStorage()._links = newValue}
-  }
+  public var links: [Opentelemetry_Proto_Trace_V1_Span.Link] = []
 
   /// dropped_links_count is the number of dropped links after the maximum size was
   /// enforced. If this value is 0, then no links were dropped.
-  public var droppedLinksCount: UInt32 {
-    get {return _storage._droppedLinksCount}
-    set {_uniqueStorage()._droppedLinksCount = newValue}
-  }
+  public var droppedLinksCount: UInt32 = 0
 
   /// An optional final status for this span. Semantically when Status isn't set, it means
   /// span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
   public var status: Opentelemetry_Proto_Trace_V1_Status {
-    get {return _storage._status ?? Opentelemetry_Proto_Trace_V1_Status()}
-    set {_uniqueStorage()._status = newValue}
+    get {return _status ?? Opentelemetry_Proto_Trace_V1_Status()}
+    set {_status = newValue}
   }
   /// Returns true if `status` has been explicitly set.
-  public var hasStatus: Bool {return _storage._status != nil}
+  public var hasStatus: Bool {return self._status != nil}
   /// Clears the value of `status`. Subsequent reads from it will return its default value.
-  public mutating func clearStatus() {_uniqueStorage()._status = nil}
+  public mutating func clearStatus() {self._status = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -263,7 +320,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
     case unspecified // = 0
 
     /// Indicates that the span represents an internal operation within an application,
-    /// as opposed to an operations happening at the boundaries. Default value.
+    /// as opposed to an operation happening at the boundaries. Default value.
     case `internal` // = 1
 
     /// Indicates that the span covers server-side handling of an RPC or other
@@ -330,6 +387,8 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
     public var name: String = String()
 
     /// attributes is a collection of attribute key/value pairs on the event.
+    /// Attribute keys MUST be unique (it is not allowed to have more than one
+    /// attribute with the same key).
     public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
     /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
@@ -361,6 +420,8 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
     public var traceState: String = String()
 
     /// attributes is a collection of attribute key/value pairs on the link.
+    /// Attribute keys MUST be unique (it is not allowed to have more than one
+    /// attribute with the same key).
     public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
     /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
@@ -374,7 +435,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _status: Opentelemetry_Proto_Trace_V1_Status? = nil
 }
 
 #if swift(>=4.2)
@@ -400,14 +461,6 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// The deprecated status code. This is an optional field.
-  ///
-  /// This field is deprecated and is replaced by the `code` field below. See backward
-  /// compatibility notes below. According to our stability guarantees this field
-  /// will be removed in 12 months, on Oct 22, 2021. All usage of old senders and
-  /// receivers that do not understand the `code` field MUST be phased out by then.
-  public var deprecatedCode: Opentelemetry_Proto_Trace_V1_Status.DeprecatedStatusCode = .ok
-
   /// A developer-facing human readable error message.
   public var message: String = String()
 
@@ -416,81 +469,8 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum DeprecatedStatusCode: SwiftProtobuf.Enum {
-    public typealias RawValue = Int
-    case ok // = 0
-    case cancelled // = 1
-    case unknownError // = 2
-    case invalidArgument // = 3
-    case deadlineExceeded // = 4
-    case notFound // = 5
-    case alreadyExists // = 6
-    case permissionDenied // = 7
-    case resourceExhausted // = 8
-    case failedPrecondition // = 9
-    case aborted // = 10
-    case outOfRange // = 11
-    case unimplemented // = 12
-    case internalError // = 13
-    case unavailable // = 14
-    case dataLoss // = 15
-    case unauthenticated // = 16
-    case UNRECOGNIZED(Int)
-
-    public init() {
-      self = .ok
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ok
-      case 1: self = .cancelled
-      case 2: self = .unknownError
-      case 3: self = .invalidArgument
-      case 4: self = .deadlineExceeded
-      case 5: self = .notFound
-      case 6: self = .alreadyExists
-      case 7: self = .permissionDenied
-      case 8: self = .resourceExhausted
-      case 9: self = .failedPrecondition
-      case 10: self = .aborted
-      case 11: self = .outOfRange
-      case 12: self = .unimplemented
-      case 13: self = .internalError
-      case 14: self = .unavailable
-      case 15: self = .dataLoss
-      case 16: self = .unauthenticated
-      default: self = .UNRECOGNIZED(rawValue)
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .ok: return 0
-      case .cancelled: return 1
-      case .unknownError: return 2
-      case .invalidArgument: return 3
-      case .deadlineExceeded: return 4
-      case .notFound: return 5
-      case .alreadyExists: return 6
-      case .permissionDenied: return 7
-      case .resourceExhausted: return 8
-      case .failedPrecondition: return 9
-      case .aborted: return 10
-      case .outOfRange: return 11
-      case .unimplemented: return 12
-      case .internalError: return 13
-      case .unavailable: return 14
-      case .dataLoss: return 15
-      case .unauthenticated: return 16
-      case .UNRECOGNIZED(let i): return i
-      }
-    }
-
-  }
-
   /// For the semantics of status codes see
-  /// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status
+  /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
   public enum StatusCode: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
@@ -534,29 +514,6 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
 
 #if swift(>=4.2)
 
-extension Opentelemetry_Proto_Trace_V1_Status.DeprecatedStatusCode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static var allCases: [Opentelemetry_Proto_Trace_V1_Status.DeprecatedStatusCode] = [
-    .ok,
-    .cancelled,
-    .unknownError,
-    .invalidArgument,
-    .deadlineExceeded,
-    .notFound,
-    .alreadyExists,
-    .permissionDenied,
-    .resourceExhausted,
-    .failedPrecondition,
-    .aborted,
-    .outOfRange,
-    .unimplemented,
-    .internalError,
-    .unavailable,
-    .dataLoss,
-    .unauthenticated,
-  ]
-}
-
 extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static var allCases: [Opentelemetry_Proto_Trace_V1_Status.StatusCode] = [
@@ -568,15 +525,62 @@ extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: CaseIterable {
 
 #endif  // swift(>=4.2)
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Trace_V1_TracesData: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_ResourceSpans: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_ScopeSpans: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Span.Event: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Span.Link: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Status: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.trace.v1"
+
+extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".TracesData"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "resource_spans"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.resourceSpans) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.resourceSpans.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.resourceSpans, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_TracesData, rhs: Opentelemetry_Proto_Trace_V1_TracesData) -> Bool {
+    if lhs.resourceSpans != rhs.resourceSpans {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
 
 extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ResourceSpans"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "resource"),
-    2: .standard(proto: "instrumentation_library_spans"),
+    2: .standard(proto: "scope_spans"),
+    1000: .standard(proto: "instrumentation_library_spans"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -586,25 +590,87 @@ extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, Swi
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._resource) }()
-      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibrarySpans) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.scopeSpans) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      case 1000: try { try decoder.decodeRepeatedMessageField(value: &self.instrumentationLibrarySpans) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._resource {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._resource {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.scopeSpans.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.scopeSpans, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     if !self.instrumentationLibrarySpans.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.instrumentationLibrarySpans, fieldNumber: 2)
+      try visitor.visitRepeatedMessageField(value: self.instrumentationLibrarySpans, fieldNumber: 1000)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Trace_V1_ResourceSpans, rhs: Opentelemetry_Proto_Trace_V1_ResourceSpans) -> Bool {
     if lhs._resource != rhs._resource {return false}
+    if lhs.scopeSpans != rhs.scopeSpans {return false}
     if lhs.instrumentationLibrarySpans != rhs.instrumentationLibrarySpans {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ScopeSpans"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "scope"),
+    2: .same(proto: "spans"),
+    3: .standard(proto: "schema_url"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._scope) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.spans) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._scope {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.spans.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.spans, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_ScopeSpans, rhs: Opentelemetry_Proto_Trace_V1_ScopeSpans) -> Bool {
+    if lhs._scope != rhs._scope {return false}
+    if lhs.spans != rhs.spans {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -615,6 +681,7 @@ extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans: SwiftProtobu
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "instrumentation_library"),
     2: .same(proto: "spans"),
+    3: .standard(proto: "schema_url"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -625,17 +692,25 @@ extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans: SwiftProtobu
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._instrumentationLibrary) }()
       case 2: try { try decoder.decodeRepeatedMessageField(value: &self.spans) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.schemaURL) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._instrumentationLibrary {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._instrumentationLibrary {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.spans.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.spans, fieldNumber: 2)
+    }
+    if !self.schemaURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.schemaURL, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -643,6 +718,7 @@ extension Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans: SwiftProtobu
   public static func ==(lhs: Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans, rhs: Opentelemetry_Proto_Trace_V1_InstrumentationLibrarySpans) -> Bool {
     if lhs._instrumentationLibrary != rhs._instrumentationLibrary {return false}
     if lhs.spans != rhs.spans {return false}
+    if lhs.schemaURL != rhs.schemaURL {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -668,157 +744,101 @@ extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobu
     15: .same(proto: "status"),
   ]
 
-  fileprivate class _StorageClass {
-    var _traceID: Data = Data()
-    var _spanID: Data = Data()
-    var _traceState: String = String()
-    var _parentSpanID: Data = Data()
-    var _name: String = String()
-    var _kind: Opentelemetry_Proto_Trace_V1_Span.SpanKind = .unspecified
-    var _startTimeUnixNano: UInt64 = 0
-    var _endTimeUnixNano: UInt64 = 0
-    var _attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
-    var _droppedAttributesCount: UInt32 = 0
-    var _events: [Opentelemetry_Proto_Trace_V1_Span.Event] = []
-    var _droppedEventsCount: UInt32 = 0
-    var _links: [Opentelemetry_Proto_Trace_V1_Span.Link] = []
-    var _droppedLinksCount: UInt32 = 0
-    var _status: Opentelemetry_Proto_Trace_V1_Status? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _traceID = source._traceID
-      _spanID = source._spanID
-      _traceState = source._traceState
-      _parentSpanID = source._parentSpanID
-      _name = source._name
-      _kind = source._kind
-      _startTimeUnixNano = source._startTimeUnixNano
-      _endTimeUnixNano = source._endTimeUnixNano
-      _attributes = source._attributes
-      _droppedAttributesCount = source._droppedAttributesCount
-      _events = source._events
-      _droppedEventsCount = source._droppedEventsCount
-      _links = source._links
-      _droppedLinksCount = source._droppedLinksCount
-      _status = source._status
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try { try decoder.decodeSingularBytesField(value: &_storage._traceID) }()
-        case 2: try { try decoder.decodeSingularBytesField(value: &_storage._spanID) }()
-        case 3: try { try decoder.decodeSingularStringField(value: &_storage._traceState) }()
-        case 4: try { try decoder.decodeSingularBytesField(value: &_storage._parentSpanID) }()
-        case 5: try { try decoder.decodeSingularStringField(value: &_storage._name) }()
-        case 6: try { try decoder.decodeSingularEnumField(value: &_storage._kind) }()
-        case 7: try { try decoder.decodeSingularFixed64Field(value: &_storage._startTimeUnixNano) }()
-        case 8: try { try decoder.decodeSingularFixed64Field(value: &_storage._endTimeUnixNano) }()
-        case 9: try { try decoder.decodeRepeatedMessageField(value: &_storage._attributes) }()
-        case 10: try { try decoder.decodeSingularUInt32Field(value: &_storage._droppedAttributesCount) }()
-        case 11: try { try decoder.decodeRepeatedMessageField(value: &_storage._events) }()
-        case 12: try { try decoder.decodeSingularUInt32Field(value: &_storage._droppedEventsCount) }()
-        case 13: try { try decoder.decodeRepeatedMessageField(value: &_storage._links) }()
-        case 14: try { try decoder.decodeSingularUInt32Field(value: &_storage._droppedLinksCount) }()
-        case 15: try { try decoder.decodeSingularMessageField(value: &_storage._status) }()
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBytesField(value: &self.traceID) }()
+      case 2: try { try decoder.decodeSingularBytesField(value: &self.spanID) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.traceState) }()
+      case 4: try { try decoder.decodeSingularBytesField(value: &self.parentSpanID) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 6: try { try decoder.decodeSingularEnumField(value: &self.kind) }()
+      case 7: try { try decoder.decodeSingularFixed64Field(value: &self.startTimeUnixNano) }()
+      case 8: try { try decoder.decodeSingularFixed64Field(value: &self.endTimeUnixNano) }()
+      case 9: try { try decoder.decodeRepeatedMessageField(value: &self.attributes) }()
+      case 10: try { try decoder.decodeSingularUInt32Field(value: &self.droppedAttributesCount) }()
+      case 11: try { try decoder.decodeRepeatedMessageField(value: &self.events) }()
+      case 12: try { try decoder.decodeSingularUInt32Field(value: &self.droppedEventsCount) }()
+      case 13: try { try decoder.decodeRepeatedMessageField(value: &self.links) }()
+      case 14: try { try decoder.decodeSingularUInt32Field(value: &self.droppedLinksCount) }()
+      case 15: try { try decoder.decodeSingularMessageField(value: &self._status) }()
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._traceID.isEmpty {
-        try visitor.visitSingularBytesField(value: _storage._traceID, fieldNumber: 1)
-      }
-      if !_storage._spanID.isEmpty {
-        try visitor.visitSingularBytesField(value: _storage._spanID, fieldNumber: 2)
-      }
-      if !_storage._traceState.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._traceState, fieldNumber: 3)
-      }
-      if !_storage._parentSpanID.isEmpty {
-        try visitor.visitSingularBytesField(value: _storage._parentSpanID, fieldNumber: 4)
-      }
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 5)
-      }
-      if _storage._kind != .unspecified {
-        try visitor.visitSingularEnumField(value: _storage._kind, fieldNumber: 6)
-      }
-      if _storage._startTimeUnixNano != 0 {
-        try visitor.visitSingularFixed64Field(value: _storage._startTimeUnixNano, fieldNumber: 7)
-      }
-      if _storage._endTimeUnixNano != 0 {
-        try visitor.visitSingularFixed64Field(value: _storage._endTimeUnixNano, fieldNumber: 8)
-      }
-      if !_storage._attributes.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._attributes, fieldNumber: 9)
-      }
-      if _storage._droppedAttributesCount != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._droppedAttributesCount, fieldNumber: 10)
-      }
-      if !_storage._events.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._events, fieldNumber: 11)
-      }
-      if _storage._droppedEventsCount != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._droppedEventsCount, fieldNumber: 12)
-      }
-      if !_storage._links.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._links, fieldNumber: 13)
-      }
-      if _storage._droppedLinksCount != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._droppedLinksCount, fieldNumber: 14)
-      }
-      if let v = _storage._status {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if !self.traceID.isEmpty {
+      try visitor.visitSingularBytesField(value: self.traceID, fieldNumber: 1)
     }
+    if !self.spanID.isEmpty {
+      try visitor.visitSingularBytesField(value: self.spanID, fieldNumber: 2)
+    }
+    if !self.traceState.isEmpty {
+      try visitor.visitSingularStringField(value: self.traceState, fieldNumber: 3)
+    }
+    if !self.parentSpanID.isEmpty {
+      try visitor.visitSingularBytesField(value: self.parentSpanID, fieldNumber: 4)
+    }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 5)
+    }
+    if self.kind != .unspecified {
+      try visitor.visitSingularEnumField(value: self.kind, fieldNumber: 6)
+    }
+    if self.startTimeUnixNano != 0 {
+      try visitor.visitSingularFixed64Field(value: self.startTimeUnixNano, fieldNumber: 7)
+    }
+    if self.endTimeUnixNano != 0 {
+      try visitor.visitSingularFixed64Field(value: self.endTimeUnixNano, fieldNumber: 8)
+    }
+    if !self.attributes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 9)
+    }
+    if self.droppedAttributesCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.droppedAttributesCount, fieldNumber: 10)
+    }
+    if !self.events.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.events, fieldNumber: 11)
+    }
+    if self.droppedEventsCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.droppedEventsCount, fieldNumber: 12)
+    }
+    if !self.links.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.links, fieldNumber: 13)
+    }
+    if self.droppedLinksCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.droppedLinksCount, fieldNumber: 14)
+    }
+    try { if let v = self._status {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Trace_V1_Span, rhs: Opentelemetry_Proto_Trace_V1_Span) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._traceID != rhs_storage._traceID {return false}
-        if _storage._spanID != rhs_storage._spanID {return false}
-        if _storage._traceState != rhs_storage._traceState {return false}
-        if _storage._parentSpanID != rhs_storage._parentSpanID {return false}
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._kind != rhs_storage._kind {return false}
-        if _storage._startTimeUnixNano != rhs_storage._startTimeUnixNano {return false}
-        if _storage._endTimeUnixNano != rhs_storage._endTimeUnixNano {return false}
-        if _storage._attributes != rhs_storage._attributes {return false}
-        if _storage._droppedAttributesCount != rhs_storage._droppedAttributesCount {return false}
-        if _storage._events != rhs_storage._events {return false}
-        if _storage._droppedEventsCount != rhs_storage._droppedEventsCount {return false}
-        if _storage._links != rhs_storage._links {return false}
-        if _storage._droppedLinksCount != rhs_storage._droppedLinksCount {return false}
-        if _storage._status != rhs_storage._status {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.traceID != rhs.traceID {return false}
+    if lhs.spanID != rhs.spanID {return false}
+    if lhs.traceState != rhs.traceState {return false}
+    if lhs.parentSpanID != rhs.parentSpanID {return false}
+    if lhs.name != rhs.name {return false}
+    if lhs.kind != rhs.kind {return false}
+    if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
+    if lhs.endTimeUnixNano != rhs.endTimeUnixNano {return false}
+    if lhs.attributes != rhs.attributes {return false}
+    if lhs.droppedAttributesCount != rhs.droppedAttributesCount {return false}
+    if lhs.events != rhs.events {return false}
+    if lhs.droppedEventsCount != rhs.droppedEventsCount {return false}
+    if lhs.links != rhs.links {return false}
+    if lhs.droppedLinksCount != rhs.droppedLinksCount {return false}
+    if lhs._status != rhs._status {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -944,7 +964,6 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftPr
 extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Status"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "deprecated_code"),
     2: .same(proto: "message"),
     3: .same(proto: "code"),
   ]
@@ -955,7 +974,6 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularEnumField(value: &self.deprecatedCode) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.message) }()
       case 3: try { try decoder.decodeSingularEnumField(value: &self.code) }()
       default: break
@@ -964,9 +982,6 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.deprecatedCode != .ok {
-      try visitor.visitSingularEnumField(value: self.deprecatedCode, fieldNumber: 1)
-    }
     if !self.message.isEmpty {
       try visitor.visitSingularStringField(value: self.message, fieldNumber: 2)
     }
@@ -977,34 +992,11 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
   }
 
   public static func ==(lhs: Opentelemetry_Proto_Trace_V1_Status, rhs: Opentelemetry_Proto_Trace_V1_Status) -> Bool {
-    if lhs.deprecatedCode != rhs.deprecatedCode {return false}
     if lhs.message != rhs.message {return false}
     if lhs.code != rhs.code {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
-}
-
-extension Opentelemetry_Proto_Trace_V1_Status.DeprecatedStatusCode: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "DEPRECATED_STATUS_CODE_OK"),
-    1: .same(proto: "DEPRECATED_STATUS_CODE_CANCELLED"),
-    2: .same(proto: "DEPRECATED_STATUS_CODE_UNKNOWN_ERROR"),
-    3: .same(proto: "DEPRECATED_STATUS_CODE_INVALID_ARGUMENT"),
-    4: .same(proto: "DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED"),
-    5: .same(proto: "DEPRECATED_STATUS_CODE_NOT_FOUND"),
-    6: .same(proto: "DEPRECATED_STATUS_CODE_ALREADY_EXISTS"),
-    7: .same(proto: "DEPRECATED_STATUS_CODE_PERMISSION_DENIED"),
-    8: .same(proto: "DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED"),
-    9: .same(proto: "DEPRECATED_STATUS_CODE_FAILED_PRECONDITION"),
-    10: .same(proto: "DEPRECATED_STATUS_CODE_ABORTED"),
-    11: .same(proto: "DEPRECATED_STATUS_CODE_OUT_OF_RANGE"),
-    12: .same(proto: "DEPRECATED_STATUS_CODE_UNIMPLEMENTED"),
-    13: .same(proto: "DEPRECATED_STATUS_CODE_INTERNAL_ERROR"),
-    14: .same(proto: "DEPRECATED_STATUS_CODE_UNAVAILABLE"),
-    15: .same(proto: "DEPRECATED_STATUS_CODE_DATA_LOSS"),
-    16: .same(proto: "DEPRECATED_STATUS_CODE_UNAUTHENTICATED"),
-  ]
 }
 
 extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: SwiftProtobuf._ProtoNameProviding {

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/trace_config.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/trace_config.pb.swift
@@ -208,6 +208,15 @@ public struct Opentelemetry_Proto_Trace_V1_RateLimitingSampler {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Trace_V1_TraceConfig: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_TraceConfig.OneOf_Sampler: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_ConstantSampler: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_ConstantSampler.ConstantDecision: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_TraceIdRatioBased: @unchecked Sendable {}
+extension Opentelemetry_Proto_Trace_V1_RateLimitingSampler: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.trace.v1"
@@ -233,30 +242,42 @@ extension Opentelemetry_Proto_Trace_V1_TraceConfig: SwiftProtobuf.Message, Swift
       switch fieldNumber {
       case 1: try {
         var v: Opentelemetry_Proto_Trace_V1_ConstantSampler?
+        var hadOneofValue = false
         if let current = self.sampler {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .constantSampler(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.sampler = .constantSampler(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.sampler = .constantSampler(v)
+        }
       }()
       case 2: try {
         var v: Opentelemetry_Proto_Trace_V1_TraceIdRatioBased?
+        var hadOneofValue = false
         if let current = self.sampler {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .traceIDRatioBased(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.sampler = .traceIDRatioBased(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.sampler = .traceIDRatioBased(v)
+        }
       }()
       case 3: try {
         var v: Opentelemetry_Proto_Trace_V1_RateLimitingSampler?
+        var hadOneofValue = false
         if let current = self.sampler {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .rateLimitingSampler(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.sampler = .rateLimitingSampler(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.sampler = .rateLimitingSampler(v)
+        }
       }()
       case 4: try { try decoder.decodeSingularInt64Field(value: &self.maxNumberOfAttributes) }()
       case 5: try { try decoder.decodeSingularInt64Field(value: &self.maxNumberOfTimedEvents) }()
@@ -270,8 +291,9 @@ extension Opentelemetry_Proto_Trace_V1_TraceConfig: SwiftProtobuf.Message, Swift
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     switch self.sampler {
     case .constantSampler?: try {
       guard case .constantSampler(let v)? = self.sampler else { preconditionFailure() }

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/trace_service.grpc.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/trace_service.grpc.swift
@@ -26,7 +26,7 @@ import SwiftProtobuf
 
 
 /// Service that can be used to push spans between one Application instrumented with
-/// OpenTelemetry and an collector, or between an collector and a central collector (in this
+/// OpenTelemetry and a collector, or between a collector and a central collector (in this
 /// case spans are sent/received to/from multiple Applications).
 ///
 /// Usage: instantiate `Opentelemetry_Proto_Collector_Trace_V1_TraceServiceClient`, then call methods of this protocol to make API calls.
@@ -94,7 +94,7 @@ public final class Opentelemetry_Proto_Collector_Trace_V1_TraceServiceClient: Op
 }
 
 /// Service that can be used to push spans between one Application instrumented with
-/// OpenTelemetry and an collector, or between an collector and a central collector (in this
+/// OpenTelemetry and a collector, or between a collector and a central collector (in this
 /// case spans are sent/received to/from multiple Applications).
 ///
 /// To build a server, implement a class that conforms to this protocol.

--- a/Sources/Exporters/OpenTelemetryProtocol/proto/trace_service.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/proto/trace_service.pb.swift
@@ -61,6 +61,11 @@ public struct Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse 
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: @unchecked Sendable {}
+extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "opentelemetry.proto.collector.trace.v1"

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
@@ -49,12 +49,12 @@ class OtlpMetricExproterTests: XCTestCase {
         XCTAssertEqual(fakeCollector.receivedMetrics.count, 1)
         let otlpMetric = fakeCollector.receivedMetrics[0].instrumentationLibraryMetrics[0].metrics[0]
         XCTAssertEqual(metric.name, otlpMetric.name)
-        XCTAssertEqual(otlpMetric.intGauge.dataPoints.count, 1)
-        let dataPoint = otlpMetric.intGauge.dataPoints[0]
+        XCTAssertEqual(otlpMetric.gauge.dataPoints.count, 1)
+        let dataPoint = otlpMetric.gauge.dataPoints[0]
         let sum = metric.data[0] as! SumData<Int>
         XCTAssertEqual(sum.timestamp.timeIntervalSince1970.toNanoseconds, dataPoint.timeUnixNano)
         XCTAssertEqual(sum.startTimestamp.timeIntervalSince1970.toNanoseconds, dataPoint.startTimeUnixNano)
-        XCTAssertEqual(sum.sum, Int(dataPoint.value))
+        XCTAssertEqual(sum.sum, Int(dataPoint.asInt))
     }
 
     func testExportMultipleMetrics() {


### PR DESCRIPTION
Creating this PR again as the last one ( #300 ) failed on EasyCLA possibly due to incorrect user.email. I am setting `git config user.email "vvydier@gmail.com"` before `git commit` this time.
Description of the PR: Labels has been deprecated in https://github.com/open-telemetry/opentelemetry-proto/pull/342 and attributes are now used in it's place. This was reported by @trevor-dialpad  and the OTLP Exporter needed this change if a user uses opentelemetry-swift with along other otel sdk's or uses it with newer version of the otel-collector