### PR TITLE
added pod trunk push to Tag-And-Release.yml

### DIFF
--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -32,3 +32,11 @@ jobs:
           tag: ${{ steps.check-release.outputs.version }}
           prerelease: true
           generateReleaseNotes: true
+      - name: push cocoapods
+        env: 
+          COCOAPODS_TRUNK_TOKEN=${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        id: cocoapod_trunk_push
+        run: |
+          pod trunk push OpenTelemetry-Swift-Api.podspec --allow-warnings 
+          pod trunk push OpenTelemetry-Swift-Sdk.podspec --allow-warnings --synchronous
+        


### PR DESCRIPTION
This will push our podspecs to trunk when the release job runs.

We won't know if this works or not until the next release. 😬 