### PR TITLE
Reenable disabled tests

### DIFF
--- a/Tests/ExportersTests/DatadogExporter/DatadogExporterTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/DatadogExporterTests.swift
@@ -18,9 +18,9 @@ class DatadogExporterTests: XCTestCase {
     }
 
     func testWhenExportSpanIsCalled_thenTraceAndLogsAreUploaded() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Test is flaky on watchOS")
-        }
+#if os(watchOS)
+        throw XCTSkip("Test is flaky on watchOS")
+#endif
 
         var logsSent = false
         var tracesSent = false
@@ -99,9 +99,9 @@ class DatadogExporterTests: XCTestCase {
     }
 
     func testWhenExportMetricIsCalled_thenMetricsAreUploaded() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Test is flaky on watchOS")
-        }
+#if os(watchOS)
+        throw XCTSkip("Test is flaky on watchOS")
+#endif
 
         var metricsSent = false
         let expecMetrics = expectation(description: "metrics received")

--- a/Tests/ExportersTests/DatadogExporter/Logs/LogsExporterTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Logs/LogsExporterTests.swift
@@ -18,10 +18,9 @@ class LogsExporterTests: XCTestCase {
     }
 
     func testWhenExportSpanIsCalledAndSpanHasEvent_thenLogIsUploaded() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Test is flaky on watchOS")
-        }
-
+#if os(watchOS)
+        throw XCTSkip("Test is flaky on watchOS")
+#endif
         var logsSent = false
         let expec = expectation(description: "logs received")
         let server = HttpTestServer(url: URL(string: "http://localhost:33333"),
@@ -29,7 +28,7 @@ class LogsExporterTests: XCTestCase {
                                                                  logsReceivedCallback: {
                                                                      logsSent = true
                                                                      expec.fulfill()
-        }))
+                                                                 }))
 
         let sem = DispatchSemaphore(value: 0)
         DispatchQueue.global(qos: .default).async {
@@ -81,7 +80,7 @@ class LogsExporterTests: XCTestCase {
                         name: "spanName",
                         kind: .server,
                         startTime: Date(timeIntervalSinceReferenceDate: 3000),
-                        events: [SpanData.Event(name: "event", timestamp: Date(), attributes:["attributeKey": AttributeValue.string("attributeValue")])],
+                        events: [SpanData.Event(name: "event", timestamp: Date(), attributes: ["attributeKey": AttributeValue.string("attributeValue")])],
                         endTime: Date(timeIntervalSinceReferenceDate: 3001),
                         hasRemoteParent: false)
     }

--- a/Tests/ExportersTests/DatadogExporter/Spans/SpansExporterTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Spans/SpansExporterTests.swift
@@ -18,17 +18,17 @@ class SpansExporterTests: XCTestCase {
     }
 
     func testWhenExportSpanIsCalled_thenTraceIsUploaded() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Test is flaky on watchOS")
-        }
+#if os(watchOS)
+        throw XCTSkip("Test is flaky on watchOS")
+#endif
 
         var tracesSent = false
         let expec = expectation(description: "traces received")
         let server = HttpTestServer(url: URL(string: "http://localhost:33333"),
                                     config: HttpTestServerConfig(tracesReceivedCallback: {
-                                        tracesSent = true
-                                        expec.fulfill()
-                                    },
+                                                                     tracesSent = true
+                                                                     expec.fulfill()
+                                                                 },
                                                                  logsReceivedCallback: nil))
         let sem = DispatchSemaphore(value: 0)
         DispatchQueue.global(qos: .default).async {

--- a/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
@@ -37,9 +37,9 @@ class DataUploadWorkerTests: XCTestCase {
     // MARK: - Data Uploads
 
     func testItUploadsAllData() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-        }
+#if os(watchOS)
+        throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+#endif
 
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
@@ -159,9 +159,9 @@ class DataUploadWorkerTests: XCTestCase {
     }
 
     func testWhenBatchFails_thenIntervalIncreases() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-        }
+#if os(watchOS)
+        throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+#endif
 
         let delayChangeExpectation = expectation(description: "Upload delay is increased")
         let mockDelay = MockDelay { command in
@@ -195,9 +195,9 @@ class DataUploadWorkerTests: XCTestCase {
     }
 
     func testWhenBatchSucceeds_thenIntervalDecreases() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-        }
+#if os(watchOS)
+        throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+#endif
 
         let delayChangeExpectation = expectation(description: "Upload delay is decreased")
         let mockDelay = MockDelay { command in
@@ -257,9 +257,9 @@ class DataUploadWorkerTests: XCTestCase {
     }
 
     func testItFlushesAllData() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-        }
