### PR TITLE
Added missing os version gates for Concurrency

### DIFF
--- a/Examples/Logging Tracer/LoggingTracer.swift
+++ b/Examples/Logging Tracer/LoggingTracer.swift
@@ -79,6 +79,7 @@ class LoggingTracer: Tracer {
         }
 
     #if canImport(_Concurrency)
+        @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
         func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
             let span = self.startSpan()
             defer {

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
@@ -76,6 +76,7 @@ class PropagatedSpanBuilder: SpanBuilder {
     }
 
 #if canImport(_Concurrency)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
         let span = self.startSpan()
         defer {

--- a/Tests/OpenTelemetryApiTests/Baggage/DefaultBaggageManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/DefaultBaggageManagerTests.swift
@@ -60,6 +60,7 @@ class DefaultBaggageManagerTests: DefaultBaggageManagerTestsInfo {
 }
 
 #if canImport(_Concurrency)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 class DefaultBaggageManagerConcurrency: DefaultBaggageManagerTestsInfo {
     override var contextManagers: [any ContextManager] {
         Self.concurrencyContextManagers()


### PR DESCRIPTION
In the previous PR I missed couple of places where OS version gates should be added. This PR fixes that.