### PR TITLE
ActivityContextManager: Release lock after context value has been removed

### DIFF
--- a/Sources/OpenTelemetryApi/Context/ActivityContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/ActivityContextManager.swift
@@ -74,11 +74,11 @@ class ActivityContextManager: ContextManager {
         if contextMap[activityIdent]?.isEmpty ?? false {
             contextMap[activityIdent] = nil
         }
-        rlock.unlock()
         if let scope = objectScope.object(forKey: value) {
             var scope = scope.scope
             os_activity_scope_leave(&scope)
             objectScope.removeObject(forKey: value)
         }
+        rlock.unlock()
     }
 }


### PR DESCRIPTION
I encountered this crash that we retrieved from Crashlytics.

```
Crashed: com.apple.root.background-qos
0  libobjc.A.dylib                0x1e700 objc_loadWeakRetained + 148
1  libobjc.A.dylib                0x1e898 objc_loadWeak + 20
2  Foundation                     0x10a788 probeGC + 452
3  Foundation                     0x31e0 -[NSConcreteMapTable objectForKey:] + 44
4  Skywalker                      0x2cc4b50 ActivityContextManager.removeContextValue(forKey:value:) + 1 (ActivityContextManager.swift:1)
5  Skywalker                      0x2cd3fbc RecordEventsReadableSpan.end(time:) + 41 (OpenTelemetryContextProvider.swift:41)
```
After some research, we've found out that [NSMapTable are also thread-unsafe](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html). This pull request will release the lock in ActivityContextManager after the context has been removed.