### PR TITLE
Adds logger to OtlpTraceExporter init so GRPC calls can be logged.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "Tests"
+

--- a/Sources/Exporters/OpenTelemetryProtocol/common/EnvVarHeaders.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/common/EnvVarHeaders.swift
@@ -8,18 +8,37 @@ import OpenTelemetryApi
 
 /// Provides a framework for detection of resource information from the environment variable
 public struct EnvVarHeaders {
-    private static let otelAttributesEnv = "OTEL_EXPORTER_OTLP_HEADERS"
     private static let labelListSplitter = Character(",")
     private static let labelKeyValueSplitter = Character("=")
 
     ///  This resource information is loaded from the 
     ///  environment variable.
-    public static let attributes : [(String,String)]? = parseAttributes(rawEnvAttributes: ProcessInfo.processInfo.environment[otelAttributesEnv])
+    public static let attributes : [(String,String)]? = EnvVarHeaders.attributes()
+
+    public static func attributes(for rawEnvAttributes: String? = ProcessInfo.processInfo.environment["OTEL_EXPORTER_OTLP_HEADERS"]) -> [(String,String)]? {
+        parseAttributes(rawEnvAttributes: rawEnvAttributes)
+    }
 
     private init() {}
 
+    private static func isKey(token: String) -> Bool {
+        let alpha = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        let digit = CharacterSet(charactersIn: "0123456789")
+        let special = CharacterSet(charactersIn: "!#$%&'*+-.^_`|~")
+        let tchar = special.union(alpha).union(digit)
+        return tchar.isSuperset(of: CharacterSet(charactersIn: token))
+    }
+
+    private static func isValue(baggage: String) -> Bool {
+        let asciiSet = CharacterSet(charactersIn: UnicodeScalar(0) ..< UnicodeScalar(0x80))
+        let special = CharacterSet(charactersIn: "^\"|\"$")
+        let baggageOctet = asciiSet.subtracting(.controlCharacters).subtracting(.whitespaces).union(special)
+        return baggageOctet.isSuperset(of: CharacterSet(charactersIn: baggage))
+    }
+
     /// Creates a label map from the environment variable string.
     /// - Parameter rawEnvLabels: the comma-separated list of labels
+    /// NOTE: Parsing does not fully match W3C Correlation-Context
     private static func parseAttributes(rawEnvAttributes: String?) -> [(String, String)]? {
         guard let rawEnvLabels = rawEnvAttributes else { return nil }
 
@@ -30,10 +49,17 @@ public struct EnvVarHeaders {
             if split.count != 2 {
                 return
             }
+
             let key = split[0].trimmingCharacters(in: .whitespaces)
-            let value = split[1].trimmingCharacters(in: CharacterSet(charactersIn: "^\"|\"$"))
+            guard isKey(token: key) else { return }
+
+            let value = split[1].trimmingCharacters(in: .whitespaces)
+            guard isValue(baggage: value) else { return }
+
             labels.append((key,value))
         }
-        return labels
+        return labels.count > 0 ? labels : nil
     }
 }
+
+

--- a/Sources/Exporters/OpenTelemetryProtocol/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/OtlpMetricExporter.swift
@@ -19,12 +19,10 @@ public class OtlpMetricExporter: MetricExporter {
 
     
 
-    public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() }), envVarHeaders: [(String,String)]? = EnvVarHeaders.attributes
-    ) {
+    public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() }), envVarHeaders: [(String,String)]? = EnvVarHeaders.attributes) {
         self.channel = channel
         self.config = config
         self.metricClient = Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceClient(channel: self.channel)
-
         if let headers = envVarHeaders {
             callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
         } else if let headers = config.headers {

--- a/Sources/Exporters/OpenTelemetryProtocol/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/OtlpMetricExporter.swift
@@ -17,14 +17,15 @@ public class OtlpMetricExporter: MetricExporter {
     let config : OtlpConfiguration
     var callOptions : CallOptions? = nil
 
+    
 
-
-    public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() })) {
+    public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() }), envVarHeaders: [(String,String)]? = EnvVarHeaders.attributes
+    ) {
         self.channel = channel
         self.config = config
         self.metricClient = Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceClient(channel: self.channel)
 
-        if let headers = EnvVarHeaders.attributes {
+        if let headers = envVarHeaders {
             callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
         } else if let headers = config.headers {
             callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)

--- a/Sources/Exporters/OpenTelemetryProtocol/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/OtlpMetricExporter.swift
@@ -4,6 +4,7 @@
  */
 
 import Foundation
+import Logging
 import GRPC
 import NIO
 import NIOHPACK
@@ -18,15 +19,18 @@ public class OtlpMetricExporter: MetricExporter {
 
 
 
-    public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration()) {
+    public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() })) {
         self.channel = channel
         self.config = config
         self.metricClient = Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceClient(channel: self.channel)
 
         if let headers = EnvVarHeaders.attributes {
-            callOptions = CallOptions(customMetadata: HPACKHeaders(headers))
+            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
         } else if let headers = config.headers {
-            callOptions = CallOptions(customMetadata: HPACKHeaders(headers))
+            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
+        }
+        else {
+            callOptions = CallOptions(logger: logger)
         }
     }
     

