### PR TITLE
Use the correct instrument type while creating aysnchronous instruments

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleCounterMeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleCounterMeterBuilderSdk.swift
@@ -1,14 +1,13 @@
 //
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 
 import Foundation
 import OpenTelemetryApi
 
-public class DoubleCounterMeterBuilderSdk : DoubleCounterBuilder, InstrumentBuilder {
-    
-  var meterSharedState: StableMeterSharedState
+public class DoubleCounterMeterBuilderSdk: DoubleCounterBuilder, InstrumentBuilder {
+    var meterSharedState: StableMeterSharedState
     
     var meterProviderSharedState: MeterProviderSharedState
         
@@ -16,29 +15,30 @@ public class DoubleCounterMeterBuilderSdk : DoubleCounterBuilder, InstrumentBuil
     
     let valueType: InstrumentValueType = .double
     
+    var instrumentName: String
+    
     var description: String
     
     var unit: String
     
-    var instrumentName: String
-    
-    init(meterProviderSharedState : MeterProviderSharedState, meterSharedState : StableMeterSharedState, name : String, description: String, unit: String) {
+    init(meterProviderSharedState: MeterProviderSharedState,
+         meterSharedState: StableMeterSharedState,
+         name: String,
+         description: String,
+         unit: String) {
         self.meterProviderSharedState = meterProviderSharedState
         self.meterSharedState = meterSharedState
         self.unit = unit
         self.description = description
-        self.instrumentName  = name
+        self.instrumentName = name
     }
     
     public func build() -> OpenTelemetryApi.DoubleCounter {
         buildSynchronousInstrument(DoubleCounterSdk.init)
     }
     
-     public func buildWithCallback(_ callback: @escaping (OpenTelemetryApi.ObservableDoubleMeasurement) -> Void) -> OpenTelemetryApi.ObservableDoubleCounter {
-        registerDoubleAsynchronousInstrument(type: .counter, updater: callback)
+    public func buildWithCallback(_ callback: @escaping (OpenTelemetryApi.ObservableDoubleMeasurement) -> Void)
+        -> OpenTelemetryApi.ObservableDoubleCounter {
+        registerDoubleAsynchronousInstrument(type: .observableCounter, updater: callback)
     }
-    
-
-    
-    
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleUpDownCounterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/DoubleUpDownCounterBuilderSdk.swift
@@ -1,12 +1,12 @@
 //
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 
 import Foundation
 import OpenTelemetryApi
 
-public class DoubleUpDownCounterBuilderSdk : DoubleUpDownCounterBuilder, InstrumentBuilder {
+public class DoubleUpDownCounterBuilderSdk: DoubleUpDownCounterBuilder, InstrumentBuilder {
     var meterSharedState: StableMeterSharedState
     
     var meterProviderSharedState: MeterProviderSharedState
@@ -15,28 +15,30 @@ public class DoubleUpDownCounterBuilderSdk : DoubleUpDownCounterBuilder, Instrum
     
     let valueType: InstrumentValueType = .double
     
+    var instrumentName: String
+    
     var description: String
     
     var unit: String
     
-    var instrumentName: String
-    
-    init(meterProviderSharedState : MeterProviderSharedState, meterSharedState : StableMeterSharedState, name : String, description: String, unit: String) {
+    init(meterProviderSharedState: MeterProviderSharedState,
+         meterSharedState: StableMeterSharedState,
+         name: String,
+         description: String,
+         unit: String) {
         self.meterProviderSharedState = meterProviderSharedState
         self.meterSharedState = meterSharedState
         self.unit = unit
         self.description = description
-        self.instrumentName  = name
+        self.instrumentName = name
     }
     
     public func build() -> OpenTelemetryApi.DoubleUpDownCounter {
         buildSynchronousInstrument(DoubleUpDownCounterSdk.init)
     }
     
-    public func buildWithCallback(_ callback: @escaping (OpenTelemetryApi.ObservableDoubleMeasurement) -> Void) -> OpenTelemetryApi.ObservableDoubleUpDownCounter {
-        registerDoubleAsynchronousInstrument(type: type, updater: callback)
+    public func buildWithCallback(_ callback: @escaping (OpenTelemetryApi.ObservableDoubleMeasurement) -> Void)
+    -> OpenTelemetryApi.ObservableDoubleUpDownCounter {
+        registerDoubleAsynchronousInstrument(type: .observableUpDownCounter, updater: callback)
     }
-    
-
-    
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/LongCounterMeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/LongCounterMeterBuilderSdk.swift
@@ -1,34 +1,32 @@
 //
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 
 import Foundation
 import OpenTelemetryApi
 
-public class LongCounterMeterBuilderSdk : LongCounterBuilder, InstrumentBuilder {
-    
+public class LongCounterMeterBuilderSdk: LongCounterBuilder, InstrumentBuilder {
     var meterProviderSharedState: MeterProviderSharedState
     
     var meterSharedState: StableMeterSharedState
     
-    var type: InstrumentType
+    let type: InstrumentType = .counter
     
-    var valueType: InstrumentValueType
+    let valueType: InstrumentValueType = .long
+    
+    var instrumentName: String
     
     var description: String = ""
     
     var unit: String = ""
     
-    var instrumentName: String
-    
-    internal init(meterProviderSharedState: inout MeterProviderSharedState, meterSharedState: inout StableMeterSharedState, name: String) {
+    init(meterProviderSharedState: inout MeterProviderSharedState,
+         meterSharedState: inout StableMeterSharedState,
+         name: String) {
         self.meterProviderSharedState = meterProviderSharedState
         self.meterSharedState = meterSharedState
         self.instrumentName = name
-        type = .counter
-        valueType = .long
-        
     }
     
     public func ofDoubles() -> OpenTelemetryApi.DoubleCounterBuilder {
@@ -39,10 +37,8 @@ public class LongCounterMeterBuilderSdk : LongCounterBuilder, InstrumentBuilder 
         return buildSynchronousInstrument(LongCounterSdk.init)
     }
     
-    public func buildWithCallback(_ callback: @escaping (OpenTelemetryApi.ObservableLongMeasurement) -> Void) -> OpenTelemetryApi.ObservableLongCounter {
-        registerLongAsynchronousInstrument(type: type, updater: callback)
+    public func buildWithCallback(_ callback: @escaping (OpenTelemetryApi.ObservableLongMeasurement) -> Void)
+        -> OpenTelemetryApi.ObservableLongCounter {
+        registerLongAsynchronousInstrument(type: .observableCounter, updater: callback)
     }
-    
-    
 }
-

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/LongUpDownCounterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/LongUpDownCounterBuilderSdk.swift
@@ -1,15 +1,12 @@
 //
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 
 import Foundation
 import OpenTelemetryApi
 
-public class LongUpDownCounterBuilderSdk : LongUpDownCounterBuilder, InstrumentBuilder {
-    
-    var instrumentName: String
-    
+public class LongUpDownCounterBuilderSdk: LongUpDownCounterBuilder, InstrumentBuilder {
     var meterSharedState: StableMeterSharedState
     
     var meterProviderSharedState: MeterProviderSharedState
@@ -18,11 +15,15 @@ public class LongUpDownCounterBuilderSdk : LongUpDownCounterBuilder, InstrumentB
     
     let valueType: InstrumentValueType = .long
     
+    var instrumentName: String
+    
     var description: String = ""
     
     var unit: String = ""
     
-    init(meterProviderSharedState: inout MeterProviderSharedState, meterSharedState: inout StableMeterSharedState, name : String) {
+    init(meterProviderSharedState: inout MeterProviderSharedState,
+         meterSharedState: inout StableMeterSharedState,
+         name: String) {
         self.meterSharedState = meterSharedState
         self.meterProviderSharedState = meterProviderSharedState
         self.instrumentName = name
@@ -36,9 +37,8 @@ public class LongUpDownCounterBuilderSdk : LongUpDownCounterBuilder, InstrumentB
         buildSynchronousInstrument(LongUpDownCounterSdk.init)
     }
     
-    public func buildWithCallback(_ callback: @escaping (OpenTelemetryApi.ObservableLongMeasurement) -> Void) -> OpenTelemetryApi.ObservableLongUpDownCounter {
-        registerLongAsynchronousInstrument(type: type, updater: callback)
+    public func buildWithCallback(_ callback: @escaping (OpenTelemetryApi.ObservableLongMeasurement) -> Void)
+        -> OpenTelemetryApi.ObservableLongUpDownCounter {
+        registerLongAsynchronousInstrument(type: .observableUpDownCounter, updater: callback)
     }
-    
-    
 }


### PR DESCRIPTION
The fix is for https://github.com/open-telemetry/opentelemetry-swift/issues/471

While creating asynchronous instrument from synchronous one, we need to pass the correct `InstrumentType` instead of using the value of synchronous instance.

