### PR TITLE
Exposes OpenTelemetryConcurrency target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,7 @@ fastlane/test_output
 
 iOSInjectionProject/
 
+# VSCode
+.vscode/*
+
 .DS_Store

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,6 +13,7 @@ let package = Package(
     ],
     products: [
         .library(name: "OpenTelemetryApi", type: .static, targets: ["OpenTelemetryApi"]),
+        .library(name: "OpenTelemetryConcurrency", type: .static, targets: ["OpenTelemetryConcurrency"]),
         .library(name: "OpenTelemetrySdk", type: .static, targets: ["OpenTelemetrySdk"]),
         .library(name: "SwiftMetricsShim", type: .static, targets: ["SwiftMetricsShim"]),
         .library(name: "StdoutExporter", type: .static, targets: ["StdoutExporter"]),


### PR DESCRIPTION
Thank you @semicoleon for the excellent changes in https://github.com/open-telemetry/opentelemetry-swift/pull/546! This MR simply exposes the new `OpenTelemetryConcurrency` target through the `OpenTelemetryApi` product so that it is available for usage by downstream packages. This enables usage as shown in [`/Examples/ConcurrencyContext/main.swift`](https://github.com/open-telemetry/opentelemetry-swift/blob/f745a6435bad737dcb29807cd451326f63327a87/Examples/ConcurrencyContext/main.swift).

If you'd prefer for `OpenTelemetryConcurrency` to get its own product, just let me know and I'm happy to adjust. Thanks!