### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -15,6 +15,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get the tag version
       id: tag_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Update version
       run: sh Scripts/updateVersion.sh $GITHUB_TOKEN ${{ steps.tag_version.outputs.VERSION }}


### PR DESCRIPTION
## Description

Closes #509 

Update `workflows` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
```

**TO-BE**

```yaml
run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
```