--- a/Sources/Exporters/OpenTelemetryProtocol/trace/OtlpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/trace/OtlpTraceExporter.swift
@@ -17,11 +17,11 @@ public class OtlpTraceExporter: SpanExporter {
     let config : OtlpConfiguration
     var callOptions : CallOptions? = nil
 
-    public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() })) {
+    public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() }), envVarHeaders: [(String,String)]? = EnvVarHeaders.attributes) {
         self.channel = channel
         traceClient = Opentelemetry_Proto_Collector_Trace_V1_TraceServiceClient(channel: channel)
         self.config = config
-        if let headers = EnvVarHeaders.attributes {
+        if let headers = envVarHeaders {
             callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
         } else if let headers = config.headers {
             callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)

--- a/Tests/ExportersTests/OpenTelemetryProtocol/EnvVarHeadersTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/EnvVarHeadersTests.swift
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryProtocolExporter
+import XCTest
+
+class EnvVarHeadersTests: XCTestCase {
+
+    func test_attributesIsNil_whenAccessedThroughStaticProperty() throws {
+        XCTAssertNil(EnvVarHeaders.attributes)
+    }
+
+    func test_attributesIsNil_whenNoRawValueProvided() throws {
+        XCTAssertNil(EnvVarHeaders.attributes(for: nil))
+    }
+
+    func test_attributesContainOneKeyValuePair_whenRawValueProvidedHasOneKeyValuePair() throws {
+        let capturedAttributes = EnvVarHeaders.attributes(for: "key1=value1")
+        XCTAssertNotNil(capturedAttributes)
+        XCTAssertEqual(capturedAttributes![0].0, "key1")
+        XCTAssertEqual(capturedAttributes![0].1, "value1")
+    }
+
+    func test_attributesIsNil_whenInvalidRawValueProvided() throws {
+        XCTAssertNil(EnvVarHeaders.attributes(for: "key1"))
+    }
+
+    func test_attributesContainTwoKeyValuePair_whenRawValueProvidedHasTwoKeyValuePair() throws {
+        let capturedAttributes = EnvVarHeaders.attributes(for: " key1=value1,  key2 = value2 ")
+        XCTAssertNotNil(capturedAttributes)
+        XCTAssertEqual(capturedAttributes![0].0, "key1")
+        XCTAssertEqual(capturedAttributes![0].1, "value1")
+        XCTAssertEqual(capturedAttributes![1].0, "key2")
+        XCTAssertEqual(capturedAttributes![1].1, "value2")
+    }
+
+    func test_attributesIsNil_whenRawValueContainsWhiteSpace() throws {
+        let capturedAttributes = EnvVarHeaders.attributes(for: "key=value with\twhitespace")
+        XCTAssertNil(capturedAttributes)
+    }
+
+    func test_attributesExcludesInvalidTuples_whenRawValueContainsInvalidCharacters() throws {
+        let capturedAttributes = EnvVarHeaders.attributes(for: "key=value with whitespace")
+        XCTAssertNil(capturedAttributes)
+    }
+
+}

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
@@ -69,6 +69,7 @@ class OtlpMetricExproterTests: XCTestCase {
         XCTAssertNotNil(exporter.config.headers)
         XCTAssertEqual(exporter.config.headers?[0].0, "FOO")
         XCTAssertEqual(exporter.config.headers?[0].1, "BAR")
+        XCTAssertEqual("BAR", exporter.callOptions?.customMetadata.first(name: "FOO"))
     }
 
     func testConfigHeadersAreSet_whenInitCalledWithExplicitHeaders() throws {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
@@ -1,3 +1,7 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 import Foundation
 import Logging
@@ -54,6 +58,24 @@ class OtlpMetricExproterTests: XCTestCase {
         XCTAssertEqual(logger.label, "my.grpc.logger")
     }
 
+    func testConfigHeadersIsNil_whenDefaultInitCalled() throws {
+        let exporter = OtlpMetricExporter(channel: channel)
+        XCTAssertNil(exporter.config.headers)
+    }
+
+    func testConfigHeadersAreSet_whenInitCalledWithCustomConfig() throws {
+        let config: OtlpConfiguration = OtlpConfiguration(timeout: TimeInterval(10), headers: [("FOO", "BAR")])
+        let exporter = OtlpMetricExporter(channel: channel, config: config)
+        XCTAssertNotNil(exporter.config.headers)
+        XCTAssertEqual(exporter.config.headers?[0].0, "FOO")
+        XCTAssertEqual(exporter.config.headers?[0].1, "BAR")
+    }
+
+    func testConfigHeadersAreSet_whenInitCalledWithExplicitHeaders() throws {
+        let exporter = OtlpMetricExporter(channel: channel, envVarHeaders: [("FOO", "BAR")])
+        XCTAssertNil(exporter.config.headers)
+        XCTAssertEqual("BAR", exporter.callOptions?.customMetadata.first(name: "FOO"))
+    }
 
     func testGaugeExport() {
         let metric = generateGaugeMetric()

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterTests.swift
@@ -1,5 +1,6 @@
 
 import Foundation
+import Logging
 import GRPC
 import NIO
 import OpenTelemetryApi
@@ -36,6 +37,23 @@ class OtlpMetricExproterTests: XCTestCase {
         XCTAssertEqual(fakeCollector.receivedMetrics, MetricsAdapter.toProtoResourceMetrics(metricDataList: [metric]))
         exporter.shutdown()
     }
+
+    func testImplicitGrpcLoggingConfig() throws {
+        let exporter = OtlpMetricExporter(channel: channel)
+        guard let logger = exporter.callOptions?.logger else {
+            throw "Missing logger"
+        }
+        XCTAssertEqual(logger.label, "io.grpc")
+    }
+
+    func testExplicitGrpcLoggingConfig() throws {
+        let exporter = OtlpMetricExporter(channel: channel, logger: Logger(label: "my.grpc.logger"))
+        guard let logger = exporter.callOptions?.logger else {
+            throw "Missing logger"
+        }
+        XCTAssertEqual(logger.label, "my.grpc.logger")
+    }
+
 
     func testGaugeExport() {
         let metric = generateGaugeMetric()

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -63,6 +63,25 @@ class OtlpTraceExporterTests: XCTestCase {
         XCTAssertEqual(logger.label, "my.grpc.logger")
     }
 
+    func testConfigHeadersIsNil_whenDefaultInitCalled() throws {
+        let exporter = OtlpTraceExporter(channel: channel)
+        XCTAssertNil(exporter.config.headers)
+    }
+
+    func testConfigHeadersAreSet_whenInitCalledWithCustomConfig() throws {
+        let config: OtlpConfiguration = OtlpConfiguration(timeout: TimeInterval(10), headers: [("FOO", "BAR")])
+        let exporter = OtlpTraceExporter(channel: channel, config: config)
+        XCTAssertNotNil(exporter.config.headers)
+        XCTAssertEqual(exporter.config.headers?[0].0, "FOO")
+        XCTAssertEqual(exporter.config.headers?[0].1, "BAR")
+    }
+
+    func testConfigHeadersAreSet_whenInitCalledWithExplicitHeaders() throws {
+        let exporter = OtlpTraceExporter(channel: channel, envVarHeaders: [("FOO", "BAR")])
+        XCTAssertNil(exporter.config.headers)
+        XCTAssertEqual("BAR", exporter.callOptions?.customMetadata.first(name: "FOO"))
+    }
+
     func testExportMultipleSpans() {
         var spans = [SpanData]()
         for _ in 0 ..< 10 {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -74,6 +74,7 @@ class OtlpTraceExporterTests: XCTestCase {
         XCTAssertNotNil(exporter.config.headers)
         XCTAssertEqual(exporter.config.headers?[0].0, "FOO")
         XCTAssertEqual(exporter.config.headers?[0].1, "BAR")
+        XCTAssertEqual("BAR", exporter.callOptions?.customMetadata.first(name: "FOO"))
     }
 
     func testConfigHeadersAreSet_whenInitCalledWithExplicitHeaders() throws {


### PR DESCRIPTION
The `CallOptions` created in the constructor for `OtlpTraceExporter` includes an optional `logger` parameter. The change in this PR makes it possible for the caller to provide a logger that will be used when GRPC calls are made.