### PR TITLE
Bump minimum supported watchOS version

### DIFF
--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -9,7 +9,7 @@ let package = Package(
         .macOS(.v10_13),
         .iOS(.v11),
         .tvOS(.v11),
-        .watchOS(.v3)
+        .watchOS(.v5)
     ],
     products: [
         .library(name: "OpenTelemetryApi", type: .static, targets: ["OpenTelemetryApi"]),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -7,8 +7,8 @@ let package = Package(
     name: "opentelemetry-swift",
     platforms: [
         .macOS(.v10_13),
-        .iOS(.v11),
-        .tvOS(.v11),
+        .iOS(.v13),
+        .tvOS(.v13),
         .watchOS(.v5)
     ],
     products: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "opentelemetry-swift",
     platforms: [
-        .macOS(.v10_13),
+        .macOS(.v10_15),
         .iOS(.v13),
         .tvOS(.v13),
         .watchOS(.v5)

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -9,7 +9,7 @@ let package = Package(
         .macOS(.v10_13),
         .iOS(.v11),
         .tvOS(.v11),
-        .watchOS(.v3)
+        .watchOS(.v5)
     ],
     products: [
         .library(name: "OpenTelemetryApi", type: .static, targets: ["OpenTelemetryApi"]),


### PR DESCRIPTION
Hi!

My app doesn't compile with Xcode 15 (currently in beta). The problem is caused by the opentelemetry-swift package. I got the following errors in Xcode build log:


> Build target OpenTelemetryProtocolExporterCommon
> The package product 'Logging' requires minimum platform version 5.0 for the watchOS platform, but this target supports 4.0
> The package product 'SwiftProtobuf' requires minimum platform version 5.0 for the watchOS platform, but this target supports 4.0
> 
> Build target OpenTelemetryProtocolExporterGrpc
> The package product 'Logging' requires minimum platform version 5.0 for the watchOS platform, but this target supports 4.0
> 
> The package product 'SwiftProtobuf' requires minimum platform version 5.0 for the watchOS platform, but this target supports 4.0
> The package product 'GRPC' requires minimum platform version 5.0 for the watchOS platform, but this target supports 4.0
> 
> Build target OpenTelemetryProtocolExporterHttp
> The package product 'Logging' requires minimum platform version 5.0 for the watchOS platform, but this target supports 4.0
> The package product 'SwiftProtobuf' requires minimum platform version 5.0 for the watchOS platform, but this target supports 4.0
> 

I could fix the issue by forking opentelemetry-swift, bumping the watchOS version in your Package@swift5.6.swift and making my app depend on the fork.

