### PR TITLE
make SDKResourceExtention data sources init() public

### DIFF
--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/ApplicationDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/ApplicationDataSource.swift
@@ -6,6 +6,8 @@
 import Foundation
 
 public class ApplicationDataSource: IApplicationDataSource {
+    public init() {}
+    
     public var name: String? {
         Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String
     }

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift
@@ -12,6 +12,8 @@ import Foundation
     import UIKit
 #endif
 public class DeviceDataSource: IDeviceDataSource {
+    public init() {}
+
     public var model: String? {
         #if os(watchOS)
             return WKInterfaceDevice.current().localizedModel

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/OperatingSystemDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/OperatingSystemDataSource.swift
@@ -13,6 +13,7 @@ import Foundation
 import OpenTelemetrySdk
 
 public class OperatingSystemDataSource: IOperatingSystemDataSource {
+    public init() {}
     public var description: String {
         name + " " + ProcessInfo.processInfo.operatingSystemVersionString
     }

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
@@ -7,6 +7,7 @@ import Foundation
 import OpenTelemetrySdk
 
 public class TelemetryDataSource: ITelemetryDataSource {
+    public init() {}
     public var language: String {
         ResourceAttributes.TelemetrySdkLanguageValues.swift.description
     }


### PR DESCRIPTION
The init functions of these objects are internal by default, which wasn't intentional.