### PR TITLE
Add Request Context to URLSessionInstrumentation Baggage Provider

### DIFF
--- a/Sources/Instrumentation/URLSession/README.md
+++ b/Sources/Instrumentation/URLSession/README.md
@@ -28,5 +28,5 @@ This behaviour can be modified or augmented by using the optional callbacks defi
 
 `receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)?` -  Called after an error is received,  it allows to add extra information to the Span
 
-`baggageProvider: ((URLRequest, Span) -> (Baggage)?)?`: Provides baggage instance for instrumented requests that is merged with active baggage. The callback receives URLRequest and Span parameters to create dynamic baggage based on request context. The resulting baggage is injected into request headers using the configured propagator.
+`baggageProvider: ((inout URLRequest, Span) -> (Baggage)?)?`: Provides baggage instance for instrumented requests that is merged with active baggage. The callback receives URLRequest and Span parameters to create dynamic baggage based on request context. The resulting baggage is injected into request headers using the configured propagator.
 

--- a/Sources/Instrumentation/URLSession/README.md
+++ b/Sources/Instrumentation/URLSession/README.md
@@ -28,4 +28,5 @@ This behaviour can be modified or augmented by using the optional callbacks defi
 
 `receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)?` -  Called after an error is received,  it allows to add extra information to the Span
 
+`baggageProvider: ((URLRequest, Span) -> (Baggage)?)?`: Provides baggage instance for instrumented requests that is merged with active baggage. The callback receives URLRequest and Span parameters to create dynamic baggage based on request context. The resulting baggage is injected into request headers using the configured propagator.
 

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -76,16 +76,15 @@ public struct URLSessionInstrumentationConfiguration {
     ///  The array of URLSession delegate classes that will be instrumented by the library, will autodetect if nil is passed.
     public var delegateClassesToInstrument: [AnyClass]?
 
-    /// Implement this callback to provide a custom baggage instance for all instrumented requests.
-    /// The provided baggage is merged with active baggage (if any) to create a combined baggage.
-    /// The combined baggage is then injected into request headers using the configured `TextMapBaggagePropagator`.
-    /// This allows consistent propagation across requests, regardless of the active context.
+    /// Provides a baggage instance for instrumented requests that is merged with active baggage (if any).
+    /// The callback can be used to define static baggage for all requests or create dynamic baggage
+    /// based on the provided URLRequest and Span parameters.
     /// 
-    /// The callback provides access to the URLRequest and Span, allowing you to enrich the baggage
-    /// content based on request details or span context.
+    /// The resulting baggage is injected into request headers using the configured `TextMapBaggagePropagator`,
+    /// ensuring consistent propagation across requests, regardless of the active context.
     ///
     /// Note: The injected baggage depends on the propagator in use (e.g., W3C or custom).
-    /// Returns: A `Baggage` instance or `nil` if no default baggage is needed.
+    /// Returns: A `Baggage` instance or `nil` if no baggage is needed.
     public let baggageProvider: ((URLRequest, Span?) -> (Baggage)?)?
 
 }

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -25,7 +25,7 @@ public struct URLSessionInstrumentationConfiguration {
                 receivedResponse: ((URLResponse, DataOrFile?, Span) -> Void)? = nil,
                 receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)? = nil,
                 delegateClassesToInstrument: [AnyClass]? = nil,
