### PR TITLE
Remove duplicate appending of log records

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -23,9 +23,7 @@ public class OtlpHttpLogExporter : OtlpHttpExporterBase, LogRecordExporter {
   }
   
   public func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord], explicitTimeout: TimeInterval? = nil) -> OpenTelemetrySdk.ExportResult {
-    pendingLogRecords.append(contentsOf: logRecords)
     var sendingLogRecords: [ReadableLogRecord] = []
-    
     exporterLock.withLockVoid {
       pendingLogRecords.append(contentsOf: logRecords)
       sendingLogRecords = pendingLogRecords


### PR DESCRIPTION
Fixes a bug introduced in #497 that causes all log records to be duplicated.