### PR TITLE
Set headers for request in HTTP Metric exporter

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OltpHTTPMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OltpHTTPMetricExporter.swift
@@ -31,7 +31,17 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter {
       $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(metricDataList: sendingMetrics)
     }
     
-    let request = createRequest(body: body, endpoint: endpoint)
+    var request = createRequest(body: body, endpoint: endpoint)
+    if let headers = envVarHeaders {
+        headers.forEach { key, value in
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
+    } else if let headers = config.headers {
+        headers.forEach { key, value in
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+    }
     httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success(_):


### PR DESCRIPTION
## Background

I have noticed that headers in `OtlpConfiguration` or `OtlpHttpExporterBase.envVarHeaders` do not get added to the request when exporting through `OtlpHttpMetricExporter`.

## What's changed in this PR?

This PR will set custom headers to `OtlpHttpTraceExporter` requests. I followed the [implementation](https://github.com/open-telemetry/opent.lemetry-swift/blob/4eb75bc8f0d6449bc197637b5c6044b51ab8c4ed/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift#L35) in `OtlpHttpTraceExporter`.