### PR TITLE
Use String key for tracerProvider dictionary

### DIFF
--- a/Sources/OpenTelemetrySdk/Common/InstrumentationLibraryInfo.swift
+++ b/Sources/OpenTelemetrySdk/Common/InstrumentationLibraryInfo.swift
@@ -23,4 +23,9 @@ public struct InstrumentationScopeInfo: Hashable, Codable {
         self.name = name
         self.version = version
     }
+	
+	public var stringVersion: String {
+		return "\(name):\(version ?? "main")"
+	}
+	
 }


### PR DESCRIPTION
We encountered some crash regarding InstrumentationLibraryInfo that mutated during runtime. 

```
Crashed: 
0  libswiftCore.dylib             0x1125c _assertionFailure(_:_:flags:) + 248
1  libswiftCore.dylib             0x12f8e0 KEY_TYPE_OF_DICTIONARY_VIOLATES_HASHABLE_REQUIREMENTS(_:) + 2604
2  App                      0x1868300 specialized _NativeDictionary.mutatingFind(_:isUnique:) + 3301816
3  App                      0x18624ac TracerProviderSdk.get(instrumentationName:instrumentationVersion:) + 3277668 (<compiler-generated>:3277668)
4  App                      0x186835c protocol witness for TracerProvider.get(instrumentationName:instrumentationVersion:) in conformance TracerProviderSdk + 3301908 (<compiler-generated>:3301908)
```
We tried to make the property inside InstrumentationLibraryInfo as immutable, but the crash still happen. Our latest fix is to change dictionary key in `TracerProviderSdk.tracerProvider` into String type. So far, this crash does not happen anymore in our app with this fix.
