### PR TITLE
Fixed removeContextValue function and added a Test testRemoveContextValuesFromSpan for it

### DIFF
--- a/Sources/OpenTelemetryApi/Context/ActivityContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/ActivityContextManager.swift
@@ -68,14 +68,12 @@ class ActivityContextManager: ContextManager {
     }
 
     func removeContextValue(forKey key: OpenTelemetryContextKeys, value: AnyObject) {
-        let activityIdent = os_activity_get_identifier(OS_ACTIVITY_CURRENT, nil)
         rlock.lock()
-        if let currentValue = contextMap[activityIdent]?[key.rawValue],
-           currentValue === value
-        {
-         contextMap[activityIdent]?[key.rawValue] = nil
-          if contextMap[activityIdent]?.isEmpty ?? false {
-            contextMap[activityIdent] = nil
+        
+        for (activityKey, activity) in contextMap where value === activity[key.rawValue] {
+            contextMap[activityKey]?[key.rawValue] = nil
+          if contextMap[activityKey]?.isEmpty ?? false {
+            contextMap[activityKey] = nil
           }
         }
         if let scope = objectScope.object(forKey: value) {

--- a/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
@@ -318,11 +318,11 @@ class ActivityContextManagerTests: XCTestCase {
         XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === span1)
         
         //Add it to one parent in one thread
-        let parent1 = defaultTracer.spanBuilder(spanName: "parent1").startSpan()
-        ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: parent1)
-        XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === parent1)
-        
         DispatchQueue.global().async {
+            let parent1 = self.defaultTracer.spanBuilder(spanName: "parent1").startSpan()
+            ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: parent1)
+            XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === parent1)
+            
             let activeSpan = ActivityContextManager.instance.getCurrentContextValue(forKey: .span)
             XCTAssert(activeSpan === parent1)
             ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
@@ -330,20 +330,22 @@ class ActivityContextManagerTests: XCTestCase {
         }
 
         //Add it to another parent in another thread
-        let parent2 = defaultTracer.spanBuilder(spanName: "parent2").startSpan()
-        ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: parent2)
-        XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === parent2)
-        
         DispatchQueue.global().async {
+            let parent2 = self.defaultTracer.spanBuilder(spanName: "parent2").startSpan()
+            ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: parent2)
+            XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === parent2)
+            
             let activeSpan = ActivityContextManager.instance.getCurrentContextValue(forKey: .span)
             XCTAssert(activeSpan === parent2)
             ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
             parent2.end()
         }
         
-        //remove all the contexts from the span and check if the Context is nil
         sleep(1)
-        ActivityContextManager.instance.removeContextValue(forKey: .span, value: span1)
+        // Remove all the contexts from the span and check if the Context is nil
+        // Ending the span will remove all the context associated with it, dont need to call removeContextValue explicitly
+        // ActivityContextManager.instance.removeContextValue(forKey: .span, value: span1)
+        span1.end()
         XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === nil)
     }
     


### PR DESCRIPTION
I tested this with a span and added it to 2 parent spans in different threads. Total of 5 contexts getting removed in this case.
Tested with a crude mechanism (using sleep) for now. Will improve it with a Semaphore or async/await later.