### PR TITLE
Add option to set the timestamp in LogRecordBuilder

### DIFF
--- a/Sources/OpenTelemetryApi/Logs/DefaultLogger.swift
+++ b/Sources/OpenTelemetryApi/Logs/DefaultLogger.swift
@@ -37,6 +37,9 @@ public class DefaultLogger : Logger {
     }
 
     private class NoopLogRecordBuilder : EventBuilder {
+        func setTimestamp(_ timestamp: Date) -> Self {
+            return self
+        }
 
         func setObservedTimestamp(_ observed: Date) -> Self {
             return self

--- a/Sources/OpenTelemetryApi/Logs/LogRecordBuilder.swift
+++ b/Sources/OpenTelemetryApi/Logs/LogRecordBuilder.swift
@@ -6,6 +6,11 @@
 import Foundation
 
 public protocol LogRecordBuilder {
+    /// set the timestamp on which the event ocurred
+    ///
+    /// - Parameter timestamp: the Date object
+    /// - Returns: self
+    func setTimestamp(_ timestamp: Date) -> Self
 
     /// set the timestamp that the log was observed
     ///

--- a/Sources/OpenTelemetrySdk/Logs/LogRecordBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Logs/LogRecordBuilderSdk.swift
@@ -15,7 +15,7 @@ public class LogRecordBuilderSdk : EventBuilder {
     private var limits : LogLimits
     private var instrumentationScope : InstrumentationScopeInfo
     private var includeSpanContext : Bool
-    
+    private var timestamp: Date?
     private var observedTimestamp : Date?
     private var body : String?
     private var severity: Severity?
@@ -31,7 +31,12 @@ public class LogRecordBuilderSdk : EventBuilder {
         self.instrumentationScope = instrumentationScope
         attributes = AttributesDictionary(capacity: sharedState.logLimits.maxAttributeCount, valueLengthLimit: sharedState.logLimits.maxAttributeLength)
     }
-    
+
+    public func setTimestamp(_ timestamp: Date) -> Self {
+        self.timestamp = timestamp
+        return self
+    }
+
     public func setObservedTimestamp(_ observed: Date) -> Self {
         self.observedTimestamp = observed
         return self
@@ -68,7 +73,7 @@ public class LogRecordBuilderSdk : EventBuilder {
         
         sharedState.activeLogRecordProcessor.onEmit(logRecord: ReadableLogRecord(resource: sharedState.resource,
                                                                                  instrumentationScopeInfo: instrumentationScope,
-                                                                                 timestamp: sharedState.clock.now,
+                                                                                 timestamp: timestamp ?? sharedState.clock.now,
                                                                                  observedTimestamp: observedTimestamp,
                                                                                  spanContext: spanContext,
                                                                                  severity: severity,

--- a/Tests/OpenTelemetryApiTests/Logs/DefaultLoggerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Logs/DefaultLoggerTests.swift
@@ -25,6 +25,7 @@ class DefaultLoggerTests : XCTestCase {
         XCTAssertNoThrow(defaultLogger.logRecordBuilder()
             .setSpanContext(spanContext)
             .setAttributes([:])
+            .setTimestamp(Date())
             .setObservedTimestamp(Date())
             .setSeverity(.debug)
             .setBody("hello, world")

--- a/Tests/OpenTelemetrySdkTests/Logs/LogRecordBuilderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Logs/LogRecordBuilderSdkTests.swift
@@ -1,0 +1,48 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// 
+
+import XCTest
+@testable import OpenTelemetrySdk
+
+final class LogRecordBuilderSdkTests: XCTestCase {
+    private let mockProcessor = LogRecordProcessorMock()
+    private let testClock = TestClock()
+    private var sharedState: LoggerSharedState!
+
+    override func setUp() {
+        sharedState = LoggerSharedState(resource: .empty, logLimits: .init(), processors: [mockProcessor], clock: testClock)
+    }
+
+    func testGivenNeitherTimestampNorObservedSet_whenEmit_thenTimestampFromClockAndObservedIsNil() {
+        // When
+        LogRecordBuilderSdk(sharedState: sharedState, instrumentationScope: .init(), includeSpanContext: false)
+            .emit()
+
+        // Then
+        XCTAssertEqual(mockProcessor.onEmitCalledTimes, 1)
+        let logRecord = mockProcessor.onEmitCalledLogRecord
+        XCTAssertEqual(logRecord?.timestamp, testClock.now)
+        XCTAssertNil(logRecord?.observedTimestamp)
+    }
+
+    func testGivenTimestampAndObservedSet_whenEmit_thenRecordHasTimestampAndObserved() {
+        let timestamp = TestUtils.dateFromNanos(1234000001234)
+        let observedTimestamp = TestUtils.dateFromNanos(1234000005678)
+
+        // Given
+        let logRecordBuilder = LogRecordBuilderSdk(sharedState: sharedState, instrumentationScope: .init(), includeSpanContext: false)
+            .setTimestamp(timestamp)
+            .setObservedTimestamp(observedTimestamp)
+
+        // When
+        logRecordBuilder.emit()
+
+        // Then
+        XCTAssertEqual(mockProcessor.onEmitCalledTimes, 1)
+        let logRecord = mockProcessor.onEmitCalledLogRecord
+        XCTAssertEqual(logRecord?.timestamp, timestamp)
+        XCTAssertEqual(logRecord?.observedTimestamp, observedTimestamp)
+    }
+}


### PR DESCRIPTION
This PR adds the option to set the `Timestamp` for log events when using the `LogRecordBuilder`. I looked at other libraries, like the one for [Java](https://github.com/open-telemetry/opentelemetry-java/blob/47ee573f07c9025547d494608863d9314b29df4b/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java#L30) before I started working on this PR and they allow setting both the timestamp and observed timestamp. To not change any existing functionality I went with `timestamp ?? sharedState.clock.now` in the `emit()` function, which should allow anyone who does not care about setting the timestamp manually to ignore this change.

For the tests I only explicitly covered the cases when both timestamp and observed timestamp are either set or not set. Please let me know if you prefer testing this in a different way or have any feedback for improvement.