### PR TITLE
Allow Prometheus exporter to be used without HTTP server

### DIFF
--- a/Sources/Exporters/Prometheus/PrometheusExporterExtensions.swift
+++ b/Sources/Exporters/Prometheus/PrometheusExporterExtensions.swift
@@ -20,7 +20,7 @@ public enum PrometheusExporterExtensions {
     static let prometheusHistogramBucketPostFix = "_bucket"
     static let prometheusHistogramLeLabelName = "le"
 
-    static func writeMetricsCollection(exporter: PrometheusExporter) -> String {
+    public static func writeMetricsCollection(exporter: PrometheusExporter) -> String {
         var output = ""
         let metrics = exporter.getAndClearMetrics()
         let now = String(Int64((Date().timeIntervalSince1970 * 1000.0).rounded()))


### PR DESCRIPTION
Currently the only way to use the Prometheus exporter is via `PrometheusExporterHttpServer`. 

`PrometheusExporterHttpServer` calls `PrometheusExporterExtensions.writeMetricsCollection` to do the heavy lifting of building the response payload string. Allowing library users access to this function would allow for different/existing HTTP server frameworks to be used.