### PR TITLE
Upgrade swift-nio-extras version to fix security issue.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
+          "revision": "fb70a0f5e984f23be48b11b4f1909f3bee016178",
+          "version": "1.19.1"
         }
       },
       {


### PR DESCRIPTION
Update swift-nio-extras to latest version 1.19.1. This version fixed [CVE-2022-3252](https://github.com/advisories/GHSA-773g-x274-8qmf).

While consumers can upgrade the library directly in their project via SPM, this project should also update the Package.resolved because the security tool (e.g Trivy) just scans the dependencies' versions and raise issues accordingly.

It's a PR from #461 