### PR TITLE
Allow the DoubleHistogramInstrument to record value

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleHistogramMeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleHistogramMeterSdk.swift
@@ -1,27 +1,27 @@
 //
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 
 import Foundation
 import OpenTelemetryApi
 
-public class DoubleHistogramMeterSdk : DoubleHistogram, Instrument {
+public class DoubleHistogramMeterSdk: DoubleHistogram, Instrument {
     public var instrumentDescriptor: InstrumentDescriptor
-    public var storage : WritableMetricStorage
+    public var storage: WritableMetricStorage
 
-    init(instrumentDescriptor : InstrumentDescriptor, storage: WritableMetricStorage) {
+    init(instrumentDescriptor: InstrumentDescriptor, storage: WritableMetricStorage) {
         self.instrumentDescriptor = instrumentDescriptor
         self.storage = storage
     }
     
     public func record(value: Double) {
-        record(value: value, attributes: [String:AttributeValue]())
+        record(value: value, attributes: [String: AttributeValue]())
     }
     
-    public func record(value: Double, attributes: [String : OpenTelemetryApi.AttributeValue]) {
+    public func record(value: Double, attributes: [String: OpenTelemetryApi.AttributeValue]) {
         if value < 0 {
-            // todo : log error
+            print("Histograms can only record non-negative values. Instrument \(instrumentDescriptor.name) has recorded a negative value.")
             return
         }
         storage.recordDouble(value: value, attributes: attributes)

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleHistogramMeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleHistogramMeterSdk.swift
@@ -20,7 +20,10 @@ public class DoubleHistogramMeterSdk : DoubleHistogram, Instrument {
     }
     
     public func record(value: Double, attributes: [String : OpenTelemetryApi.AttributeValue]) {
-       //TODO: implement
+        if value < 0 {
+            // todo : log error
+            return
+        }
+        storage.recordDouble(value: value, attributes: attributes)
     }
-        
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/LongHistogramMeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/LongHistogramMeterSdk.swift
@@ -22,7 +22,7 @@ public class LongHistogramMeterSdk : LongHistogram, Instrument {
     
     public func record(value: Int, attributes: [String : OpenTelemetryApi.AttributeValue]) {
         if value < 0 {
-            // todo : log error
+            print("Histograms can only record non-negative values. Instrument \(instrumentDescriptor.name) has recorded a negative value.")
             return
         }
         storage.recordLong(value: value, attributes: attributes)


### PR DESCRIPTION
The fix is for https://github.com/open-telemetry/opentelemetry-swift/issues/468

As per in `LongHistogramMeterSdk`, we need to record the value for `DoubleHistogramInstrument` as well


