### PR TITLE
Fix some Xcode warnings

### DIFF
--- a/Examples/Logs Sample/main.swift
+++ b/Examples/Logs Sample/main.swift
@@ -1,7 +1,7 @@
 //
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 
 import Foundation
 import OpenTelemetryApi
@@ -11,22 +11,26 @@ import Logging
 import GRPC
 import NIO
 
-
 func configure() {
-  let configuration = ClientConnection.Configuration.default(
-      target: .hostAndPort("localhost", 4317),
-      eventLoopGroup: MultiThreadedEventLoopGroup(numberOfThreads: 1))
+    let configuration = ClientConnection.Configuration.default(
+        target: .hostAndPort("localhost", 4317),
+        eventLoopGroup: MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    )
 
-      
-  _ = OtlpLogExporter(channel: ClientConnection(configuration: configuration))
-  
-      OpenTelemetry.registerLoggerProvider(loggerProvider: LoggerProviderBuilder().with(processors: [
-        BatchLogRecordProcessor(logRecordExporter:OtlpLogExporter(channel: ClientConnection(configuration: configuration)))]).build())
-      
-  }
+    let loggerProvider = LoggerProviderBuilder()
+        .with(processors: [
+            BatchLogRecordProcessor(logRecordExporter: OtlpLogExporter(channel: ClientConnection(configuration: configuration)))
+        ])
+        .build()
 
-  configure()
-        
-  let eventProvider = OpenTelemetry.instance.loggerProvider.loggerBuilder(instrumentationScopeName: "myScope").setEventDomain("device").build()
-      
-      
+    OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+}
+
+configure()
+
+let eventProvider = OpenTelemetry
+    .instance
+    .loggerProvider
+    .loggerBuilder(instrumentationScopeName: "myScope")
+    .setEventDomain("device")
+    .build()

--- a/Examples/Logs Sample/main.swift
+++ b/Examples/Logs Sample/main.swift
@@ -18,7 +18,7 @@ func configure() {
       eventLoopGroup: MultiThreadedEventLoopGroup(numberOfThreads: 1))
 
       
-  OtlpLogExporter(channel: ClientConnection(configuration: configuration))
+  _ = OtlpLogExporter(channel: ClientConnection(configuration: configuration))
   
       OpenTelemetry.registerLoggerProvider(loggerProvider: LoggerProviderBuilder().with(processors: [
         BatchLogRecordProcessor(logRecordExporter:OtlpLogExporter(channel: ClientConnection(configuration: configuration)))]).build())

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -147,7 +147,7 @@ class URLSessionLogger {
         }
         instrumentation.configuration.injectCustomHeaders?(&request, span)
         var instrumentedRequest = request
