### PR TITLE
fix: avoid ending spans multiple times

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -290,14 +290,19 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
 
     public func end(time: Date) {
-        internalStatusQueue.sync(flags: .barrier) {
+        let alreadyEnded = internalStatusQueue.sync(flags: .barrier) {
             if internalEnd {
-                return
-
-            } else {
-                internalEnd = true
+                return true
             }
+
+            internalEnd = true
+            return false
         }
+
+        if alreadyEnded {
+            return
+        }
+
         eventsSyncLock.withLockVoid {
             attributesSyncLock.withLockVoid {
                 isRecording = false


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-swift/pull/379 changed the existing code such that ending a span multiple times sends it to the processor/exporter multiple times. With the previous logic this did not happen.

Added a quick bailout when ending a span and it has already ended.