### PR TITLE
Improves testability of EnvVarResource.

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
@@ -24,7 +24,7 @@ public class MeterProviderSdk: MeterProvider {
     public init(metricProcessor: MetricProcessor,
                 metricExporter: MetricExporter,
                 metricPushInterval: TimeInterval = MeterProviderSdk.defaultPushInterval,
-                resource: Resource = EnvVarResource.resource)
+                resource: Resource = EnvVarResource.get())
     {
         meterSharedState = MeterSharedState(metricProcessor: metricProcessor, metricPushInterval: metricPushInterval, metricExporter: metricExporter, resource: resource)
 

--- a/Sources/OpenTelemetrySdk/Resources/EnvVarResource.swift
+++ b/Sources/OpenTelemetrySdk/Resources/EnvVarResource.swift
@@ -17,6 +17,10 @@ public struct EnvVarResource {
     public static let resource = Resource().merging(other: Resource(attributes: parseResourceAttributes(rawEnvAttributes: ProcessInfo.processInfo.environment[otelResourceAttributesEnv])))
     private init() {}
 
+    public static func get(environment: [String: String] = ProcessInfo.processInfo.environment) -> Resource {
+        return Resource().merging(other: Resource(attributes: parseResourceAttributes(rawEnvAttributes: environment[otelResourceAttributesEnv])))
+    }
+
     /// Creates a label map from the OC_RESOURCE_LABELS environment variable.
     /// OC_RESOURCE_LABELS: A comma-separated list of labels describing the source in more detail,
     /// e.g. “key1=val1,key2=val2”. Domain names and paths are accepted as label keys. Values may be

--- a/Sources/OpenTelemetrySdk/Trace/TracerProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TracerProviderSdk.swift
@@ -15,7 +15,7 @@ public class TracerProviderSdk: TracerProvider {
     /// Returns a new TracerProviderSdk with default Clock, IdGenerator and Resource.
     public init(clock: Clock = MillisClock(),
                 idGenerator: IdGenerator = RandomIdGenerator(),
-                resource: Resource = EnvVarResource.resource,
+                resource: Resource = EnvVarResource.get(),
                 spanLimits: SpanLimits = SpanLimits(),
                 sampler: Sampler = Samplers.parentBased(root: Samplers.alwaysOn),
                 spanProcessors: [SpanProcessor] = [])

--- a/Tests/OpenTelemetrySdkTests/Resource/EnvVarResourceTest.swift
+++ b/Tests/OpenTelemetrySdkTests/Resource/EnvVarResourceTest.swift
@@ -11,34 +11,41 @@ class EnvVarResourceTest: XCTestCase {
     func testDefaultSharedInstance() {
         let resource = EnvVarResource.resource
         XCTAssertEqual(resource.attributes.count, 4)
-        XCTAssertTrue(resource.attributes.keys.contains("service.name"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.name"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.language"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.version"))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.serviceName.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkName.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkLanguage.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkVersion.rawValue))
     }
 
     func testGetUniqueInstance() {
         let resource = EnvVarResource.get()
         XCTAssertEqual(resource.attributes.count, 4)
-        XCTAssertTrue(resource.attributes.keys.contains("service.name"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.name"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.language"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.version"))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.serviceName.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkName.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkLanguage.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkVersion.rawValue))
     }
 
     func testGetUniqueInstanceConsideringEnvironment() {
         let environment = [ "OTEL_RESOURCE_ATTRIBUTES": "unique.key=some.value,another.key=another.value"]
         let resource = EnvVarResource.get(environment: environment)
         XCTAssertEqual(resource.attributes.count, 6)
-        XCTAssertTrue(resource.attributes.keys.contains("service.name"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.name"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.language"))
-        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.version"))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.serviceName.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkName.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkLanguage.rawValue))
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.telemetrySdkVersion.rawValue))
 
         XCTAssertTrue(resource.attributes.keys.contains("unique.key"))
         XCTAssertEqual(resource.attributes["unique.key"]!, AttributeValue("some.value"))
 
         XCTAssertTrue(resource.attributes.keys.contains("another.key"))
         XCTAssertEqual(resource.attributes["another.key"]!, AttributeValue("another.value"))
+    }
+
+    func testSpecifyingServiceNameViaEnvironment_changesResourceAttributeValue() {
+        let environment = [ "OTEL_RESOURCE_ATTRIBUTES": "service.name=CustomServiceName"]
+        let resource = EnvVarResource.get(environment: environment)
+        XCTAssertTrue(resource.attributes.keys.contains(ResourceAttributes.serviceName.rawValue))
+        XCTAssertEqual(resource.attributes[ResourceAttributes.serviceName.rawValue], AttributeValue("CustomServiceName"))
     }
 }

--- a/Tests/OpenTelemetrySdkTests/Resource/EnvVarResourceTest.swift
+++ b/Tests/OpenTelemetrySdkTests/Resource/EnvVarResourceTest.swift
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import XCTest
+
+class EnvVarResourceTest: XCTestCase {
+    func testDefaultSharedInstance() {
+        let resource = EnvVarResource.resource
+        XCTAssertEqual(resource.attributes.count, 4)
+        XCTAssertTrue(resource.attributes.keys.contains("service.name"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.name"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.language"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.version"))
+    }
+
+    func testGetUniqueInstance() {
+        let resource = EnvVarResource.get()
+        XCTAssertEqual(resource.attributes.count, 4)
+        XCTAssertTrue(resource.attributes.keys.contains("service.name"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.name"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.language"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.version"))
+    }
+
+    func testGetUniqueInstanceConsideringEnvironment() {
+        let environment = [ "OTEL_RESOURCE_ATTRIBUTES": "unique.key=some.value,another.key=another.value"]
+        let resource = EnvVarResource.get(environment: environment)
+        XCTAssertEqual(resource.attributes.count, 6)
+        XCTAssertTrue(resource.attributes.keys.contains("service.name"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.name"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.language"))
+        XCTAssertTrue(resource.attributes.keys.contains("telemetry.sdk.version"))
+
+        XCTAssertTrue(resource.attributes.keys.contains("unique.key"))
+        XCTAssertEqual(resource.attributes["unique.key"]!, AttributeValue("some.value"))
+
+        XCTAssertTrue(resource.attributes.keys.contains("another.key"))
+        XCTAssertEqual(resource.attributes["another.key"]!, AttributeValue("another.value"))
+    }
+}


### PR DESCRIPTION
This is a small addition to the EnvVarResource to allow testing with a provided environment array. It adds a static `get` method which takes a `[String: String]` array as an input parameter. The parameter has a default value of `ProcessInfo.processInfo.environment`. This makes it possible to write tests that verify that setting the `OTEL_RESOURCE_ATTRIBUTES` environment variable works as expected.  It also makes it possible for client apps that wish to construct their own Resource instance to utilize the `EnvVarResource` class.

The original `EnvVarResource.resource` static property remains, so this is not a breaking change.  

Tests of the new behavior were added too.