-        objc_setAssociatedObject(instrumentedRequest, &URLSessionInstrumentation.instrumentedKey, true, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+        objc_setAssociatedObject(instrumentedRequest, URLSessionInstrumentation.instrumentedKey, true, .OBJC_ASSOCIATION_COPY_NONATOMIC)
         var traceHeaders = tracePropagationHTTPHeaders(span: span, textMapPropagator: OpenTelemetry.instance.propagators.textMapPropagator)
         if let originalHeaders = request.allHTTPHeaderFields {
             traceHeaders.merge(originalHeaders) { _, new in new }

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/State/AsynchronousMetricStorage.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/State/AsynchronousMetricStorage.swift
@@ -65,7 +65,7 @@ public class AsynchronousMetricStorage: MetricStorage {
     public func collect(resource: Resource, scope: InstrumentationScopeInfo, startEpochNanos: UInt64, epochNanos: UInt64) -> StableMetricData {
         var result: [[String: AttributeValue]: PointData]
         if aggregationTemporality == .delta {
-            var points = self.points
+            let points = self.points
             var lastPoints = self.lastPoints
             lastPoints = lastPoints.filter { element in
                 points[element.key] == nil // remove if points does not contain key

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/State/AsynchronousMetricStorage.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/State/AsynchronousMetricStorage.swift
@@ -42,7 +42,7 @@ public class AsynchronousMetricStorage: MetricStorage {
         let newMeasurement = measurement.hasDoubleValue ? Measurement.doubleMeasurement(startEpochNano: start, endEpochNano: measurement.epochNano, value: measurement.doubleValue, attributes: processedAttributes) : Measurement.longMeasurement(startEpochNano: start, endEpochNano: measurement.epochNano, value: measurement.longValue, attributes: processedAttributes)
         do {
             try recordPoint(point: aggregator.toPoint(measurement: newMeasurement))
-        } catch let HistogramAggregatorError.unsupportedOperation(error) {
+        } catch HistogramAggregatorError.unsupportedOperation {
             // TODO: log error
         } catch {
             // TODO: log default error

--- a/Tests/ExportersTests/DatadogExporter/DatadogExporterTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/DatadogExporterTests.swift
@@ -18,10 +18,9 @@ class DatadogExporterTests: XCTestCase {
     }
 
     func testWhenExportSpanIsCalled_thenTraceAndLogsAreUploaded() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Test is flaky on watchOS")
-#endif
-
+        #else
         var logsSent = false
         var tracesSent = false
         let expecTrace = expectation(description: "trace received")
@@ -90,6 +89,7 @@ class DatadogExporterTests: XCTestCase {
             XCTFail()
         }
         server.stop()
+        #endif
     }
 
     private func simpleSpan(tracer: TracerSdk) {
@@ -99,10 +99,9 @@ class DatadogExporterTests: XCTestCase {
     }
 
     func testWhenExportMetricIsCalled_thenMetricsAreUploaded() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Test is flaky on watchOS")
-#endif
-
+        #else
         var metricsSent = false
         let expecMetrics = expectation(description: "metrics received")
         expecMetrics.assertForOverFulfill = false
@@ -157,5 +156,6 @@ class DatadogExporterTests: XCTestCase {
         }
 
         server.stop()
+        #endif
     }
 }

--- a/Tests/ExportersTests/DatadogExporter/Logs/LogsExporterTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Logs/LogsExporterTests.swift
@@ -18,9 +18,9 @@ class LogsExporterTests: XCTestCase {
     }
 
     func testWhenExportSpanIsCalledAndSpanHasEvent_thenLogIsUploaded() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Test is flaky on watchOS")
-#endif
+        #else
         var logsSent = false
         let expec = expectation(description: "logs received")
         let server = HttpTestServer(url: URL(string: "http://localhost:33333"),
@@ -68,6 +68,7 @@ class LogsExporterTests: XCTestCase {
         XCTAssertTrue(logsSent)
 
         server.stop()
+        #endif
     }
 
     private func createBasicSpanWithEvent() -> SpanData {

--- a/Tests/ExportersTests/DatadogExporter/Spans/SpansExporterTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Spans/SpansExporterTests.swift
@@ -18,10 +18,9 @@ class SpansExporterTests: XCTestCase {
     }
 
     func testWhenExportSpanIsCalled_thenTraceIsUploaded() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Test is flaky on watchOS")
-#endif
-
+        #else
         var tracesSent = false
         let expec = expectation(description: "traces received")
         let server = HttpTestServer(url: URL(string: "http://localhost:33333"),
@@ -68,6 +67,7 @@ class SpansExporterTests: XCTestCase {
         XCTAssertTrue(tracesSent)
 
         server.stop()
+        #endif
     }
 
     private func createBasicSpan() -> SpanData {

--- a/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
@@ -37,10 +37,9 @@ class DataUploadWorkerTests: XCTestCase {
     // MARK: - Data Uploads
 
     func testItUploadsAllData() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-#endif
-
+        #else
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             httpClient: HTTPClient(session: server.getInterceptedURLSession()),
@@ -70,6 +69,7 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
 
         XCTAssertEqual(try temporaryDirectory.files().count, 0)
+        #endif
     }
 
     func testGivenDataToUpload_whenUploadFinishesAndDoesNotNeedToBeRetried_thenDataIsDeleted() {
@@ -159,10 +159,9 @@ class DataUploadWorkerTests: XCTestCase {
     }
 
     func testWhenBatchFails_thenIntervalIncreases() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-#endif
-
+        #else
         let delayChangeExpectation = expectation(description: "Upload delay is increased")
         let mockDelay = MockDelay { command in
             if case .increase = command {
@@ -192,13 +191,13 @@ class DataUploadWorkerTests: XCTestCase {
         server.waitFor(requestsCompletion: 1)
         waitForExpectations(timeout: 1, handler: nil)
         worker.cancelSynchronously()
+        #endif
     }
 
     func testWhenBatchSucceeds_thenIntervalDecreases() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-#endif
-
+        #else
         let delayChangeExpectation = expectation(description: "Upload delay is decreased")
         let mockDelay = MockDelay { command in
             if case .decrease = command {
@@ -228,6 +227,7 @@ class DataUploadWorkerTests: XCTestCase {
         server.waitFor(requestsCompletion: 1)
         waitForExpectations(timeout: 2, handler: nil)
         worker.cancelSynchronously()
+        #endif
     }
 
     // MARK: - Tearing Down
@@ -257,10 +257,9 @@ class DataUploadWorkerTests: XCTestCase {
     }
 
     func testItFlushesAllData() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-#endif
-
+        #else
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             httpClient: HTTPClient(session: server.getInterceptedURLSession()),
@@ -292,6 +291,7 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k3":"v3"}]"#.utf8Data })
 
         worker.cancelSynchronously()
+        #endif
     }
 }
 

--- a/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/DataUploadWorkerTests.swift
@@ -91,7 +91,7 @@ class DataUploadWorkerTests: XCTestCase {
             featureName: .mockAny()
         )
 
-        wait(for: [startUploadExpectation], timeout: 1)
+        wait(for: [startUploadExpectation], timeout: .timeout)
         worker.cancelSynchronously()
 
         // Then
@@ -117,7 +117,7 @@ class DataUploadWorkerTests: XCTestCase {
             featureName: .mockAny()
         )
 
-        wait(for: [startUploadExpectation], timeout: 1)
+        wait(for: [startUploadExpectation], timeout: .timeout)
         worker.cancelSynchronously()
 
         // Then
@@ -154,7 +154,7 @@ class DataUploadWorkerTests: XCTestCase {
 
         // Then
         server.waitFor(requestsCompletion: 0)
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: .timeout)
         worker.cancelSynchronously()
     }
 
@@ -189,7 +189,7 @@ class DataUploadWorkerTests: XCTestCase {
 
         // Then
         server.waitFor(requestsCompletion: 1)
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: .timeout)
         worker.cancelSynchronously()
         #endif
     }
@@ -225,7 +225,7 @@ class DataUploadWorkerTests: XCTestCase {
 
         // Then
         server.waitFor(requestsCompletion: 1)
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: .timeout)
         worker.cancelSynchronously()
         #endif
     }
@@ -312,4 +312,8 @@ struct MockDelay: Delay {
         callback?(.increase)
         callback = nil
     }
+}
+
+private extension TimeInterval {
+    static let timeout: Self = 5
 }

--- a/Tests/ExportersTests/DatadogExporter/Upload/DataUploaderTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/DataUploaderTests.swift
@@ -10,9 +10,9 @@ extension DataUploadStatus: EquatableInTests {}
 
 class DataUploaderTests: XCTestCase {
     func testWhenUploadCompletesWithSuccess_itReturnsExpectedUploadStatus() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-#endif
+        #else
         // Given
         let randomResponse: HTTPURLResponse = .mockResponseWith(statusCode: (100 ... 599).randomElement()!)
         let randomRequestIDOrNil: String? = Bool.random() ? .mockRandom() : nil
@@ -34,13 +34,13 @@ class DataUploaderTests: XCTestCase {
 
         XCTAssertEqual(uploadStatus, expectedUploadStatus)
         server.waitFor(requestsCompletion: 1)
+        #endif
     }
 
     func testWhenUploadCompletesWithFailure_itReturnsExpectedUploadStatus() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-#endif
-
+        #else
         // Given
         let randomErrorDescription: String = .mockRandom()
         let randomError = NSError(domain: .mockRandom(), code: .mockRandom(), userInfo: [NSLocalizedDescriptionKey: randomErrorDescription])
@@ -59,5 +59,6 @@ class DataUploaderTests: XCTestCase {
 
         XCTAssertEqual(uploadStatus, expectedUploadStatus)
         server.waitFor(requestsCompletion: 1)
+        #endif
     }
 }

--- a/Tests/ExportersTests/DatadogExporter/Upload/HTTPClientTests.swift
+++ b/Tests/ExportersTests/DatadogExporter/Upload/HTTPClientTests.swift
@@ -27,10 +27,9 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testWhenRequestIsNotDelivered_itReturnsHTTPRequestDeliveryError() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-#endif
-
+        #else
         let mockError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "no internet connection"])
         let server = ServerMock(delivery: .failure(error: mockError))
         let expectation = self.expectation(description: "receive response")
@@ -48,5 +47,6 @@ class HTTPClientTests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
         server.waitFor(requestsCompletion: 1)
+        #endif
     }
 }

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -196,9 +196,8 @@ class URLSessionInstrumentationTests: XCTestCase {
 
     public func testConfigurationCallbacksCalledWhenForbidden() throws {
         #if os(watchOS)
-            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-        #endif
-
+        throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+        #else
         let request = URLRequest(url: URL(string: "http://localhost:33333/forbidden")!)
         let task = URLSession.shared.dataTask(with: request) { data, _, _ in
             if let data = data {
@@ -218,6 +217,7 @@ class URLSessionInstrumentationTests: XCTestCase {
         XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled)
         XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled)
         XCTAssertFalse(URLSessionInstrumentationTests.checker.receivedErrorCalled)
+        #endif
     }
 
     public func testConfigurationCallbacksCalledWhenError() {
@@ -411,8 +411,8 @@ class URLSessionInstrumentationTests: XCTestCase {
         @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
         public func testConfigurationCallbacksCalledWhenForbiddenAsync() async throws {
             #if os(watchOS)
-                throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
-            #endif
+            throw XCTSkip("Implementation needs to be updated for watchOS to make this test pass")
+            #else
             let request = URLRequest(url: URL(string: "http://localhost:33333/forbidden")!)
             let (data, _) = try await URLSession.shared.data(for: request)
             let string = String(decoding: data, as: UTF8.self)
@@ -425,6 +425,7 @@ class URLSessionInstrumentationTests: XCTestCase {
             XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled)
             XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled)
             XCTAssertFalse(URLSessionInstrumentationTests.checker.receivedErrorCalled)
+            #endif
         }
 
         @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)

--- a/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
@@ -214,7 +214,7 @@ class ActivityContextManagerTests: XCTestCase {
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     // First created task correctly does not inherit activity when created detached
-    func testStartAndEndSpanInAsyncTaskDetachedWithParentAsync() async {
+    func testStartAndEndSpanInAsyncTaskDetachedWithParentAsync() {
         let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTask1").startSpan()
         ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
         let expec = expectation(description: "testStartAndEndSpanInAsyncTaskWithParent")
@@ -226,7 +226,7 @@ class ActivityContextManagerTests: XCTestCase {
         }
         span1.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
-        await waitForExpectations(timeout: 30)
+        waitForExpectations(timeout: 30)
     }
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
@@ -248,7 +248,7 @@ class ActivityContextManagerTests: XCTestCase {
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     // First created task correctly inherits activity when created, so assigns the proper parent
-    func testStartAndEndSpanInAsyncTaskWithParentAsync() async {
+    func testStartAndEndSpanInAsyncTaskWithParentAsync() {
         let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTask1").startSpan()
         ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
         let expec = expectation(description: "testStartAndEndSpanInAsyncTaskWithParent")
@@ -258,7 +258,7 @@ class ActivityContextManagerTests: XCTestCase {
             XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === span1)
             expec.fulfill()
         }
-        await waitForExpectations(timeout: 30)
+        waitForExpectations(timeout: 30)
         span1.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
@@ -293,7 +293,7 @@ class ActivityContextManagerTests: XCTestCase {
     }
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-    func testActiveSpanIsKeptPerTaskAsync() async {
+    func testActiveSpanIsKeptPerTaskAsync() {
         let expectation1 = self.expectation(description: "firstSpan created")
         let expectation2 = self.expectation(description: "secondSpan created")
 
@@ -316,7 +316,7 @@ class ActivityContextManagerTests: XCTestCase {
         }
 
         XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === parent)
-        await waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
         parent.end()
         XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }

--- a/Tests/OpenTelemetrySdkTests/Logs/BatchLogRecordProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Logs/BatchLogRecordProcessorTests.swift
@@ -46,6 +46,7 @@ class BatchLogRecordProcessorTests : XCTestCase {
         let processor = BatchLogRecordProcessor(logRecordExporter: waitingExporter,scheduleDelay: 10000,maxQueueSize: maxQueueSize, maxExportBatchSize: maxQueueSize/2)
         let loggerProvider = LoggerProviderBuilder().with(processors: [processor]).build()
         _ = loggerProvider.get(instrumentationScopeName: "BatchLogRecordProcessorTest")
+        #warning("Unfinished test")
     }
     
     func testForceExport() {

--- a/Tests/OpenTelemetrySdkTests/Logs/BatchLogRecordProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Logs/BatchLogRecordProcessorTests.swift
@@ -45,7 +45,7 @@ class BatchLogRecordProcessorTests : XCTestCase {
         let waitingExporter = WaitingLogRecordExporter(numberToWaitFor: maxQueueSize)
         let processor = BatchLogRecordProcessor(logRecordExporter: waitingExporter,scheduleDelay: 10000,maxQueueSize: maxQueueSize, maxExportBatchSize: maxQueueSize/2)
         let loggerProvider = LoggerProviderBuilder().with(processors: [processor]).build()
-        let logger = loggerProvider.get(instrumentationScopeName: "BatchLogRecordProcessorTest")
+        _ = loggerProvider.get(instrumentationScopeName: "BatchLogRecordProcessorTest")
     }
     
     func testForceExport() {

--- a/Tests/OpenTelemetrySdkTests/Metrics/CounterTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/CounterTests.swift
@@ -130,10 +130,9 @@ final class CounterTests: XCTestCase {
     }
 
     public func testIntCounterBoundInstrumentsStatusUpdatedCorrectlyMultiThread() throws {
-#if os(watchOS)
+        #if os(watchOS)
         throw XCTSkip("Test is flaky on watchOS")
-#endif
-
+        #else
         let testProcessor = TestMetricProcessor()
         let meter = MeterProviderSdk(metricProcessor: testProcessor, metricExporter: NoopMetricExporter()).get(instrumentationName: "scope1") as! MeterSdk
         let testCounter = meter.createIntCounter(name: "testCounter").internalCounter as! CounterMetricSdk<Int>
@@ -179,6 +178,7 @@ final class CounterTests: XCTestCase {
         }
         // 610 = 110 from initial update, 500 from the multi-thread test case.
         XCTAssertEqual(610, sum)
+        #endif
     }
 
     public func testDoubleCounterBoundInstrumentsStatusUpdatedCorrectlyMultiThread() {


### PR DESCRIPTION
This PR fixes half of the Xcode warnings. The other half is due to the thrift-generated Swift 3 files.

For the `'currentRadioAccessTechnology' was deprecated in iOS 12.0` warning, I recommend to drop support for iOS 11 and iOS 12. They are old enough. iOS 12 was released in September 2018.

| macOS | iOS | watchOS |
|---|---|---|
| <img width="400" alt="macOS" src="https://github.com/open-telemetry/opentelemetry-swift/assets/947205/4949557f-0845-468b-bb73-c96dec338efe"> | <img width="400" alt="iOS" src="https://github.com/open-telemetry/opentelemetry-swift/assets/947205/04d956e1-d81d-4033-84b3-ba9a97acaa2a"> | <img width="400" alt="watchOS" src="https://github.com/open-telemetry/opentelemetry-swift/assets/947205/f04efb52-9217-4f81-9f04-7b7c942e7b40"> |

As far as I can see Jaeger is supporting the [OpenTelemetry Protocol](https://www.jaegertracing.io/docs/1.46/apis/#opentelemetry-protocol-stable) and [Protobuf via gRPC](https://www.jaegertracing.io/docs/1.46/apis/#protobuf-via-grpc-stable) ([second reference](https://www.jaegertracing.io/docs/1.46/apis/#grpcprotobuf-stable)). Do you have any plans moving away from Thrift?