### PR TITLE
Add Callback to Set Parent in URLSessionInstrumention

### DIFF
--- a/Sources/Instrumentation/URLSession/README.md
+++ b/Sources/Instrumentation/URLSession/README.md
@@ -19,6 +19,8 @@ This behaviour can be modified or augmented by using the optional callbacks defi
 
 `nameSpan: ((URLRequest) -> (String)?)?` - Modifies the name for the given request instead of stantard Opentelemetry name
 
+`setParent: ((URLRequest) -> (SpanContext)?)?` - Sets the Span's parent using the provided SpanContext
+
 `createdRequest: ((URLRequest, Span) -> Void)?` - Called after request is created,  it allows to add extra information to the Span
 
 `receivedResponse: ((URLResponse, DataOrFile?, Span) -> Void)?`- Called after response is received,  it allows to add extra information to the Span

--- a/Sources/Instrumentation/URLSession/README.md
+++ b/Sources/Instrumentation/URLSession/README.md
@@ -19,7 +19,7 @@ This behaviour can be modified or augmented by using the optional callbacks defi
 
 `nameSpan: ((URLRequest) -> (String)?)?` - Modifies the name for the given request instead of stantard Opentelemetry name
 
-`setParent: ((URLRequest) -> (SpanContext)?)?` - Sets the Span's parent using the provided SpanContext
+`spanCustomization: ((URLRequest, SpanBuilder) -> Void)?` - Customizes the span while it's being built, such as by adding a parent, a link, attributes, etc.
 
 `createdRequest: ((URLRequest, Span) -> Void)?` - Called after request is created,  it allows to add extra information to the Span
 

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -15,7 +15,7 @@ public struct URLSessionInstrumentationConfiguration {
     public init(shouldRecordPayload: ((URLSession) -> (Bool)?)? = nil,
                 shouldInstrument: ((URLRequest) -> (Bool)?)? = nil,
                 nameSpan: ((URLRequest) -> (String)?)? = nil,
-                setParent: ((URLRequest) -> (SpanContext)?)? = nil,
+                spanCustomization: ((URLRequest, SpanBuilder) -> Void)? = nil,
                 shouldInjectTracingHeaders: ((URLRequest) -> (Bool)?)? = nil,
                 injectCustomHeaders: ((inout URLRequest, Span?) -> Void)? = nil,
                 createdRequest: ((URLRequest, Span) -> Void)? = nil,
@@ -27,7 +27,7 @@ public struct URLSessionInstrumentationConfiguration {
         self.shouldInjectTracingHeaders = shouldInjectTracingHeaders
         self.injectCustomHeaders = injectCustomHeaders
         self.nameSpan = nameSpan
-        self.setParent = setParent
+        self.spanCustomization = spanCustomization
         self.createdRequest = createdRequest
         self.receivedResponse = receivedResponse
         self.receivedError = receivedError
@@ -54,8 +54,8 @@ public struct URLSessionInstrumentationConfiguration {
     /// default name: `HTTP {method}` e.g. `HTTP PUT`
     public var nameSpan: ((URLRequest) -> (String)?)?
 
-    /// Implement this callback to override the default span parent for a given request, return nil to use parentless default
-    public var setParent: ((URLRequest) -> (SpanContext)?)?
+    /// Implement this callback to customize the span, such as by adding a parent, a link, attributes, etc
+    public var spanCustomization: ((URLRequest, SpanBuilder) -> Void)?
 
     ///  Called before the span is created, it allows to add extra information to the Span
     public var createdRequest: ((URLRequest, Span) -> Void)?

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -15,6 +15,7 @@ public struct URLSessionInstrumentationConfiguration {
     public init(shouldRecordPayload: ((URLSession) -> (Bool)?)? = nil,
                 shouldInstrument: ((URLRequest) -> (Bool)?)? = nil,
                 nameSpan: ((URLRequest) -> (String)?)? = nil,
+                setParent: ((URLRequest) -> (SpanContext)?)? = nil,
                 shouldInjectTracingHeaders: ((URLRequest) -> (Bool)?)? = nil,
                 injectCustomHeaders: ((inout URLRequest, Span?) -> Void)? = nil,
                 createdRequest: ((URLRequest, Span) -> Void)? = nil,
@@ -26,6 +27,7 @@ public struct URLSessionInstrumentationConfiguration {
         self.shouldInjectTracingHeaders = shouldInjectTracingHeaders
         self.injectCustomHeaders = injectCustomHeaders
         self.nameSpan = nameSpan
+        self.setParent = setParent
         self.createdRequest = createdRequest
         self.receivedResponse = receivedResponse
         self.receivedError = receivedError
@@ -51,6 +53,9 @@ public struct URLSessionInstrumentationConfiguration {
     /// Implement this callback to override the default span name for a given request, return nil to use default.
     /// default name: `HTTP {method}` e.g. `HTTP PUT`
     public var nameSpan: ((URLRequest) -> (String)?)?
+
+    /// Implement this callback to override the default span parent for a given request, return nil to use parentless default
+    public var setParent: ((URLRequest) -> (SpanContext)?)?
 
     ///  Called before the span is created, it allows to add extra information to the Span
     public var createdRequest: ((URLRequest, Span) -> Void)?

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -68,6 +68,9 @@ class URLSessionLogger {
         }
         let spanBuilder = instrumentation.tracer.spanBuilder(spanName: spanName)
         spanBuilder.setSpanKind(spanKind: .client)
+        if let parentSpanContext = instrumentation.configuration.setParent?(request) {
+            spanBuilder.setParent(parentSpanContext)
+        }
         attributes.forEach {
             spanBuilder.setAttribute(key: $0.key, value: $0.value)
         }

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -68,12 +68,10 @@ class URLSessionLogger {
         }
         let spanBuilder = instrumentation.tracer.spanBuilder(spanName: spanName)
         spanBuilder.setSpanKind(spanKind: .client)
-        if let parentSpanContext = instrumentation.configuration.setParent?(request) {
-            spanBuilder.setParent(parentSpanContext)
-        }
         attributes.forEach {
             spanBuilder.setAttribute(key: $0.key, value: $0.value)
         }
+        instrumentation.configuration.spanCustomization?(request, spanBuilder)
 
         let span = spanBuilder.startSpan()
         runningSpansQueue.sync {


### PR DESCRIPTION
This adds the ability to use a callback in `URLSessionInstrumentationConfiguration` for the purpose of setting a parent for the span produced by `URLSessionInstrumentation`. The `URLSessionInstrumentation` tooling provides excellent out-of-box support, but seems to emit only parentless spans. This addition is useful in the case of a networking call being a child of another (in- or inter-) process.