### PR TITLE
fix: Make arguments of SpanBase's '==' of type Self

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -113,7 +113,7 @@ public extension SpanBase {
         hasher.combine(context.spanId)
     }
 
-    static func == (lhs: SpanBase, rhs: SpanBase) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.context.spanId == rhs.context.spanId
     }
 }


### PR DESCRIPTION
Resolves a compilation failure when built with nightly Swift development snapshots: https://github.com/open-telemetry/opentelemetry-swift/issues/613