### PR TITLE
Adds StdoutLogExporter to match (renamed) StdoutSpanExporter

### DIFF
--- a/Examples/Network Sample/main.swift
+++ b/Examples/Network Sample/main.swift
@@ -51,7 +51,7 @@ func simpleNetworkCallWithDelegate() {
 }
 
 
-let spanProcessor = SimpleSpanProcessor(spanExporter: StdoutExporter(isDebug: true))
+let spanProcessor = SimpleSpanProcessor(spanExporter: StdoutSpanExporter(isDebug: true))
 OpenTelemetry.registerTracerProvider(tracerProvider:
     TracerProviderBuilder()
         .add(spanProcessor: spanProcessor)

--- a/Sources/Exporters/Stdout/StdoutLogExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutLogExporter.swift
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetrySdk
+
+class StdoutLogExporter: LogRecordExporter {
+    let isDebug: Bool
+
+    init(isDebug: Bool) {
+        self.isDebug = isDebug
+    }
+
+    func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord], explicitTimeout: TimeInterval?) -> OpenTelemetrySdk.ExportResult {
+        if isDebug {
+            for logRecord in logRecords {
+                print(String(repeating: "-", count: 40))
+                print("Severity: \(String(describing: logRecord.severity))")
+                print("Body: \(String(describing: logRecord.body))")
+                print("InstrumentationScopeInfo: \(logRecord.instrumentationScopeInfo)")
+                print("Timestamp: \(logRecord.timestamp)")
+                print("ObservedTimestamp: \(String(describing: logRecord.observedTimestamp))")
+                print("SpanContext: \(String(describing: logRecord.spanContext))")
+                print("Resource: \(logRecord.resource.attributes)")
+                print("Attributes: \(logRecord.attributes)")
+                print(String(repeating: "-", count: 40) + "\n")
+            }
+        } else {
+            do {
+                let jsonData = try JSONEncoder().encode(logRecords)
+                if let jsonString = String(data: jsonData, encoding: .utf8) {
+                    print(jsonString)
+                }
+            } catch {
+                print("Failed to serialize LogRecord as JSON: \(error)")
+                return .failure
+            }
+        }
+        return .success
+    }
+
+    func forceFlush(explicitTimeout: TimeInterval?) -> OpenTelemetrySdk.ExportResult {
+        return .success
+    }
+
+    func shutdown(explicitTimeout: TimeInterval?) { }
+}

--- a/Sources/Exporters/Stdout/StdoutSpanExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutSpanExporter.swift
@@ -7,7 +7,8 @@ import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 
-typealias StdoutExporter=StdoutSpanExporter
+@available(*, deprecated, renamed: "StdoutSpanExporter")
+public typealias StdoutExporter=StdoutSpanExporter
 
 public class StdoutSpanExporter: SpanExporter {
     let isDebug: Bool

--- a/Sources/Exporters/Stdout/StdoutSpanExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutSpanExporter.swift
@@ -7,7 +7,9 @@ import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 
-public class StdoutExporter: SpanExporter {
+typealias StdoutExporter=StdoutSpanExporter
+
+public class StdoutSpanExporter: SpanExporter {
     let isDebug: Bool
 
     public init(isDebug: Bool = false) {


### PR DESCRIPTION

- Adds LogExporter to help debug Logging. Will output to stdout similar to the Span exporter.
- Renames `StdoutExporter` to `StdoutSpanExporter` to make room for `StdoutLogExporter`
- Adds typealias for `StdoutExporter` to not break callers usage
  - Adds deprecation notice to typealias to alert callers that name has changed.
