### PR TITLE
deprecated root interfaces for old metrics

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
@@ -12,6 +12,7 @@ import OpenTelemetryApi
 import OpenTelemetryProtocolExporterCommon
 import OpenTelemetrySdk
 
+@available(*, deprecated, renamed: "StableOtlpMetricExporter")
 public class OtlpMetricExporter: MetricExporter {
     let channel: GRPCChannel
     var metricClient: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceNIOClient

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OltpHTTPMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OltpHTTPMetricExporter.swift
@@ -14,6 +14,7 @@ public func defaultOltpHTTPMetricsEndpoint() -> URL {
   URL(string: "http://localhost:4318/v1/metrics")!
 }
 
+@available(*, deprecated, renamed: "StableOtlpHTTPMetricExporter")
 public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter {
   var pendingMetrics: [Metric] = []
   private let exporterLock = Lock()

--- a/Sources/OpenTelemetryApi/Metrics/MeterProvider.swift
+++ b/Sources/OpenTelemetryApi/Metrics/MeterProvider.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Creates Meters for an instrumentation library.
 /// Libraries should use this class as follows to obtain Meter instance.
 // Phase 2
-//@available(*, deprecated, renamed: "StableMeterProvider")
+@available(*, deprecated, renamed: "StableMeterProvider")
 public protocol MeterProvider: AnyObject {
     /// Returns a Meter for a given name and version.
     /// - Parameters:

--- a/Sources/OpenTelemetryApi/OpenTelemetry.swift
+++ b/Sources/OpenTelemetryApi/OpenTelemetry.swift
@@ -70,6 +70,7 @@ public struct OpenTelemetry {
         instance.tracerProvider = tracerProvider
     }
 
+    @available(*, deprecated, message: "Use registerStableMeterProvider instead.")
     public static func registerMeterProvider(meterProvider: MeterProvider) {
         instance.meterProvider = meterProvider
     }

--- a/Sources/OpenTelemetrySdk/Metrics/MeterProviderBuilder.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterProviderBuilder.swift
@@ -6,6 +6,9 @@ import Foundation
 
 import OpenTelemetryApi
 
+
+
+@available(*, deprecated, renamed: "StableMeterProviderBuilder")
 public class MeterProviderBuilder {
     public private(set) var resource : Resource = Resource()
     public private(set) var metricExporter : MetricExporter = NoopMetricExporter()

--- a/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
@@ -7,7 +7,7 @@ import Foundation
 import OpenTelemetryApi
 
 // Phase 2
-//@available(*, deprecated, renamed: "StableMeterProviderSdk")
+@available(*, deprecated, renamed: "StableMeterProviderSdk")
 public class MeterProviderSdk: MeterProvider {
     private let lock = Lock()
     public static let defaultPushInterval: TimeInterval = 60

--- a/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterSdk.swift
@@ -12,6 +12,7 @@ public extension Meter {
     }
 }
 
+@available(*, deprecated, renamed: "StableMeterSdk")
 class MeterSdk: Meter {
     fileprivate let collectLock = Lock()
     fileprivate let rawMetricLock = Lock()


### PR DESCRIPTION
I chose to only deprecate the root interfaces for metrics, rather than all the various meters