-                baggageProvider: ((URLRequest, Span?) -> (Baggage)?)? = nil)
+                baggageProvider: ((inout URLRequest, Span?) -> (Baggage)?)? = nil)
     {
         self.shouldRecordPayload = shouldRecordPayload
         self.shouldInstrument = shouldInstrument
@@ -85,6 +85,6 @@ public struct URLSessionInstrumentationConfiguration {
     ///
     /// Note: The injected baggage depends on the propagator in use (e.g., W3C or custom).
     /// Returns: A `Baggage` instance or `nil` if no baggage is needed.
-    public let baggageProvider: ((URLRequest, Span?) -> (Baggage)?)?
+    public let baggageProvider: ((inout URLRequest, Span?) -> (Baggage)?)?
 
 }

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -25,7 +25,7 @@ public struct URLSessionInstrumentationConfiguration {
                 receivedResponse: ((URLResponse, DataOrFile?, Span) -> Void)? = nil,
                 receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)? = nil,
                 delegateClassesToInstrument: [AnyClass]? = nil,
-                defaultBaggageProvider: (() -> (Baggage)?)? = nil)
+                baggageProvider: ((URLRequest, Span?) -> (Baggage)?)? = nil)
     {
         self.shouldRecordPayload = shouldRecordPayload
         self.shouldInstrument = shouldInstrument
@@ -37,7 +37,7 @@ public struct URLSessionInstrumentationConfiguration {
         self.receivedResponse = receivedResponse
         self.receivedError = receivedError
         self.delegateClassesToInstrument = delegateClassesToInstrument
-        self.defaultBaggageProvider = defaultBaggageProvider
+        self.baggageProvider = baggageProvider
     }
 
     // Instrumentation Callbacks
@@ -76,13 +76,16 @@ public struct URLSessionInstrumentationConfiguration {
     ///  The array of URLSession delegate classes that will be instrumented by the library, will autodetect if nil is passed.
     public var delegateClassesToInstrument: [AnyClass]?
 
-    /// Implement this callback to provide a default baggage instance for all instrumented requests.
+    /// Implement this callback to provide a custom baggage instance for all instrumented requests.
     /// The provided baggage is merged with active baggage (if any) to create a combined baggage.
     /// The combined baggage is then injected into request headers using the configured `TextMapBaggagePropagator`.
     /// This allows consistent propagation across requests, regardless of the active context.
+    /// 
+    /// The callback provides access to the URLRequest and Span, allowing you to enrich the baggage
+    /// content based on request details or span context.
     ///
     /// Note: The injected baggage depends on the propagator in use (e.g., W3C or custom).
     /// Returns: A `Baggage` instance or `nil` if no default baggage is needed.
-    public let defaultBaggageProvider: (() -> (Baggage)?)?
+    public let baggageProvider: ((URLRequest, Span?) -> (Baggage)?)?
 
 }

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -157,11 +157,11 @@ class URLSessionLogger {
             return nil
         }
         instrumentation.configuration.injectCustomHeaders?(&request, span)
+        let customBaggage = instrumentation.configuration.baggageProvider?(&request, span)
+
         var instrumentedRequest = request
         objc_setAssociatedObject(instrumentedRequest, URLSessionInstrumentation.instrumentedKey, true, .OBJC_ASSOCIATION_COPY_NONATOMIC)
         let propagators = OpenTelemetry.instance.propagators
-
-        let customBaggage = instrumentation.configuration.baggageProvider?(request, span)
 
         var traceHeaders = tracePropagationHTTPHeaders(span: span,
                                                        customBaggage: customBaggage,

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -161,10 +161,10 @@ class URLSessionLogger {
         objc_setAssociatedObject(instrumentedRequest, URLSessionInstrumentation.instrumentedKey, true, .OBJC_ASSOCIATION_COPY_NONATOMIC)
         let propagators = OpenTelemetry.instance.propagators
 
-        let defaultBaggage = instrumentation.configuration.defaultBaggageProvider?()
+        let customBaggage = instrumentation.configuration.baggageProvider?(request, span)
 
         var traceHeaders = tracePropagationHTTPHeaders(span: span,
-                                                       defaultBaggage: defaultBaggage,
+                                                       customBaggage: customBaggage,
                                                        textMapPropagator: propagators.textMapPropagator,
                                                        textMapBaggagePropagator: propagators.textMapBaggagePropagator)
 
@@ -175,7 +175,7 @@ class URLSessionLogger {
         return instrumentedRequest
     }
 
-    private static func tracePropagationHTTPHeaders(span: Span?, defaultBaggage: Baggage?, textMapPropagator: TextMapPropagator, textMapBaggagePropagator: TextMapBaggagePropagator) -> [String: String] {
+    private static func tracePropagationHTTPHeaders(span: Span?, customBaggage: Baggage?, textMapPropagator: TextMapPropagator, textMapBaggagePropagator: TextMapBaggagePropagator) -> [String: String] {
         var headers = [String: String]()
 
         struct HeaderSetter: Setter {
@@ -195,8 +195,8 @@ class URLSessionLogger {
             activeBaggage.getEntries().forEach { baggageBuilder.put(key: $0.key, value: $0.value, metadata: $0.metadata) }
         }
 
-        if let defaultBaggage {
-            defaultBaggage.getEntries().forEach { baggageBuilder.put(key: $0.key, value: $0.value, metadata: $0.metadata) }
+        if let customBaggage {
+            customBaggage.getEntries().forEach { baggageBuilder.put(key: $0.key, value: $0.value, metadata: $0.metadata) }
         }
 
         let combinedBaggage = baggageBuilder.build()


### PR DESCRIPTION
**Description:**
This PR enhances the `URLSessionInstrumentation` baggage provider by adding `URLRequest` and `Span` parameters to its callback signature. The enhanced provider enables context-aware baggage creation based on request properties and span information, while maintaining compatibility with active baggage merging. This allows for dynamic baggage customization based on request context.