### PR TITLE
Fix the order of initialization between DoubleHistogram and LongHistogram

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleHistogramMeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleHistogramMeterBuilderSdk.swift
@@ -1,34 +1,36 @@
 //
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 
 import Foundation
 import OpenTelemetryApi
 
-public class DoubleHistogramMeterBuilderSdk : DoubleHistogramBuilder, InstrumentBuilder {
+public class DoubleHistogramMeterBuilderSdk: DoubleHistogramBuilder, InstrumentBuilder {
     var meterProviderSharedState: MeterProviderSharedState
     
     var meterSharedState: StableMeterSharedState
     
-    var type: InstrumentType
+    let type: InstrumentType = .histogram
     
-    var valueType: InstrumentValueType
+    let valueType: InstrumentValueType = .double
+    
+    let instrumentName: String
     
     var description: String
     
     var unit: String
     
-    var instrumentName: String
-    
-    init(meterProviderSharedState: inout MeterProviderSharedState, meterSharedState: inout StableMeterSharedState, name: String) {
+    init(meterProviderSharedState: inout MeterProviderSharedState,
+         meterSharedState: inout StableMeterSharedState,
+         name: String,
+         description: String = "",
+         unit: String = "") {
         self.meterProviderSharedState = meterProviderSharedState
         self.meterSharedState = meterSharedState
-        self.type = .histogram
-        self.valueType = .double
-        self.description = ""
-        self.unit = ""
         self.instrumentName = name
+        self.description = description
+        self.unit = unit
     }
 
     public func ofLongs() -> OpenTelemetryApi.LongHistogramBuilder {
@@ -38,8 +40,4 @@ public class DoubleHistogramMeterBuilderSdk : DoubleHistogramBuilder, Instrument
     public func build() -> OpenTelemetryApi.DoubleHistogram {
         buildSynchronousInstrument(DoubleHistogramMeterSdk.init)
     }
-    
-
-    
-    
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/LongHistogramMeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/LongHistogramMeterBuilderSdk.swift
@@ -1,20 +1,19 @@
 //
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 
 import Foundation
 import OpenTelemetryApi
 
-public class LongHistogramMeterBuilderSdk : LongHistogramBuilder, InstrumentBuilder {
-    
+public class LongHistogramMeterBuilderSdk: LongHistogramBuilder, InstrumentBuilder {
     var meterProviderSharedState: MeterProviderSharedState
     
     var meterSharedState: StableMeterSharedState
     
-    var type: InstrumentType = .histogram
+    let type: InstrumentType = .histogram
     
-    var valueType: InstrumentValueType = .long
+    let valueType: InstrumentValueType = .long
     
     var description: String
     
@@ -22,20 +21,19 @@ public class LongHistogramMeterBuilderSdk : LongHistogramBuilder, InstrumentBuil
     
     var instrumentName: String
     
-    internal init(meterProviderSharedState: MeterProviderSharedState, meterSharedState: StableMeterSharedState, description: String, unit: String, instrumentName: String) {
+    internal init(meterProviderSharedState: MeterProviderSharedState,
+                  meterSharedState: StableMeterSharedState,
+                  instrumentName: String,
+                  description: String,
+                  unit: String) {
         self.meterProviderSharedState = meterProviderSharedState
         self.meterSharedState = meterSharedState
+        self.instrumentName = instrumentName
         self.description = description
         self.unit = unit
-        self.instrumentName = instrumentName
     }
-    
     
     public func build() -> OpenTelemetryApi.LongHistogram {
         buildSynchronousInstrument(LongHistogramMeterSdk.init)
     }
-    
-
-    
-    
 }


### PR DESCRIPTION
The fix is for https://github.com/open-telemetry/opentelemetry-swift/issues/470

Both kind of instrument build sdk should have the same order: `instrumentName`, `description`, `unit`. It then allows the `swapBuilder(...)` perform correctly 