### PR TITLE
change sysctl call in device data source

### DIFF
--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift
@@ -29,13 +29,8 @@ public class DeviceDataSource: IDeviceDataSource {
             // Returned 'error #12: Optional("Cannot allocate memory")' because len was not initialized properly.
 
             let desiredLen = UnsafeMutablePointer<Int>.allocate(capacity: 1)
-            let lenRequestError = sysctl(hwName, 2, nil, desiredLen, nil, 0)
-            if lenRequestError != 0 {
-                // TODO: better error log
-                print("error #\(errno): \(String(describing: String(utf8String: strerror(errno))))")
-
-                return nil
-            }
+            
+            sysctl(hwName, 2, nil, desiredLen, nil, 0)
 
             let machine = UnsafeMutablePointer<CChar>.allocate(capacity: desiredLen[0])
             let len: UnsafeMutablePointer<Int>! = UnsafeMutablePointer<Int>.allocate(capacity: 1)


### PR DESCRIPTION
fixes #310 
It seems like we were error checking on the first sysctl call, which is only getting the buffer size, so there probably shouldn't be an error check.