### PR TITLE
Fix system version  comparison in iOS and watchOS

### DIFF
--- a/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
+++ b/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
@@ -62,7 +62,7 @@ enum InstrumentationUtils {
         }
 #elseif os(watchOS)
         let version = WKInterfaceDevice.current().systemVersion
-        if versionNumber >= "9.0"
+        if version >= "9.0"
         {
             return true
         }

--- a/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
+++ b/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
@@ -62,15 +62,13 @@ enum InstrumentationUtils {
         }
 #elseif os(watchOS)
         let version = WKInterfaceDevice.current().systemVersion
-        if let versionNumber = Double(version),
-           versionNumber >= 9.0
+        if versionNumber >= "9.0"
         {
             return true
         }
 #else
         let version = UIDevice.current.systemVersion
-        if let versionNumber = Double(version),
-           versionNumber >= 16.0
+        if version >= "16.0"
         {
             return true
         }


### PR DESCRIPTION
Fix system version comparison in iOS and watchOS. It was failing when version included more than two numbers.

Fixes #483