### PR TITLE
fix: explicitly mark the closure's return type

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -290,7 +290,7 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
 
     public func end(time: Date) {
-        let alreadyEnded = internalStatusQueue.sync(flags: .barrier) {
+        let alreadyEnded = internalStatusQueue.sync(flags: .barrier) { () -> Bool in
             if internalEnd {
                 return true
             }


### PR DESCRIPTION
Complement to https://github.com/open-telemetry/opentelemetry-swift/pull/400

Swift 5.5.2 thought the closure is too complicated: `error: unable to infer complex closure return type`