### PR TITLE
Fix URLSession instrumentation in iOS 16

### DIFF
--- a/Sources/Exporters/DatadogExporter/Utils/Device.swift
+++ b/Sources/Exporters/DatadogExporter/Utils/Device.swift
@@ -6,7 +6,7 @@
 #if os(macOS)
 import Foundation
 import SystemConfiguration
-#elseif os(iOS) || targetEnvironment(macCatalyst)
+#elseif os(iOS) || targetEnvironment(macCatalyst) || os(tvOS)
 import UIKit
 #elseif os(watchOS)
 import WatchKit
@@ -23,7 +23,8 @@ internal class Device {
     init(
         model: String,
         osName: String,
-        osVersion: String) {
+        osVersion: String)
+    {
         self.model = model
         self.osName = osName
         self.osVersion = osVersion
@@ -36,6 +37,7 @@ internal class Device {
             osName: uiDevice.systemName,
             osVersion: uiDevice.systemVersion)
     }
+
     #elseif os(macOS)
     convenience init(processInfo: ProcessInfo) {
         self.init(
@@ -64,8 +66,7 @@ internal class Device {
         return Device(
             model: device.model,
             osName: device.systemName,
-            osVersion: device.systemVersion
-        )
+            osVersion: device.systemVersion)
         #endif
     }
 }

--- a/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
+++ b/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
@@ -4,8 +4,10 @@
  */
 
 import Foundation
-#if !os(macOS)
+#if os(iOS) || os(tvOS)
 import UIKit
+#elseif os(watchOS)
+import WatchKit
 #endif
 
 enum InstrumentationUtils {
@@ -52,10 +54,17 @@ enum InstrumentationUtils {
         }
     }
 
-    static func usesUndocumentedAsyncAwaitMethods() -> Bool {
+    static var usesUndocumentedAsyncAwaitMethods: Bool = {
 #if os(macOS)
         let os = ProcessInfo.processInfo.operatingSystemVersion
         if os.majorVersion >= 13 {
+            return true
+        }
+#elseif os(watchOS)
+        let version = WKInterfaceDevice.current().systemVersion
+        if let versionNumber = Double(version),
+           versionNumber >= 9.0
+        {
             return true
         }
 #else
@@ -67,5 +76,5 @@ enum InstrumentationUtils {
         }
 #endif
         return false
-    }
+    }()
 }

--- a/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
+++ b/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
@@ -4,6 +4,9 @@
  */
 
 import Foundation
