### PR TITLE
Maintainer status self nomination

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,9 +12,9 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-# Maintainers: @SergeyKanzhelev @nachoBonafonte
+# Maintainers: @SergeyKanzhelev @nachoBonafonte @bryce-b
 
-# Approvers: @bryce-b @vvydier
+# Approvers: @vvydier
 
 
 * @nachoBonafonte @bryce-b @vvydier


### PR DESCRIPTION
Per the [becoming a maintainer](https://github.com/open-telemetry/community/blob/main/community-membership.md#becoming-a-maintainer) instructions, I am adding myself to the maintainers section of the CODEOWNERS.md file.