### PR TITLE
Modify `toSpanData` to happen inside `attributesLock` to prevent data races

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -192,29 +192,27 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
 
     public func toSpanData() -> SpanData {
-        eventsSyncLock.withLock {
-            attributesSyncLock.withLock {
-                return SpanData(traceId: context.traceId,
-                                spanId: context.spanId,
-                                traceFlags: context.traceFlags,
-                                traceState: context.traceState,
-                                parentSpanId: parentContext?.spanId,
-                                resource: resource,
-                                instrumentationScope: instrumentationScopeInfo,
-                                name: name,
-                                kind: kind,
-                                startTime: startTime,
-                                attributes: attributes.attributes,
-                                events: adaptEvents(),
-                                links: adaptLinks(),
-                                status: status,
-                                endTime: endTime ?? clock.now,
-                                hasRemoteParent: hasRemoteParent,
-                                hasEnded: hasEnded,
-                                totalRecordedEvents: getTotalRecordedEvents(),
-                                totalRecordedLinks: totalRecordedLinks,
-                                totalAttributeCount: totalAttributeCount)
-            }
+        attributesSyncLock.withLock {
+            return SpanData(traceId: context.traceId,
+                            spanId: context.spanId,
+                            traceFlags: context.traceFlags,
+                            traceState: context.traceState,
+                            parentSpanId: parentContext?.spanId,
+                            resource: resource,
+                            instrumentationScope: instrumentationScopeInfo,
+                            name: name,
+                            kind: kind,
+                            startTime: startTime,
+                            attributes: attributes.attributes,
+                            events: adaptEvents(),
+                            links: adaptLinks(),
+                            status: status,
+                            endTime: endTime ?? clock.now,
+                            hasRemoteParent: hasRemoteParent,
+                            hasEnded: hasEnded,
+                            totalRecordedEvents: getTotalRecordedEvents(),
+                            totalRecordedLinks: totalRecordedLinks,
+                            totalAttributeCount: totalAttributeCount)
         }
     }
 

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -192,26 +192,28 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
 
     public func toSpanData() -> SpanData {
-        return SpanData(traceId: context.traceId,
-                        spanId: context.spanId,
-                        traceFlags: context.traceFlags,
-                        traceState: context.traceState,
-                        parentSpanId: parentContext?.spanId,
-                        resource: resource,
-                        instrumentationScope: instrumentationScopeInfo,
-                        name: name,
-                        kind: kind,
-                        startTime: startTime,
-                        attributes: attributes.attributes,
-                        events: adaptEvents(),
-                        links: adaptLinks(),
-                        status: status,
-                        endTime: endTime ?? clock.now,
-                        hasRemoteParent: hasRemoteParent,
-                        hasEnded: hasEnded,
-                        totalRecordedEvents: getTotalRecordedEvents(),
-                        totalRecordedLinks: totalRecordedLinks,
-                        totalAttributeCount: totalAttributeCount)
+        attributesSyncLock.withLock {
+            return SpanData(traceId: context.traceId,
+                            spanId: context.spanId,
+                            traceFlags: context.traceFlags,
+                            traceState: context.traceState,
+                            parentSpanId: parentContext?.spanId,
+                            resource: resource,
+                            instrumentationScope: instrumentationScopeInfo,
+                            name: name,
+                            kind: kind,
+                            startTime: startTime,
+                            attributes: attributes.attributes,
+                            events: adaptEvents(),
+                            links: adaptLinks(),
+                            status: status,
+                            endTime: endTime ?? clock.now,
+                            hasRemoteParent: hasRemoteParent,
+                            hasEnded: hasEnded,
+                            totalRecordedEvents: getTotalRecordedEvents(),
+                            totalRecordedLinks: totalRecordedLinks,
+                            totalAttributeCount: totalAttributeCount)
+        }
     }
 
     private func adaptEvents() -> [SpanData.Event] {

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -192,27 +192,29 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
 
     public func toSpanData() -> SpanData {
-        attributesSyncLock.withLock {
-            return SpanData(traceId: context.traceId,
-                            spanId: context.spanId,
-                            traceFlags: context.traceFlags,
-                            traceState: context.traceState,
-                            parentSpanId: parentContext?.spanId,
-                            resource: resource,
-                            instrumentationScope: instrumentationScopeInfo,
-                            name: name,
-                            kind: kind,
-                            startTime: startTime,
-                            attributes: attributes.attributes,
-                            events: adaptEvents(),
-                            links: adaptLinks(),
-                            status: status,
-                            endTime: endTime ?? clock.now,
-                            hasRemoteParent: hasRemoteParent,
-                            hasEnded: hasEnded,
-                            totalRecordedEvents: getTotalRecordedEvents(),
-                            totalRecordedLinks: totalRecordedLinks,
-                            totalAttributeCount: totalAttributeCount)
+        eventsSyncLock.withLock {
+            attributesSyncLock.withLock {
+                return SpanData(traceId: context.traceId,
+                                spanId: context.spanId,
+                                traceFlags: context.traceFlags,
+                                traceState: context.traceState,
+                                parentSpanId: parentContext?.spanId,
+                                resource: resource,
+                                instrumentationScope: instrumentationScopeInfo,
+                                name: name,
+                                kind: kind,
+                                startTime: startTime,
+                                attributes: attributes.attributes,
+                                events: adaptEvents(),
+                                links: adaptLinks(),
+                                status: status,
+                                endTime: endTime ?? clock.now,
+                                hasRemoteParent: hasRemoteParent,
+                                hasEnded: hasEnded,
+                                totalRecordedEvents: getTotalRecordedEvents(),
+                                totalRecordedLinks: totalRecordedLinks,
+                                totalAttributeCount: totalAttributeCount)
+            }
         }
     }
 


### PR DESCRIPTION
# Overview
This PR addresses a potential data race issue when `toSpanData()` is called concurrently with modifications to `attributes` by wrapping both operations within the same lock. 

## Explanation
When somebody needs to call `toSpanData` during the lifetime of a `Span`, the `toSpanData()` method accesses `attributes` and `totalAttributeCount ` while another thread may be modifying them (each time an `attribute` is added/removed `totalAttributeCount` is also modified), leading to potential crashes or memory corruption.

Fixes #630 