### PR TITLE
Adds a way to generate XCFramework that can be used for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,8 @@ test-without-building-tvos:
 .PHONY: test-without-building-watchos
 test-without-building-watchos:
 	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_WATCHOS) test-without-building | xcbeautify
+
+
+.PHONY: generate-xcframework
+generate-xcframework:
+	./Scripts/generate_xcframework.sh OpenTelemetryApi

--- a/Scripts/generate_xcframework.sh
+++ b/Scripts/generate_xcframework.sh
@@ -1,0 +1,26 @@
+PACKAGE_NAME="$1"
+
+
+xcodebuild -scheme "$PACKAGE_NAME" -sdk iphoneos -configuration Release BUILD_LIBRARY_FOR_DISTRIBUTION=YES ARCHS=arm64 BUILD_DIR=./Build -destination "generic/platform=iOS"
+pushd Build/Release-iphoneos
+  ar -crs "lib$PACKAGE_NAME.a" "$PACKAGE_NAME.o"
+popd
+
+xcodebuild -scheme "$PACKAGE_NAME" -sdk iphonesimulator -configuration Release BUILD_LIBRARY_FOR_DISTRIBUTION=YES ARCHS="arm64 x86_64" BUILD_DIR=./Build -destination "generic/platform=iOS Simulator"
+pushd Build/Release-iphonesimulator
+  ar -crs "lib$PACKAGE_NAME.a" "$PACKAGE_NAME.o"
+  popd
+
+
+xcodebuild -scheme "$PACKAGE_NAME" -sdk  macosx -configuration Release BUILD_LIBRARY_FOR_DISTRIBUTION=YES ARCHS="arm64 x86_64" BUILD_DIR=./Build -destination "generic/platform=macOS"
+pushd Build/Release
+  ar -crs "lib$PACKAGE_NAME.a" "$PACKAGE_NAME.o"
+  popd
+
+pushd Build
+  xcodebuild -create-xcframework \
+    -library "Release-iphonesimulator/lib$PACKAGE_NAME.a" \
+    -library "Release-iphoneos/lib$PACKAGE_NAME.a" \
+    -library "Release/lib$PACKAGE_NAME.a" \
+    -output $PACKAGE_NAME.xcframework
+popd


### PR DESCRIPTION
I am not aware of all the packages that should be generated for releases. We needed `OpenTelemetryApi`, but it should be easy to extend it for other packages.