### PR TITLE
Changing access control level for few methods in SpanAdapter

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolCommon/trace/SpanAdapter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/trace/SpanAdapter.swift
@@ -67,7 +67,7 @@ public struct SpanAdapter {
     return protoSpan
   }
   
-  static func toProtoSpanKind(kind: SpanKind) -> Opentelemetry_Proto_Trace_V1_Span.SpanKind {
+  public static func toProtoSpanKind(kind: SpanKind) -> Opentelemetry_Proto_Trace_V1_Span.SpanKind {
     switch kind {
     case .internal:
       return Opentelemetry_Proto_Trace_V1_Span.SpanKind.internal
@@ -82,7 +82,7 @@ public struct SpanAdapter {
     }
   }
   
-  static func toProtoSpanEvent(event: SpanData.Event) -> Opentelemetry_Proto_Trace_V1_Span.Event {
+  public static func toProtoSpanEvent(event: SpanData.Event) -> Opentelemetry_Proto_Trace_V1_Span.Event {
     var protoEvent = Opentelemetry_Proto_Trace_V1_Span.Event()
     protoEvent.name = event.name
     protoEvent.timeUnixNano = event.timestamp.timeIntervalSince1970.toNanoseconds
@@ -92,7 +92,7 @@ public struct SpanAdapter {
     return protoEvent
   }
   
-  static func toProtoSpanLink(link: SpanData.Link) -> Opentelemetry_Proto_Trace_V1_Span.Link {
+  public static func toProtoSpanLink(link: SpanData.Link) -> Opentelemetry_Proto_Trace_V1_Span.Link {
     var protoLink = Opentelemetry_Proto_Trace_V1_Span.Link()
     protoLink.traceID = TraceProtoUtils.toProtoTraceId(traceId: link.context.traceId)
     protoLink.spanID = TraceProtoUtils.toProtoSpanId(spanId: link.context.spanId)
@@ -102,7 +102,7 @@ public struct SpanAdapter {
     return protoLink
   }
   
-  static func toStatusProto(status: Status) -> Opentelemetry_Proto_Trace_V1_Status {
+  public static func toStatusProto(status: Status) -> Opentelemetry_Proto_Trace_V1_Status {
     var statusProto = Opentelemetry_Proto_Trace_V1_Status()
     switch status {
     case .ok:

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceJsonExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceJsonExporter.swift
@@ -15,7 +15,7 @@ public class OtlpTraceJsonExporter: SpanExporter {
   private var isRunning: Bool = true
   
   // MARK: - Json Exporter helper methods
-  func getExportedSpans() -> [OtlpSpan] {
+  public func getExportedSpans() -> [OtlpSpan] {
     exportedSpans
   }
   


### PR DESCRIPTION
### What's changed in this PR?
- Changing the access control level for the below methods from `internal` to `public` in `SpanAdapter`
1. toProtoSpanKind()
2. toProtoSpanEvent()
3. toProtoSpanLink()
4. toStatusProto()

- One more minor change done in `OtlpTraceJsonExporter` i,e changing the access control for the method `getExportedSpans()` to public from internal. I had contributed to this earlier but we were using this file locally. Now we are upgrading to use this directly from this repo.

### Why is this change required?
- We are leveraging OpenTelemetry extensively for both mobile and web in our app (nested as well). 
In some of the flows, the WebView generates the Spans and hands over the SpanData to mobile. In this case, the native side, instead of creating new Spans/ids, needs to override the SpanData with the received SpanData (containing already generated span ids.). So we need the above-mentioned methods to be public to do so. Hence opening the PR with the changes required.