### PR TITLE
Fix flaky tests for DatadogExporter

### DIFF
--- a/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
@@ -91,7 +91,7 @@ class DataUploadWorkerTests: XCTestCase {
             featureName: .mockAny()
         )
 
-        wait(for: [startUploadExpectation], timeout: 0.5)
+        wait(for: [startUploadExpectation], timeout: 1)
         worker.cancelSynchronously()
 
         // Then
@@ -117,7 +117,7 @@ class DataUploadWorkerTests: XCTestCase {
             featureName: .mockAny()
         )
 
-        wait(for: [startUploadExpectation], timeout: 0.5)
+        wait(for: [startUploadExpectation], timeout: 1)
         worker.cancelSynchronously()
 
         // Then

--- a/Tests/ExportersTests/DatadogExporter/Utils/EncodableValueTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Utils/EncodableValueTests.swift
@@ -9,6 +9,7 @@ import XCTest
 class EncodableValueTests: XCTestCase {
     func testItEncodesDifferentEncodableValues() throws {
         let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
 
         XCTAssertEqual(
             try encoder.encode(EncodingContainer(EncodableValue("string"))).utf8String,
@@ -42,29 +43,30 @@ class EncodableValueTests: XCTestCase {
 class JSONStringEncodableValueTests: XCTestCase {
     func testItEncodesDifferentEncodableValuesAsString() throws {
         let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
 
         XCTAssertEqual(
             try encoder.encode(
-                EncodingContainer(JSONStringEncodableValue("string", encodedUsing: JSONEncoder()))
+                EncodingContainer(JSONStringEncodableValue("string", encodedUsing: encoder))
             ).utf8String,
             #"{"value":"string"}"#
         )
         XCTAssertEqual(
             try encoder.encode(
-                EncodingContainer(JSONStringEncodableValue(123, encodedUsing: JSONEncoder()))
+                EncodingContainer(JSONStringEncodableValue(123, encodedUsing: encoder))
             ).utf8String,
             #"{"value":"123"}"#
         )
         XCTAssertEqual(
             try encoder.encode(
-                EncodingContainer(JSONStringEncodableValue(["a", "b", "c"], encodedUsing: JSONEncoder()))
+                EncodingContainer(JSONStringEncodableValue(["a", "b", "c"], encodedUsing: encoder))
             ).utf8String,
             #"{"value":"[\"a\",\"b\",\"c\"]"}"#
         )
         XCTAssertEqual(
             try encoder.encode(
                 EncodingContainer(
-                    JSONStringEncodableValue(URL(string: "https://example.com/image.png")!, encodedUsing: JSONEncoder())
+                    JSONStringEncodableValue(URL(string: "https://example.com/image.png")!, encodedUsing: encoder)
                 )
             ).utf8String,
             #"{"value":"https:\/\/example.com\/image.png"}"#
@@ -75,7 +77,7 @@ class JSONStringEncodableValueTests: XCTestCase {
         }
         XCTAssertEqual(
             try encoder.encode(
-                EncodingContainer(JSONStringEncodableValue(Foo(), encodedUsing: JSONEncoder()))
+                EncodingContainer(JSONStringEncodableValue(Foo(), encodedUsing: encoder))
             ).utf8String,
             #"{"value":"{\"bar\":\"bar_\",\"bizz\":\"bizz_\"}"}"#
         )


### PR DESCRIPTION
The `EncodableValue` tests make use of a `JSONEncoder` instance without specifying any output format. Because JSON keys are unordered by default, the tests are randomly failing. The simple fix is to set the JSONEncoder's output format to `.sortedKeys`. This has no effect to the actual implementation that is being tested, but removes flakiness from the test environment.

<img width="1062" src="https://github.com/open-telemetry/opentelemetry-swift/assets/947205/9801d465-a7de-4782-8900-427acc9c5d9b">
