### PR TITLE
[WIP] Fixed concurrency crash

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Stable/State/SynchronousMetricStorage.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/State/SynchronousMetricStorage.swift
@@ -20,7 +20,7 @@ public class SynchronousMetricStorage: SynchronousMetricStorageProtocol {
     var aggregatorHandles = [[String: AttributeValue]: AggregatorHandle]()
     let attributeProcessor: AttributeProcessor
     var aggregatorHandlePool = [AggregatorHandle]()
-    private let aggregatorHandlesQueue = DispatchQueue(label: "org.opentelemetry.SynchronousMetricStorage.aggregatorHandlesQueue", attributes: .concurrent)
+    private let aggregatorHandlesQueue = DispatchQueue(label: "org.opentelemetry.SynchronousMetricStorage.aggregatorHandlesQueue")
 
     
     static func empty() -> SynchronousMetricStorageProtocol {
@@ -76,7 +76,7 @@ public class SynchronousMetricStorage: SynchronousMetricStorageProtocol {
         
         var points = [PointData]()
         
-        aggregatorHandlesQueue.sync(flags: .barrier) {
+        aggregatorHandlesQueue.sync {
             aggregatorHandles.forEach { key, value in
                 let point = value.aggregateThenMaybeReset(startEpochNano: start, endEpochNano: epochNanos, attributes: key, reset: reset)
                 if reset {


### PR DESCRIPTION
Inside `getAggregatorHandle` function we are just not doing read, there is a write as well. Here is code that's doing write operation:
```
            aggregatorHandles[processedAttributes] = newHandle
            aggregatorHandle = newHandle
```
Concurrency queue could be overkill here, better to use a serial queue with sync or async (we will need more code changes for return) is much better option. 