### PR TITLE
Allow async instrument to close via observable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     dependencies: [
         .package(name: "Opentracing", url: "https://github.com/undefinedlabs/opentracing-objc", exact: "0.5.2"),
         .package(name: "Thrift", url: "https://github.com/undefinedlabs/Thrift-Swift", exact: "1.1.1"),
-        .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", exact: "2.59.0"),
+        .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", exact: "2.0.0"),
         .package(name: "grpc-swift", url: "https://github.com/grpc/grpc-swift.git", exact: "1.0.0"),
         .package(name: "swift-protobuf", url: "https://github.com/apple/swift-protobuf.git", exact: "1.20.2"),
         .package(name: "swift-log", url: "https://github.com/apple/swift-log.git", exact: "1.4.4"),

--- a/Sources/OpenTelemetryApi/Metrics/Stable/DefaultStableMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Stable/DefaultStableMeter.swift
@@ -84,7 +84,9 @@ public class DefaultStableMeter : StableMeter {
     }
   }
   
-  private struct NoopObservableDoubleUpDownCounter : ObservableDoubleUpDownCounter {}
+  private struct NoopObservableDoubleUpDownCounter : ObservableDoubleUpDownCounter {
+      func close() {}
+  }
   
   private struct NoopDoubleUpDownCounter : DoubleUpDownCounter {
     mutating func add(value: Double) {}
@@ -107,7 +109,9 @@ public class DefaultStableMeter : StableMeter {
     mutating func record(value: Int, attributes: [String : AttributeValue]) {}
   }
   
-  private class NoopObservableLongUpDownCounter : ObservableLongUpDownCounter {}
+  private class NoopObservableLongUpDownCounter : ObservableLongUpDownCounter {
+      func close() {}
+  }
   
   private class NoopDoubleHistogram : DoubleHistogram {
     func record(value: Double) {}
@@ -143,8 +147,13 @@ public class DefaultStableMeter : StableMeter {
     }
   }
   
-  private class NoopObservableLongCounter : ObservableLongCounter {}
-  private class NoopObservableDoubleCounter: ObservableDoubleCounter {}
+  private class NoopObservableLongCounter : ObservableLongCounter {
+      func close() {}
+  }
+    
+  private class NoopObservableDoubleCounter: ObservableDoubleCounter {
+      func close() {}
+  }
 
   private class StableNoopDoubleCounterBuilder : DoubleCounterBuilder {
     func build() -> DoubleCounter {

--- a/Sources/OpenTelemetryApi/Metrics/Stable/DefaultStableMeter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Stable/DefaultStableMeter.swift
@@ -66,9 +66,13 @@ public class DefaultStableMeter : StableMeter {
     }
   }
   
-  private struct NoopObservableLongGauge : ObservableLongGauge {}
+  private struct NoopObservableLongGauge : ObservableLongGauge {
+      func close() {}
+  }
   
-  private struct NoopObservableDoubleGauge : ObservableDoubleGauge {}
+  private struct NoopObservableDoubleGauge : ObservableDoubleGauge {
+      func close() {}
+  }
   
   private class NoopDoubleUpDownCounterBuilder : DoubleUpDownCounterBuilder {
     func build() -> DoubleUpDownCounter {

--- a/Sources/OpenTelemetryApi/Metrics/Stable/ObservableDoubleCounter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Stable/ObservableDoubleCounter.swift
@@ -6,4 +6,5 @@
 import Foundation
 
 public protocol ObservableDoubleCounter {
+    func close()
 }

--- a/Sources/OpenTelemetryApi/Metrics/Stable/ObservableDoubleGauge.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Stable/ObservableDoubleGauge.swift
@@ -6,4 +6,5 @@
 import Foundation
 
 public protocol ObservableDoubleGauge {
+    func close()
 }

--- a/Sources/OpenTelemetryApi/Metrics/Stable/ObservableDoubleUpDownCounter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Stable/ObservableDoubleUpDownCounter.swift
@@ -6,4 +6,5 @@
 import Foundation
 
 public protocol ObservableDoubleUpDownCounter {
+    func close()
 }

--- a/Sources/OpenTelemetryApi/Metrics/Stable/ObservableLongCounter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Stable/ObservableLongCounter.swift
@@ -6,4 +6,5 @@
 import Foundation
 
 public protocol ObservableLongCounter {
+    func close()
 }

--- a/Sources/OpenTelemetryApi/Metrics/Stable/ObservableLongGauge.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Stable/ObservableLongGauge.swift
@@ -6,4 +6,5 @@
 import Foundation
 
 public protocol ObservableLongGauge {
+    func close()
 }

--- a/Sources/OpenTelemetryApi/Metrics/Stable/ObservableLongUpDownCounter.swift
+++ b/Sources/OpenTelemetryApi/Metrics/Stable/ObservableLongUpDownCounter.swift
@@ -6,4 +6,5 @@
 import Foundation
 
 public protocol ObservableLongUpDownCounter {
+    func close()
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/ObservableInstrumentSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/ObservableInstrumentSdk.swift
@@ -16,4 +16,7 @@ public struct ObservableInstrumentSdk : ObservableDoubleCounter, ObservableLongC
     }
     
     // todo: Java implementation uses closeables to remove this from the meterSharedState.callback Registation. investigate alternative?
+    public func close() {
+        meterSharedState.removeCallback(callback: callbackRegistration)
+    }
 }


### PR DESCRIPTION
This is PR for https://github.com/open-telemetry/opentelemetry-swift/issues/467 and https://github.com/open-telemetry/opentelemetry-swift/issues/469

The changes follow to Android version ([link](https://github.com/open-telemetry/opentelemetry-java/blob/ef3fef9f42d69243ac857c3e06dfc8b342d50039/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkObservableInstrument.java#L51)) where all kind of observable can close its associated instrument