+#if os(watchOS)
+        throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+#endif
 
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(

--- a/Tests/ExportersTests/DatadogExporter/Upload/DataUploaderTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/DataUploaderTests.swift
@@ -10,10 +10,9 @@ extension DataUploadStatus: EquatableInTests {}
 
 class DataUploaderTests: XCTestCase {
     func testWhenUploadCompletesWithSuccess_itReturnsExpectedUploadStatus() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-        }
-
+#if os(watchOS)
+        throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+#endif
         // Given
         let randomResponse: HTTPURLResponse = .mockResponseWith(statusCode: (100 ... 599).randomElement()!)
         let randomRequestIDOrNil: String? = Bool.random() ? .mockRandom() : nil
@@ -38,9 +37,9 @@ class DataUploaderTests: XCTestCase {
     }
 
     func testWhenUploadCompletesWithFailure_itReturnsExpectedUploadStatus() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-        }
+#if os(watchOS)
+        throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+#endif
 
         // Given
         let randomErrorDescription: String = .mockRandom()

--- a/Tests/ExportersTests/DatadogExporter/Upload/HTTPClientTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/HTTPClientTests.swift
@@ -27,9 +27,9 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testWhenRequestIsNotDelivered_itReturnsHTTPRequestDeliveryError() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-        }
+#if os(watchOS)
+        throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+#endif
 
         let mockError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "no internet connection"])
         let server = ServerMock(delivery: .failure(error: mockError))

--- a/Tests/InstrumentationTests/URLSessionTests/Utils/HttpTestServer.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/Utils/HttpTestServer.swift
@@ -97,6 +97,7 @@ internal class HttpTestServer {
                         _ = channel.writeAndFlush(endpart).flatMap {
                             channel.close()
                         }
+                        break
                     } else if request.uri.unicodeScalars.starts(with: "/forbidden".unicodeScalars) {
                         let channel = context.channel
 
@@ -111,14 +112,17 @@ internal class HttpTestServer {
                         _ = channel.writeAndFlush(endpart).flatMap {
                             channel.close()
                         }
+                        break
                     } else if request.uri.unicodeScalars.starts(with: "/error".unicodeScalars) {
                         let channel = context.channel
                         config?.errorCallback?()
                         _ = channel.close()
+                        break
                     }
                 case .body:
                     break
-                case .end: break
+                case .end:
+                    break
             }
         }
 

--- a/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
@@ -226,7 +226,7 @@ class ActivityContextManagerTests: XCTestCase {
         }
         span1.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
-        await fulfillment(of: [expec], timeout: 30)
+        await waitForExpectations(timeout: 30)
     }
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
@@ -258,7 +258,7 @@ class ActivityContextManagerTests: XCTestCase {
             XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === span1)
             expec.fulfill()
         }
-        await fulfillment(of: [expec], timeout: 30)
+        await waitForExpectations(timeout: 30)
         span1.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
@@ -316,8 +316,7 @@ class ActivityContextManagerTests: XCTestCase {
         }
 
         XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === parent)
-        await fulfillment(of: [expectation1, expectation2], timeout: 30, enforceOrder: false)
-
+        await waitForExpectations(timeout: 5, handler: nil)
         parent.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }

--- a/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
@@ -226,7 +226,7 @@ class ActivityContextManagerTests: XCTestCase {
         }
         span1.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
-        await waitForExpectations(timeout: 30)
+        await fulfillment(of: [expec], timeout: 30)
     }
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
@@ -258,7 +258,7 @@ class ActivityContextManagerTests: XCTestCase {
             XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === span1)
             expec.fulfill()
         }
-        await waitForExpectations(timeout: 30)
+        await fulfillment(of: [expec], timeout: 30)
         span1.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
@@ -316,7 +316,8 @@ class ActivityContextManagerTests: XCTestCase {
         }
 
         XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === parent)
-        await waitForExpectations(timeout: 5, handler: nil)
+        await fulfillment(of: [expectation1, expectation2], timeout: 30, enforceOrder: false)
+
         parent.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }

