### PR TITLE
fixed build for older Apple OS versions

### DIFF
--- a/Sources/OpenTelemetryApi/Context/ContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/ContextManager.swift
@@ -14,7 +14,7 @@ public protocol ContextManager: AnyObject {
     func withCurrentContextValue<T>(forKey: OpenTelemetryContextKeys, value: AnyObject?, _ operation: () throws -> T) rethrows -> T
 #if canImport(_Concurrency)
     /// Updates the current context value with the given key for the duration of the passed closure. If `value` is non-`nil` the key is set to that value. If `value` is `nil` the key is removed from the current context for the duration of the closure.
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withCurrentContextValue<T>(forKey: OpenTelemetryContextKeys, value: AnyObject?, _ operation: () async throws -> T) async rethrows -> T
 #endif
 }
@@ -23,7 +23,7 @@ public protocol ContextManager: AnyObject {
 public protocol ImperativeContextManager: ContextManager { }
 
 public extension ContextManager where Self: ImperativeContextManager {
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withCurrentContextValue<T>(forKey key: OpenTelemetryContextKeys, value: AnyObject?, _ operation: () async throws -> T) async rethrows -> T {
         var oldValue: AnyObject?
         if let value {

--- a/Sources/OpenTelemetryApi/Context/ContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/ContextManager.swift
@@ -14,6 +14,7 @@ public protocol ContextManager: AnyObject {
     func withCurrentContextValue<T>(forKey: OpenTelemetryContextKeys, value: AnyObject?, _ operation: () throws -> T) rethrows -> T
 #if canImport(_Concurrency)
     /// Updates the current context value with the given key for the duration of the passed closure. If `value` is non-`nil` the key is set to that value. If `value` is `nil` the key is removed from the current context for the duration of the closure.
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withCurrentContextValue<T>(forKey: OpenTelemetryContextKeys, value: AnyObject?, _ operation: () async throws -> T) async rethrows -> T
 #endif
 }
@@ -22,6 +23,7 @@ public protocol ContextManager: AnyObject {
 public protocol ImperativeContextManager: ContextManager { }
 
 public extension ContextManager where Self: ImperativeContextManager {
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withCurrentContextValue<T>(forKey key: OpenTelemetryContextKeys, value: AnyObject?, _ operation: () async throws -> T) async rethrows -> T {
         var oldValue: AnyObject?
         if let value {

--- a/Sources/OpenTelemetryApi/Context/OpenTelemetryContextProvider.swift
+++ b/Sources/OpenTelemetryApi/Context/OpenTelemetryContextProvider.swift
@@ -59,10 +59,12 @@ public struct OpenTelemetryContextProvider {
 
 #if canImport(_Concurrency)
     /// Sets `span` as the active span for the duration of the given closure. While the span will no longer be active after the closure exits, this method does **not** end the span. Prefer `SpanBuilderBase.withActiveSpan` which handles starting, activating, and ending the span.
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveSpan<T>(_ span: SpanBase, _ operation: () async throws -> T) async rethrows -> T {
         try await contextManager.withCurrentContextValue(forKey: .span, value: span, operation)
     }
 
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveBaggage<T>(_ span: Baggage, _ operation: () async throws -> T) async rethrows -> T {
         try await contextManager.withCurrentContextValue(forKey: .baggage, value: span, operation)
     }

--- a/Sources/OpenTelemetryApi/Context/OpenTelemetryContextProvider.swift
+++ b/Sources/OpenTelemetryApi/Context/OpenTelemetryContextProvider.swift
@@ -59,12 +59,12 @@ public struct OpenTelemetryContextProvider {
 
 #if canImport(_Concurrency)
     /// Sets `span` as the active span for the duration of the given closure. While the span will no longer be active after the closure exits, this method does **not** end the span. Prefer `SpanBuilderBase.withActiveSpan` which handles starting, activating, and ending the span.
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveSpan<T>(_ span: SpanBase, _ operation: () async throws -> T) async rethrows -> T {
         try await contextManager.withCurrentContextValue(forKey: .span, value: span, operation)
     }
 
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveBaggage<T>(_ span: Baggage, _ operation: () async throws -> T) async rethrows -> T {
         try await contextManager.withCurrentContextValue(forKey: .baggage, value: span, operation)
     }

--- a/Sources/OpenTelemetryApi/Context/TaskLocalContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/TaskLocalContextManager.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Unlike the `os.activity` context manager, this class does not handle setting and removing context manually. You must always use the closure based APIs for setting active context when using this manager. The `OpenTelemetryConcurrency` module assists with this by hiding the imperative APIs by default.
 ///
 /// - Note: This restriction means this class is not suitable for dynamic context injection. If you require dynamic context injection, you will need a custom context manager.
-@available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public class TaskLocalContextManager: ContextManager {
 #if swift(>=5.9)
     package static let instance = TaskLocalContextManager()

--- a/Sources/OpenTelemetryApi/Context/TaskLocalContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/TaskLocalContextManager.swift
@@ -11,6 +11,7 @@ import Foundation
 /// Unlike the `os.activity` context manager, this class does not handle setting and removing context manually. You must always use the closure based APIs for setting active context when using this manager. The `OpenTelemetryConcurrency` module assists with this by hiding the imperative APIs by default.
 ///
 /// - Note: This restriction means this class is not suitable for dynamic context injection. If you require dynamic context injection, you will need a custom context manager.
+@available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public class TaskLocalContextManager: ContextManager {
 #if swift(>=5.9)
     package static let instance = TaskLocalContextManager()

--- a/Sources/OpenTelemetryApi/Trace/SpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanBuilder.swift
@@ -110,6 +110,7 @@ public protocol SpanBuilderBase: AnyObject {
 
 #if canImport(_Concurrency)
     /// Starts a new Span and makes it active for the duration of the passed closure. The span will be ended before this method returns.
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T
 #endif
 
@@ -125,6 +126,7 @@ public protocol SpanBuilderBase: AnyObject {
 
 #if canImport(_Concurrency)
     /// Starts a new Span. The span will be ended before this method returns.
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withStartedSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T
 #endif
 }
@@ -146,6 +148,7 @@ public extension SpanBuilderBase {
     }
 
 #if canImport(_Concurrency)
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withStartedSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
         let span = self.startSpan()
         defer {

--- a/Sources/OpenTelemetryApi/Trace/SpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanBuilder.swift
@@ -110,7 +110,7 @@ public protocol SpanBuilderBase: AnyObject {
 
 #if canImport(_Concurrency)
     /// Starts a new Span and makes it active for the duration of the passed closure. The span will be ended before this method returns.
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T
 #endif
 
@@ -126,7 +126,7 @@ public protocol SpanBuilderBase: AnyObject {
 
 #if canImport(_Concurrency)
     /// Starts a new Span. The span will be ended before this method returns.
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withStartedSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T
 #endif
 }
@@ -148,7 +148,7 @@ public extension SpanBuilderBase {
     }
 
 #if canImport(_Concurrency)
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withStartedSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
         let span = self.startSpan()
         defer {

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
@@ -174,6 +174,7 @@ class SpanBuilderSdk: SpanBuilder {
     }
 
     #if canImport(_Concurrency)
+    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
         let createdSpan = self.prepareSpan()
         defer {

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
@@ -174,7 +174,7 @@ class SpanBuilderSdk: SpanBuilder {
     }
 
     #if canImport(_Concurrency)
-    @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
         let createdSpan = self.prepareSpan()
         defer {

--- a/Sources/OpenTelemetryTestUtils/OpenTelemetryTestCase.swift
+++ b/Sources/OpenTelemetryTestUtils/OpenTelemetryTestCase.swift
@@ -76,7 +76,7 @@ open class OpenTelemetryContextTestCase: XCTestCase {
     public static func concurrencyContextManagers() -> [ContextManager] {
         var managers = [ContextManager]()
 #if canImport(_Concurrency)
-        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
             managers.append(TaskLocalContextManager.instance)
         }
 #endif
@@ -90,7 +90,7 @@ open class OpenTelemetryContextTestCase: XCTestCase {
         managers.append(ActivityContextManager.instance)
 #endif
 #if canImport(_Concurrency)
-        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
             managers.append(TaskLocalContextManager.instance)
         }
 #endif

--- a/Sources/OpenTelemetryTestUtils/OpenTelemetryTestCase.swift
+++ b/Sources/OpenTelemetryTestUtils/OpenTelemetryTestCase.swift
@@ -76,7 +76,9 @@ open class OpenTelemetryContextTestCase: XCTestCase {
     public static func concurrencyContextManagers() -> [ContextManager] {
         var managers = [ContextManager]()
 #if canImport(_Concurrency)
-        managers.append(TaskLocalContextManager.instance)
+        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+            managers.append(TaskLocalContextManager.instance)
+        }
 #endif
         return managers
     }
@@ -88,7 +90,9 @@ open class OpenTelemetryContextTestCase: XCTestCase {
         managers.append(ActivityContextManager.instance)
 #endif
 #if canImport(_Concurrency)
-        managers.append(TaskLocalContextManager.instance)
+        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+            managers.append(TaskLocalContextManager.instance)
+        }
 #endif
         return managers
     }

--- a/Tests/OpenTelemetrySdkTests/ConcurrencyTests.swift
+++ b/Tests/OpenTelemetrySdkTests/ConcurrencyTests.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if canImport(_Concurrency)
+#if canImport(_Concurrency) && canImport(OpenTelemetryConcurrency)
 import OpenTelemetryTestUtils
 import XCTest
 import OpenTelemetrySdk


### PR DESCRIPTION
Added `@available` gates for async methods so SDK can be built for older Apple platforms without `async` support.

Fixes #578 