### PR TITLE
Set timeout for HTTP request in StableOtlpHttpMetricExporter

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/StableOtlpHTTPMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/StableOtlpHTTPMetricExporter.swift
@@ -42,7 +42,8 @@ public class StableOtlpHTTPMetricExporter: StableOtlpHTTPExporterBase, StableMet
       $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(stableMetricData: sendingMetrics)
     }
     
-    let request = createRequest(body: body, endpoint: endpoint)
+    var request = createRequest(body: body, endpoint: endpoint)
+    request.timeoutInterval = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
     httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success(_):

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/StableOtlpHTTPMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/StableOtlpHTTPMetricExporter.swift
@@ -70,7 +70,8 @@ public class StableOtlpHTTPMetricExporter: StableOtlpHTTPExporterBase, StableMet
         $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(stableMetricData: pendingMetrics)
       }
       let semaphore = DispatchSemaphore(value: 0)
-      let request = createRequest(body: body, endpoint: endpoint)
+      var request = createRequest(body: body, endpoint: endpoint)
+      request.timeoutInterval = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
       httpClient.send(request: request) { result in
         switch result {
         case .success(_):


### PR DESCRIPTION
## What's changed in this PR?
Set timeout interval (`OtlpConfiguration.timeout`) to request in `StableOtlpHTTPMetricExporter` 
