### PR TITLE
Library evolution support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,133 +1,122 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "grpc-swift",
-        "repositoryURL": "https://github.com/grpc/grpc-swift.git",
-        "state": {
-          "branch": null,
-          "revision": "87cecdeb2aae6b359b754d0dc7099e8237cf1824",
-          "version": "1.11.0"
-        }
-      },
-      {
-        "package": "Opentracing",
-        "repositoryURL": "https://github.com/undefinedlabs/opentracing-objc",
-        "state": {
-          "branch": null,
-          "revision": "18c1a35ca966236cee0c5a714a51a73ff33384c1",
-          "version": "0.5.2"
-        }
-      },
-      {
-        "package": "Reachability",
-        "repositoryURL": "https://github.com/ashleymills/Reachability.swift",
-        "state": {
-          "branch": null,
-          "revision": "c01bbdf2d633cf049ae1ed1a68a2020a8bda32e2",
-          "version": "5.1.0"
-        }
-      },
-      {
-        "package": "swift-atomics",
-        "repositoryURL": "https://github.com/apple/swift-atomics.git",
-        "state": {
-          "branch": null,
-          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
-          "version": "1.0.2"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
-          "version": "1.0.3"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
-          "version": "1.4.4"
-        }
-      },
-      {
-        "package": "swift-metrics",
-        "repositoryURL": "https://github.com/apple/swift-metrics.git",
-        "state": {
-          "branch": null,
-          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-          "version": "2.2.0"
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "bc4c55b9f9584f09eb971d67d956e28d08caa9d0",
-          "version": "2.43.1"
-        }
-      },
-      {
-        "package": "swift-nio-extras",
-        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
-        "state": {
-          "branch": null,
-          "revision": "fb70a0f5e984f23be48b11b4f1909f3bee016178",
-          "version": "1.19.1"
-        }
-      },
-      {
-        "package": "swift-nio-http2",
-        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
-        "state": {
-          "branch": null,
-          "revision": "00576e6f1efa5c46dca2ca3081dc56dd233b402d",
-          "version": "1.23.0"
-        }
-      },
-      {
-        "package": "swift-nio-ssl",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
-        "state": {
-          "branch": null,
-          "revision": "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
-          "version": "2.16.1"
-        }
-      },
-      {
-        "package": "swift-nio-transport-services",
-        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
-        "state": {
-          "branch": null,
-          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
-          "version": "1.11.3"
-        }
-      },
-      {
-        "package": "SwiftProtobuf",
-        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
-        "state": {
-          "branch": null,
-          "revision": "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
-          "version": "1.20.2"
-        }
-      },
-      {
-        "package": "Thrift",
-        "repositoryURL": "https://github.com/undefinedlabs/Thrift-Swift",
-        "state": {
-          "branch": null,
-          "revision": "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
-          "version": "1.1.2"
-        }
+  "pins" : [
+    {
+      "identity" : "grpc-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift.git",
+      "state" : {
+        "revision" : "87cecdeb2aae6b359b754d0dc7099e8237cf1824",
+        "version" : "1.11.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "opentracing-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/opentracing-objc",
+      "state" : {
+        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+        "version" : "0.5.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
+        "version" : "1.4.4"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
+        "version" : "2.2.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "bc4c55b9f9584f09eb971d67d956e28d08caa9d0",
+        "version" : "2.43.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "fb70a0f5e984f23be48b11b4f1909f3bee016178",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "00576e6f1efa5c46dca2ca3081dc56dd233b402d",
+        "version" : "1.23.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
+        "version" : "2.16.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "e7f5278a26442dc46783ba7e063643d524e414a0",
+        "version" : "1.11.3"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
+      }
+    },
+    {
+      "identity" : "thrift-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
+      "state" : {
+        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+        "version" : "1.1.2"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -42,7 +42,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.20.2"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.1.1"),
-        .package(url: "https://github.com/ashleymills/Reachability.swift", from: "5.1.0")
     ],
     targets: [
         .target(name: "OpenTelemetryApi",
@@ -60,7 +59,6 @@ let package = Package(
         .target(name: "NetworkStatus",
                 dependencies: [
                     "OpenTelemetryApi",
-                    .product(name: "Reachability", package: "Reachability.swift", condition: .when(platforms: [.iOS, .macOS, .tvOS, .macCatalyst, .linux]))
                 ],
                 path: "Sources/Instrumentation/NetworkStatus",
                 linkerSettings: [.linkedFramework("CoreTelephony", .when(platforms: [.iOS], configuration: nil))]),
@@ -124,7 +122,6 @@ let package = Package(
         .testTarget(name: "NetworkStatusTests",
                     dependencies: [
                         "NetworkStatus",
-                        .product(name: "Reachability", package: "Reachability.swift", condition: .when(platforms: [.iOS, .macOS, .tvOS, .macCatalyst, .linux]))
                     ],
                     path: "Tests/InstrumentationTests/NetworkStatusTests"),
         .testTarget(name: "OpenTelemetryApiTests",

--- a/Sources/Instrumentation/NetworkStatus/NetworkMonitor.swift
+++ b/Sources/Instrumentation/NetworkStatus/NetworkMonitor.swift
@@ -20,7 +20,7 @@ public class NetworkMonitor : NetworkMonitorProtocol {
         monitor.cancel()
     }
     
-    init() {
+    public init() throws {
         let pathHandler = { (path: NWPath) in
             let availableInterfaces = path.availableInterfaces
             let wifiInterface = self.getWifiInterface(interfaces: availableInterfaces)

--- a/Sources/Instrumentation/NetworkStatus/NetworkMonitor.swift
+++ b/Sources/Instrumentation/NetworkStatus/NetworkMonitor.swift
@@ -13,6 +13,7 @@ import Network
 public class NetworkMonitor : NetworkMonitorProtocol {
     let monitor = NWPathMonitor()
     var connection : Connection = .unavailable
+    let monitorQueue = DispatchQueue(label: "OTel-Network-Monitor")
     let lock = NSLock()
 
     deinit {
@@ -44,6 +45,7 @@ public class NetworkMonitor : NetworkMonitorProtocol {
 
         }
         monitor.pathUpdateHandler = pathHandler
+        monitor.start(queue: monitorQueue)
     }
     public func getConnection() -> Connection {
         lock.lock()

--- a/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
+++ b/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
@@ -11,7 +11,7 @@ import Network
 public class NetworkStatus {
     public private(set) var networkInfo: CTTelephonyNetworkInfo
     public private(set) var networkMonitor: NetworkMonitorProtocol
-    public convenience init() throws {
+    public convenience init() {
         self.init(with: NetworkMonitor())
     }
 

--- a/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
+++ b/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
@@ -12,7 +12,7 @@ public class NetworkStatus {
     public private(set) var networkInfo: CTTelephonyNetworkInfo
     public private(set) var networkMonitor: NetworkMonitorProtocol
     public convenience init() throws {
-        self.init(with: try NetworkMonitor())
+        self.init(with: NetworkMonitor())
     }
 
     public init(with monitor: NetworkMonitorProtocol, info: CTTelephonyNetworkInfo = CTTelephonyNetworkInfo()) {

--- a/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
+++ b/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
@@ -11,8 +11,8 @@ import Network
 public class NetworkStatus {
     public private(set) var networkInfo: CTTelephonyNetworkInfo
     public private(set) var networkMonitor: NetworkMonitorProtocol
-    public convenience init() {
-        self.init(with: NetworkMonitor())
+    public convenience init() throws {
+        self.init(with: try NetworkMonitor())
     }
 
     public init(with monitor: NetworkMonitorProtocol, info: CTTelephonyNetworkInfo = CTTelephonyNetworkInfo()) {

--- a/Tests/InstrumentationTests/NetworkStatusTests/NetworkStatusTests.swift
+++ b/Tests/InstrumentationTests/NetworkStatusTests/NetworkStatusTests.swift
@@ -7,7 +7,7 @@
     import CoreTelephony
     import Foundation
     @testable import NetworkStatus
-    import Reachability
+
     import XCTest
 
     class MockNetworkMonitor: NetworkMonitorProtocol {


### PR DESCRIPTION
This removes references to Reachability in favor of NWPathMonitor. This is the first step in providing support for library evolution. #453 