### PR TITLE
Fix a thread race condition in the adaptEvents method

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -192,7 +192,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
 
     private func adaptEvents() -> [SpanData.Event] {
         var sourceEvents = [SpanData.Event]()
-        attributesSyncLock.withLockVoid {
+        eventsSyncLock.withLockVoid {
             sourceEvents = events.array
         }
         var result = [SpanData.Event]()


### PR DESCRIPTION
Fix a thread race condition in the adaptEvents method of RecordEventsReadable span, it was fixed in the past but using the wrong lock