### PR TITLE
changed CFBundleShortVersionString to use sdk's version number

### DIFF
--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
@@ -18,6 +18,6 @@ public class TelemetryDataSource: ITelemetryDataSource {
 
     public var version: String? {
         // This may not work if this agent is statically built
-        Bundle(for: type(of: self)).infoDictionary?["CFBundleShortVersionString"] as? String
+        Bundle(for: type(of: self)).infoDictionary?[Resource.OTEL_SWIFT_SDK_VERSION] as? String
     }
 }

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
@@ -16,8 +16,7 @@ public class TelemetryDataSource: ITelemetryDataSource {
         "opentelemetry"
     }
 
-    public var version: String? {
-        // This may not work if this agent is statically built
-     Resource.OTEL_SWIFT_SDK_VERSION
+    public var version: String {
+        Resource.OTEL_SWIFT_SDK_VERSION
     }
 }

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
@@ -16,7 +16,7 @@ public class TelemetryDataSource: ITelemetryDataSource {
         "opentelemetry"
     }
 
-    public var version: String {
+    public var version: String? {
         Resource.OTEL_SWIFT_SDK_VERSION
     }
 }

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/TelemetryDataSource.swift
@@ -18,6 +18,6 @@ public class TelemetryDataSource: ITelemetryDataSource {
 
     public var version: String? {
         // This may not work if this agent is statically built
-        Bundle(for: type(of: self)).infoDictionary?[Resource.OTEL_SWIFT_SDK_VERSION] as? String
+     Resource.OTEL_SWIFT_SDK_VERSION
     }
 }


### PR DESCRIPTION
changed CFBundleShortVersionString in TelemetryDataSource to use the newly minted OTEL_SWIFT_SDK_VERSION