### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolCommon/proto/metrics.pb.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/proto/metrics.pb.swift
@@ -705,7 +705,7 @@ public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
   /// events, and is assumed to be monotonic over the values of these events.
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  /// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
   public var sum: Double {
     get {return _sum ?? 0}
     set {_sum = newValue}
@@ -816,7 +816,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   /// events, and is assumed to be monotonic over the values of these events.
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  /// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
   public var sum: Double {
     get {return _sum ?? 0}
     set {_sum = newValue}
@@ -984,7 +984,7 @@ public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint {
   /// events, and is assumed to be monotonic over the values of these events.
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+  /// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
   public var sum: Double = 0
 
   /// (Optional) list of values at different quantiles of the distribution calculated


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.