--- a/Tests/OpenTelemetrySdkTests/Metrics/CounterTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/CounterTests.swift
@@ -24,18 +24,18 @@ final class CounterTests: XCTestCase {
         // We have ls1, ls2, ls3
         // ls1 and ls3 are not bound so they should removed when no usage for a Collect cycle.
         // ls2 is bound by user.
-        testCounter.add(  value: 100, labelset: ls1)
-        testCounter.add(  value: 10, labelset: ls1)
+        testCounter.add(value: 100, labelset: ls1)
+        testCounter.add(value: 10, labelset: ls1)
         // initial status for temp bound instruments are UpdatePending.
         XCTAssertEqual(RecordStatus.updatePending, testCounter.boundInstruments[ls1]?.status)
 
         let boundCounterLabel2 = testCounter.bind(labelset: ls2)
-        boundCounterLabel2.add(  value: 200)
+        boundCounterLabel2.add(value: 200)
         // initial/forever status for user bound instruments are Bound.
         XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
 
-        testCounter.add(  value: 200, labelset: ls3)
-        testCounter.add(  value: 10, labelset: ls3)
+        testCounter.add(value: 200, labelset: ls3)
+        testCounter.add(value: 10, labelset: ls3)
         // initial status for temp bound instruments are UpdatePending.
         XCTAssertEqual(RecordStatus.updatePending, testCounter.boundInstruments[ls3]?.status)
 
@@ -48,7 +48,7 @@ final class CounterTests: XCTestCase {
         XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
 
         // Use ls1 again, so that it'll be promoted to UpdatePending
-        testCounter.add(  value: 100, labelset: ls1)
+        testCounter.add(value: 100, labelset: ls1)
 
         // This collect should mark ls1 as noPendingUpdate, leave ls2 untouched.
         // And ls3 as candidateForRemoval, as it was not used since last Collect
@@ -84,18 +84,18 @@ final class CounterTests: XCTestCase {
         // We have ls1, ls2, ls3
         // ls1 and ls3 are not bound so they should removed when no usage for a Collect cycle.
         // ls2 is bound by user.
-        testCounter.add(  value: 100.0, labelset: ls1)
-        testCounter.add(  value: 10.0, labelset: ls1)
+        testCounter.add(value: 100.0, labelset: ls1)
+        testCounter.add(value: 10.0, labelset: ls1)
         // initial status for temp bound instruments are UpdatePending.
         XCTAssertEqual(RecordStatus.updatePending, testCounter.boundInstruments[ls1]?.status)
 
         let boundCounterLabel2 = testCounter.bind(labelset: ls2)
-        boundCounterLabel2.add(  value: 200.0)
+        boundCounterLabel2.add(value: 200.0)
         // initial/forever status for user bound instruments are Bound.
         XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
 
-        testCounter.add(  value: 200.0, labelset: ls3)
-        testCounter.add(  value: 10.0, labelset: ls3)
+        testCounter.add(value: 200.0, labelset: ls3)
+        testCounter.add(value: 10.0, labelset: ls3)
         // initial status for temp bound instruments are UpdatePending.
         XCTAssertEqual(RecordStatus.updatePending, testCounter.boundInstruments[ls3]?.status)
 
@@ -108,7 +108,7 @@ final class CounterTests: XCTestCase {
         XCTAssertEqual(RecordStatus.bound, testCounter.boundInstruments[ls2]?.status)
 
         // Use ls1 again, so that it'll be promoted to UpdatePending
-        testCounter.add(  value: 100.0, labelset: ls1)
+        testCounter.add(value: 100.0, labelset: ls1)
 
         // This collect should mark ls1 as noPendingUpdate, leave ls2 untouched.
         // And ls3 as candidateForRemoval, as it was not used since last Collect
@@ -130,9 +130,9 @@ final class CounterTests: XCTestCase {
     }
 
     public func testIntCounterBoundInstrumentsStatusUpdatedCorrectlyMultiThread() throws {
-        if #available(watchOS 3.0, *) {
-            throw XCTSkip("Test is flaky on watchOS")
-        }
+#if os(watchOS)
+        throw XCTSkip("Test is flaky on watchOS")
+#endif
 
         let testProcessor = TestMetricProcessor()
         let meter = MeterProviderSdk(metricProcessor: testProcessor, metricExporter: NoopMetricExporter()).get(instrumentationName: "scope1") as! MeterSdk
@@ -142,8 +142,8 @@ final class CounterTests: XCTestCase {
         let ls1 = meter.getLabelSet(labels: labels1)
 
         // Call metric update with ls1 so that ls1 wont be brand new labelset when doing multi-thread test.
-        testCounter.add(  value: 100, labelset: ls1)
-        testCounter.add(  value: 10, labelset: ls1)
+        testCounter.add(value: 100, labelset: ls1)
+        testCounter.add(value: 10, labelset: ls1)
 
         // This collect should mark ls1 NoPendingUpdate
         meter.collect()
@@ -163,7 +163,7 @@ final class CounterTests: XCTestCase {
         }
         DispatchQueue.global().async(group: mygroup) {
             for _ in 0 ..< 5 {
-                testCounter.add(  value: 100, labelset: ls1)
+                testCounter.add(value: 100, labelset: ls1)
             }
         }
         mygroup.wait()


### PR DESCRIPTION
When adding support for watchOS some tests were wrongly skipped for all platforms, skip them properly now only for watchOS and make them run for other platforms