### PR TITLE
Created `OpenTelemetryApi` and `OpenTelemetrySdk` podspecs

### DIFF
--- a/OpenTelemetryApi.podspec
+++ b/OpenTelemetryApi.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetryApi"
+  spec.version = "1.10.1"
+  spec.summary = "Swift OpenTelemetryApi"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/OpenTelemetryApi/**/*.swift"
+
+  spec.swift_version = "5.9"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+
+  # This is necessary because we use the `package` keyword to access some properties in `OpenTelemetryApi`
+  # This keyword was introduced in Swift 5.9 and it's tightly bound to SPM.
+  # To provide the correct values to the flags `-package-name` and `-module-name` we checked out the outputs from:
+  # `swift build --verbose`
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name OpenTelemetryApi -package-name opentelemetry_swift" }
+end

--- a/OpenTelemetrySdk.podspec
+++ b/OpenTelemetrySdk.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetrySdk"
+  spec.version = "1.10.1"
+  spec.summary = "Swift OpenTelemetrySDK"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/OpenTelemetrySdk/**/*.swift"
+
+  spec.swift_version = "5.9"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+
+  spec.dependency 'OpenTelemetryApi', spec.version.to_s
+end


### PR DESCRIPTION
# Description
The idea of this PR is to create the podspecs to distribute via `CocoaPods`:
- `OpenTelemetryApi`
- `OpenTelemetrySdk`

Many of the decisions made in the podspecs were extracted from `Package@swift-5.9.swift`, for example:
- Swift Version declared in podspecs is `5.9`
- Minimum iOS Deployment Target is `v13.0`
- Minimum tvOS Deployment Target is `v13.0`
- Minimum watchOS Deployment Target is `v6.0`

> [!IMPORTANT] 
> **Versioning**
>
> Both podspecs should have the same version to work properly. Since `OpenTelemetrySdk` depends on `OpenTelemetryApi` and they are closely linked, the version of the dependency in both podspecs **must be identical**.

# How to test this
Unfortunately, we cannot use the existing examples in the OTel repository. Ideally, we should test that integration with both Pods is achievable and that there are no compiling issues.

To achieve this, I've pushed those two podspecs to a private repo, created two private pods, and tested them in an app. Below are the steps to replicate this process:

## Create the private Pods
1. Create a _private_ git repository.
2. Clone the private repository locally
3. Copy both `OpenTelemetryApi.podspec` and `OpenTelemetrySdk.podspec` in the cloned repository.
4. Commit and push both podspecs into your main branch in your private repository.
5. Publish the Podspecs to your private CocoaPods repo:
   ```bash
   # Replace the github with your git private repository
   pod repo add MyPrivateOtel https://github.com/your-username/your-private-repo.git

   # Order matters! Push OpenTelemetryApi First
   pod repo push MyPrivateOtel OpenTelemetryApi.podspec --allow-warnings
   pod repo push MyPrivateOtel OpenTelemetrySdk.podspec --allow-warnings
   ```
   We use `--allow-warnings` because the process might fail due to some "harmless" warnings, like `immutable value 'xyz' was never used; consider replacing with '_' or removing it.`

6. Now you can test the two new Pods in your project. However, keep two things in mind:
   - Add  the private source at the beginning of your Podfile.
   - Include both dependencies.
  
   Here’s how your `Podfile` should look:
   ```ruby
   platform :ios, '14.0'
   source 'https://github.com/your-username/your-private-repo'

   target 'YourMainTarget' do
      pod 'OpenTelemetryApi'
      pod 'OpenTelemetrySdk'
      # Other pods
      # ...
   end
   ```
## Extra
To make `step 6` easier I created a script that sets up a sample project, adds the two pods as dependencies, imports them, and compiles. I've attached a zip file that contains the script. Run `./test-opentelemetry-pods.sh -h` or `./test-opentelemetry-pods.sh --help` to see how to use it. The script will install some dependencies to properly create an `.xcodeproj` and use cocoapods (like `bundler` and `xcodegen`). It needs both `Xcode` and `Homebrew` to work correctly.
[test-opentelemetry-pods.sh.zip](https://github.com/user-attachments/files/16639937/test-opentelemetry-pods.sh.zip)
   