### PR TITLE
Use set -e in shell script to detect errors

### DIFF
--- a/Scripts/semantic-convention/generate.sh
+++ b/Scripts/semantic-convention/generate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"


### PR DESCRIPTION
Noticed that `generate.sh` was not using `set -e`; let's fix that.