+#if !os(macOS)
+import UIKit
+#endif
 
 enum InstrumentationUtils {
     static func objc_getClassList() -> [AnyClass] {
@@ -47,5 +50,22 @@ enum InstrumentationUtils {
             f(i, ptr.pointee)
             ptr = ptr.successor()
         }
+    }
+
+    static func usesUndocumentedAsyncAwaitMethods() -> Bool {
+#if os(macOS)
+        let os = ProcessInfo.processInfo.operatingSystemVersion
+        if os.majorVersion >= 13 {
+            return true
+        }
+#else
+        let version = UIDevice.current.systemVersion
+        if let versionNumber = Double(version),
+           versionNumber >= 16.0
+        {
+            return true
+        }
+#endif
+        return false
     }
 }

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -105,7 +105,7 @@ public class URLSessionInstrumentation {
         injectTaskDidCompleteWithErrorIntoDelegateClass(cls: cls)
         injectRespondsToSelectorIntoDelegateClass(cls: cls)
         // For future use
-        if InstrumentationUtils.usesUndocumentedAsyncAwaitMethods() {
+        if InstrumentationUtils.usesUndocumentedAsyncAwaitMethods {
             injectTaskDidFinishCollectingMetricsIntoDelegateClass(cls: cls)
         }
 
@@ -577,12 +577,12 @@ public class URLSessionInstrumentation {
                 requestMap[taskId]?.setRequest(request)
             }
 
-            if InstrumentationUtils.usesUndocumentedAsyncAwaitMethods() {
+            if InstrumentationUtils.usesUndocumentedAsyncAwaitMethods {
                 let instrumentedRequest = URLSessionLogger.processAndLogRequest(request, sessionTaskId: taskId, instrumentation: self, shouldInjectHeaders: true)
                 task.setValue(instrumentedRequest, forKey: "currentRequest")
                 self.setIdKey(value: taskId, for: task)
 
-                if #available(iOS 16.0, *) {
+                if #available(OSX 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
                     let basePriority = Task.basePriority
                     //If not inside a Task basePriority is nil
                     if basePriority != nil && task.delegate == nil {
@@ -618,6 +618,5 @@ public class URLSessionInstrumentation {
 
 class FakeDelegate: NSObject, URLSessionTaskDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        let a = 0
     }
 }

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -578,14 +578,16 @@ public class URLSessionInstrumentation {
             }
 
             if InstrumentationUtils.usesUndocumentedAsyncAwaitMethods {
-                let instrumentedRequest = URLSessionLogger.processAndLogRequest(request, sessionTaskId: taskId, instrumentation: self, shouldInjectHeaders: true)
-                task.setValue(instrumentedRequest, forKey: "currentRequest")
-                self.setIdKey(value: taskId, for: task)
-
                 if #available(OSX 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
-                    let basePriority = Task.basePriority
-                    //If not inside a Task basePriority is nil
-                    if basePriority != nil && task.delegate == nil {
+                    guard Task.basePriority != nil else {
+                        return
+                    }
+                    let instrumentedRequest = URLSessionLogger.processAndLogRequest(request, sessionTaskId: taskId, instrumentation: self, shouldInjectHeaders: true)
+                    task.setValue(instrumentedRequest, forKey: "currentRequest")
+                    self.setIdKey(value: taskId, for: task)
+
+                    // If not inside a Task basePriority is nil
+                    if task.delegate == nil {
                         task.delegate = FakeDelegate()
                     }
                 }
@@ -617,6 +619,5 @@ public class URLSessionInstrumentation {
 }
 
 class FakeDelegate: NSObject, URLSessionTaskDelegate {
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-    }
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {}
 }

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -466,7 +466,7 @@ class URLSessionInstrumentationTests: XCTestCase {
             XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
         }
 
-        @available(macOS 12, iOS 15.0, tvOS 15.0, *)
+    @available(macOS 12, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
         public func testDownloadTaskWithUrlBlockAsync() async throws {
             let url = URL(string: "http://localhost:33333/success")!
 
@@ -476,7 +476,7 @@ class URLSessionInstrumentationTests: XCTestCase {
             XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
         }
 
-        @available(macOS 12, iOS 15.0, tvOS 15.0, *)
+        @available(macOS 12, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
         public func testDownloadTaskWithRequestBlockAsync() async throws {
             let url = URL(string: "http://localhost:33333/success")!
             let request = URLRequest(url: url)
@@ -520,7 +520,7 @@ class URLSessionInstrumentationTests: XCTestCase {
             XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
         }
 
-        @available(macOS 12, iOS 15.0, tvOS 15.0, *)
+        @available(macOS 12, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
         public func testDownloadTaskWithUrlDelegateAsync() async throws {
             let url = URL(string: "http://localhost:33333/success")!
 
@@ -530,7 +530,7 @@ class URLSessionInstrumentationTests: XCTestCase {
             XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
         }
 
-        @available(macOS 12, iOS 15.0, tvOS 15.0, *)
+        @available(macOS 12, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
         public func testDownloadTaskWithRequestDelegateAsync() async throws {
             let url = URL(string: "http://localhost:33333/success")!
             let request = URLRequest(url: url)


### PR DESCRIPTION
iOS 16 broke async/await URLSession instrumentation, add extra code to make it work:

Only  NSURLSessionTask.resume and URLSessionTaskDelegate.urlSession(_:task:didFinishCollecting:) are being called (contrary to what documentation says), try to move all the logic to these two methods

 Also for async/await calls without delegate set a task delegate so that the delegate method is called and we can capture it

Added many tests exercising async await network calls