### PR TITLE
make public OTelLogHandler struct

### DIFF
--- a/Sources/Bridges/OTelSwiftLog/LogHandler.swift
+++ b/Sources/Bridges/OTelSwiftLog/LogHandler.swift
@@ -7,7 +7,7 @@ let bridgeName: String = "OTelSwiftLog"
 let version: String = "1.0.0"
 
 /// A  custom log handler to translate swift logs into otel logs
-struct OTelLogHandler: LogHandler {
+public struct OTelLogHandler: LogHandler {
   
   /// Get or set the configured log level.
   ///


### PR DESCRIPTION
I use package v1.10.0
I wrote the following code and I'm getting compile error `Cannot find 'OTelLogHandler' in scope` 

```swift
import OTelSwiftLog

let handler: OTelLogHandler() // Cannot find 'OTelLogHandler' in scope
```

This PR is intended to solve that problem.