### PR TITLE
Fix multiple Xcode warnings

### DIFF
--- a/Examples/OTLP Exporter/main.swift
+++ b/Examples/OTLP Exporter/main.swift
@@ -27,7 +27,7 @@ var instrumentationScopeInfo = InstrumentationScopeInfo(name: instrumentationSco
 var tracer: TracerSdk
 tracer = OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: instrumentationScopeName, instrumentationVersion: instrumentationScopeVersion) as! TracerSdk
 
-let configuration = ClientConnection.Configuration(
+let configuration = ClientConnection.Configuration.default(
     target: .hostAndPort("localhost", 4317),
     eventLoopGroup: MultiThreadedEventLoopGroup(numberOfThreads: 1)
 )

--- a/Sources/Exporters/Prometheus/PrometheusExporter.swift
+++ b/Sources/Exporters/Prometheus/PrometheusExporter.swift
@@ -8,7 +8,7 @@ import NIOConcurrencyHelpers
 import OpenTelemetrySdk
 
 public class PrometheusExporter: MetricExporter {
-    fileprivate let metricsLock = Lock()
+    fileprivate let metricsLock = NIOLock()
     let options: PrometheusExporterOptions
     private var metrics = [Metric]()
 

--- a/Tests/ExportersTests/Prometheus/PrometheusExporterTests.swift
+++ b/Tests/ExportersTests/Prometheus/PrometheusExporterTests.swift
@@ -31,6 +31,7 @@ class PrometheusExporterTests: XCTestCase {
         }
 
         let retain_me = collectMetrics(simpleProcessor: simpleProcessor, exporter: promExporter)
+        _ = retain_me // silence warning
         usleep(useconds_t(waitDuration * 1000000))
         let url = URL(string: "http://localhost:9184/metrics/")!
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
@@ -69,7 +70,7 @@ class PrometheusExporterTests: XCTestCase {
         let testCounter = meter.createIntCounter(name: "testCounter")
         let testMeasure = meter.createIntMeasure(name: "testMeasure")
         let boundaries: Array<Int> = [5, 10, 25]
-        var testHistogram = meter.createIntHistogram(name: "testHistogram", explicitBoundaries: boundaries, absolute: true)
+        let testHistogram = meter.createIntHistogram(name: "testHistogram", explicitBoundaries: boundaries, absolute: true)
         let labels1 = ["dim1": "value1", "dim2": "value1"]
         let labels2 = ["dim1": "value2", "dim2": "value2"]
         let labels3 = ["dim1": "value1"]

--- a/Tests/InstrumentationTests/NetworkStatusTests/NetworkStatusTests.swift
+++ b/Tests/InstrumentationTests/NetworkStatusTests/NetworkStatusTests.swift
@@ -122,6 +122,7 @@
 
             var (type, subtype, info) = wifi_status.status()
             XCTAssertNil(info)
+            XCTAssertNil(subtype)
             XCTAssertEqual("wifi", type)
 
             let cell_status = NetworkStatus(with: MockNetworkMonitor(connection: .cellular), info: MockCTTelephonyNetworkInfo(dataServiceIndentifier: nil, currentRadioAccessTechnology: nil, carrier: nil))


### PR DESCRIPTION
This PR fixes multiple small Xcode warnings/issues currently visible in Xcodes "Issue navigator":

- Use `ClientConnection.Configuration.default` instead of deprecated `init`
- Use `NIOLock` instead of deprecated `Lock`
- Silence warning about `retain_me` being written but never read
- Change `testHistogram` to let, because it was never mutated
- Add assertion for `subtype`