### PR TITLE
Add user agent on OTLP requests

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocol/common/Constants.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/common/Constants.swift
@@ -1,0 +1,12 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// 
+
+import Foundation
+
+public enum Constants {
+    enum HTTP {
+        static let userAgent = "User-Agent"
+    }
+}

--- a/Sources/Exporters/OpenTelemetryProtocol/common/Headers.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/common/Headers.swift
@@ -1,0 +1,18 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// 
+
+import Foundation
+import OpenTelemetryApi
+
+public struct Headers {
+    // GetUserAgentHeader returns an OTLP header value of the form "OTel OTLP Exporter Swift/{{ .Version }}"
+    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#user-agent
+    public static func getUserAgentHeader() -> String {
+        let version = OpenTelemetry.version
+        let userAgent = "OTel-OTLP-Exporter-Swift/\(version)"
+
+        return userAgent
+    }
+}

--- a/Sources/Exporters/OpenTelemetryProtocol/common/Headers.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/common/Headers.swift
@@ -10,7 +10,10 @@ public struct Headers {
     // GetUserAgentHeader returns an OTLP header value of the form "OTel OTLP Exporter Swift/{{ .Version }}"
     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#user-agent
     public static func getUserAgentHeader() -> String {
-        let version = OpenTelemetry.version
+        var version = OpenTelemetry.version
+        if !version.isEmpty && version.hasPrefix("v") {
+            version = String(version.dropFirst(1))
+        }
         let userAgent = "OTel-OTLP-Exporter-Swift/\(version)"
 
         return userAgent

--- a/Sources/Exporters/OpenTelemetryProtocol/common/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/common/OtlpHttpExporterBase.swift
@@ -25,6 +25,7 @@ public class OtlpHttpExporterBase {
         do {
             request.httpMethod = "POST"
             request.httpBody = try body.serializedData()
+            request.setValue(Headers.getUserAgentHeader(), forHTTPHeaderField: Constants.HTTP.userAgent)
             request.setValue("application/x-protobuf", forHTTPHeaderField: "Content-Type")
         } catch {
             print("Error serializing body: \(error)")

--- a/Sources/Exporters/OpenTelemetryProtocol/logs/OtlpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/logs/OtlpLogExporter.swift
@@ -24,13 +24,20 @@ public class OtlpLogExporter : LogRecordExporter {
         self.channel = channel
         logClient = Opentelemetry_Proto_Collector_Logs_V1_LogsServiceNIOClient(channel: channel)
         self.config = config
+        let userAgentHeader = (Constants.HTTP.userAgent, Headers.getUserAgentHeader())
         if let headers = envVarHeaders {
-            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
+            var updatedHeaders = headers
+            updatedHeaders.append(userAgentHeader)
+            callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
         } else if let headers = config.headers {
-            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
+            var updatedHeaders = headers
+            updatedHeaders.append(userAgentHeader)
+            callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
         }
         else {
-            callOptions = CallOptions(logger: logger)
+            var headers = [(String, String)]()
+            headers.append(userAgentHeader)
+            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
         }
     }
 

--- a/Sources/Exporters/OpenTelemetryProtocol/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/metric/OtlpMetricExporter.swift
@@ -23,13 +23,20 @@ public class OtlpMetricExporter: MetricExporter {
         self.channel = channel
         self.config = config
         self.metricClient = Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceNIOClient(channel: self.channel)
+        let userAgentHeader = (Constants.HTTP.userAgent, Headers.getUserAgentHeader())
         if let headers = envVarHeaders {
-            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
+            var updatedHeaders = headers
+            updatedHeaders.append(userAgentHeader)
+            callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
         } else if let headers = config.headers {
-            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
+            var updatedHeaders = headers
+            updatedHeaders.append(userAgentHeader)
+            callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
         }
         else {
-            callOptions = CallOptions(logger: logger)
+            var headers = [(String, String)]()
+            headers.append(userAgentHeader)
+            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
         }
     }
     

--- a/Sources/Exporters/OpenTelemetryProtocol/trace/OtlpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocol/trace/OtlpTraceExporter.swift
@@ -21,13 +21,19 @@ public class OtlpTraceExporter: SpanExporter {
         self.channel = channel
         traceClient = Opentelemetry_Proto_Collector_Trace_V1_TraceServiceNIOClient(channel: channel)
         self.config = config
+        let userAgentHeader = (Constants.HTTP.userAgent, Headers.getUserAgentHeader())
         if let headers = envVarHeaders {
-            callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
+            var updatedHeaders = headers
+            updatedHeaders.append(userAgentHeader)
+            callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
         } else if let headers = config.headers {
+            var updatedHeaders = headers
+            updatedHeaders.append(userAgentHeader)
+            callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
+        } else {
+            var headers = [(String, String)]()
+            headers.append(userAgentHeader)
             callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
-        }
-        else {
-            callOptions = CallOptions(logger: logger)
         }
     }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricsExporterTest.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricsExporterTest.swift
@@ -55,7 +55,11 @@ class OtlpHttpMetricsExporterTest: XCTestCase {
         }
         XCTAssertEqual(result, MetricExporterResultCode.success)
         
-        XCTAssertNoThrow(try testServer.receiveHead())
+        XCTAssertNoThrow(try testServer.receiveHeadAndVerify { head in
+            let otelVersion = Headers.getUserAgentHeader()
+            XCTAssertTrue(head.headers.contains(name: Constants.HTTP.userAgent))
+            XCTAssertEqual(otelVersion, head.headers.first(name: Constants.HTTP.userAgent))
+        })
         XCTAssertNoThrow(try testServer.receiveBodyAndVerify() { body in
             var contentsBuffer = ByteBuffer(buffer: body)
             let contents = contentsBuffer.readString(length: contentsBuffer.readableBytes)!

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpTraceExporterTests.swift
@@ -25,6 +25,7 @@ class OtlpHttpTraceExporterTests: XCTestCase {
     override func tearDown() {
         XCTAssertNoThrow(try testServer.stop())
         XCTAssertNoThrow(try group.syncShutdownGracefully())
+
     }
     
     // This is a somewhat hacky solution to verifying that the spans got across correctly.  It simply looks for the metric
@@ -41,7 +42,11 @@ class OtlpHttpTraceExporterTests: XCTestCase {
         spans.append(generateFakeSpan(endpointName: endpointName2))
         let _ = exporter.export(spans: spans)
 
-        XCTAssertNoThrow(try testServer.receiveHead())
+        XCTAssertNoThrow(try testServer.receiveHeadAndVerify { head in
+            let otelVersion = Headers.getUserAgentHeader()
+            XCTAssertTrue(head.headers.contains(name: Constants.HTTP.userAgent))
+            XCTAssertEqual(otelVersion, head.headers.first(name: Constants.HTTP.userAgent))
+        })
         XCTAssertNoThrow(try testServer.receiveBodyAndVerify() { body in
             var contentsBuffer = ByteBuffer(buffer: body)
             let contents = contentsBuffer.readString(length: contentsBuffer.readableBytes)!

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -63,9 +63,22 @@ class OtlpTraceExporterTests: XCTestCase {
         XCTAssertEqual(logger.label, "my.grpc.logger")
     }
 
+    func verifyUserAgentIsSet(exporter: OtlpTraceExporter) {
+        if let callOptions = exporter.callOptions {
+            let customMetadata = callOptions.customMetadata
+            let userAgent = Headers.getUserAgentHeader()
+            if customMetadata.contains(name: Constants.HTTP.userAgent) && customMetadata.first(name: Constants.HTTP.userAgent) == userAgent {
+                return
+            }
+        }
+        XCTFail("User-Agent header was not set correctly")
+    }
+
     func testConfigHeadersIsNil_whenDefaultInitCalled() throws {
         let exporter = OtlpTraceExporter(channel: channel)
         XCTAssertNil(exporter.config.headers)
+
+        verifyUserAgentIsSet(exporter: exporter)
     }
 
     func testConfigHeadersAreSet_whenInitCalledWithCustomConfig() throws {
@@ -75,12 +88,16 @@ class OtlpTraceExporterTests: XCTestCase {
         XCTAssertEqual(exporter.config.headers?[0].0, "FOO")
         XCTAssertEqual(exporter.config.headers?[0].1, "BAR")
         XCTAssertEqual("BAR", exporter.callOptions?.customMetadata.first(name: "FOO"))
+
+        verifyUserAgentIsSet(exporter: exporter)
     }
 
     func testConfigHeadersAreSet_whenInitCalledWithExplicitHeaders() throws {
         let exporter = OtlpTraceExporter(channel: channel, envVarHeaders: [("FOO", "BAR")])
         XCTAssertNil(exporter.config.headers)
         XCTAssertEqual("BAR", exporter.callOptions?.customMetadata.first(name: "FOO"))
+
+        verifyUserAgentIsSet(exporter: exporter)
     }
 
     func testExportMultipleSpans() {


### PR DESCRIPTION
This fixes #331 We now set a user agent conforming to the [OTEL spec](https://github.com/kevinearls/opentelemetry-swift/pull/new/add-user-agent) on HTTP and GRPC requests