### PR TITLE
Update OtlpHttpTraceExporter init to support envVarHeaders

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
@@ -20,7 +20,7 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter {
     override
     public init(endpoint: URL = defaultOltpHttpTracesEndpoint(), config: OtlpConfiguration = OtlpConfiguration(),
                 useSession: URLSession? = nil, envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
-        super.init(endpoint: endpoint, config: config, useSession: useSession)
+        super.init(endpoint: endpoint, config: config, useSession: useSession, envVarHeaders: envVarHeaders)
     }
 
     public func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil) -> SpanExporterResultCode {


### PR DESCRIPTION
OtlpHttpTraceExporter init wasn't passing along the envVarHeaders to the super.init() call. 

Seems like a mistake as our implementation wouldn't work without the authorization headers passed along.