### PR TITLE
Allow OTEL_RESOURCE_ATTRIBUTES to be read from main Info.plist file

### DIFF
--- a/Sources/OpenTelemetrySdk/Resources/EnvVarResource.swift
+++ b/Sources/OpenTelemetrySdk/Resources/EnvVarResource.swift
@@ -13,12 +13,15 @@ public struct EnvVarResource {
     private static let labelKeyValueSplitter = Character("=")
 
     ///  This resource information is loaded from the OC_RESOURCE_LABELS
-    ///  environment variable.
+    ///  environment variable or from the Info.plist file of the application loading the framework.
     public static let resource = Resource().merging(other: Resource(attributes: parseResourceAttributes(rawEnvAttributes: ProcessInfo.processInfo.environment[otelResourceAttributesEnv])))
     private init() {}
 
     public static func get(environment: [String: String] = ProcessInfo.processInfo.environment) -> Resource {
-        return Resource().merging(other: Resource(attributes: parseResourceAttributes(rawEnvAttributes: environment[otelResourceAttributesEnv])))
+        let attributesToRead = environment[otelResourceAttributesEnv] ??
+            Bundle.main.infoDictionary?[otelResourceAttributesEnv] as? String
+
+        return Resource().merging(other: Resource(attributes: parseResourceAttributes(rawEnvAttributes: attributesToRead)))
     }
 
     /// Creates a label map from the OC_RESOURCE_LABELS environment variable.


### PR DESCRIPTION
It allows reading OTEL_RESOURCE_ATTRIBUTES from Info.plist file of the application loading opentelemetry if the environment variables are not set.

It is extremely useful to configure opentelemetry in mobile apps