### PR TITLE
Add stdout metrics exporter

### DIFF
--- a/Sources/Exporters/Stdout/StdoutMetricExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutMetricExporter.swift
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetrySdk
+
+public class StdoutMetricExporter: StableMetricExporter {
+    let isDebug: Bool
+    var aggregationTemporalitySelector: AggregationTemporalitySelector
+    
+    public init(isDebug: Bool, aggregationTemporalitySelector: AggregationTemporalitySelector = AggregationTemporality.alwaysCumulative()) {
+        self.isDebug = isDebug
+        self.aggregationTemporalitySelector = aggregationTemporalitySelector
+    }
+    
+    public func export(metrics: [OpenTelemetrySdk.StableMetricData]) -> OpenTelemetrySdk.ExportResult {
+        if isDebug {
+            for metric in metrics {
+                print(String(repeating: "-", count: 40))
+                print("Name: \(metric.name)")
+                print("Description: \(metric.description)")
+                print("Unit: \(metric.unit)")
+                print("IsMonotonic: \(metric.isMonotonic)")
+                print("Resource: \(metric.resource)")
+                print("InstrumentationScopeInfo: \(metric.instrumentationScopeInfo)")
+                print("Type: \(metric.type)")
+                print("AggregationTemporality: \(metric.data.aggregationTemporality)")
+                if !metric.data.points.isEmpty {
+                    print("DataPoints:")
+                    for point in metric.data.points {
+                        print("  - StartEpochNanos: \(point.startEpochNanos)")
+                        print("    EndEpochNanos: \(point.endEpochNanos)")
+                        print("    Attributes: \(point.attributes)")
+                        print("    Exemplars:")
+                        for exemplar in point.exemplars {
+                            print("      - EpochNanos: \(exemplar.epochNanos)")
+                            if let ctx = exemplar.spanContext {
+                                print("        SpanContext: \(ctx)")
+                            }
+                            print("        FilteredAttributes: \(exemplar.filteredAttributes)")
+                            if let e = exemplar as? DoubleExemplarData {
+                                print("        Value: \(e.value)")
+                            }
+                            if let e = exemplar as? LongExemplarData {
+                                print("        Value: \(e.value)")
+                            }
+                        }
+                    }
+                }
+                print(String(repeating: "-", count: 40) + "\n")
+            }
+        }  else {
+            let jsonEncoder = JSONEncoder()
+            for metric in metrics {
+                do {
+                    let jsonData = try jsonEncoder.encode(metric)
+                    if let jsonString = String(data: jsonData, encoding: .utf8) {
+                        print(jsonString)
+                    }
+                } catch {
+                    print("Failed to serialize Metric as JSON: \(error)")
+                    return .failure
+                }
+            }
+        }
+        
+        return .success
+    }
+    
+    public func flush() -> OpenTelemetrySdk.ExportResult {
+        return .success
+    }
+    
+    public func shutdown() -> OpenTelemetrySdk.ExportResult {
+        return .success
+    }
+    
+    public func getAggregationTemporality(for instrument: OpenTelemetrySdk.InstrumentType) -> OpenTelemetrySdk.AggregationTemporality {
+        return aggregationTemporalitySelector.getAggregationTemporality(for: instrument)
+    }
+}

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/Aggregation/AggregationTemporality.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/Aggregation/AggregationTemporality.swift
@@ -21,7 +21,7 @@ public class AggregationTemporalitySelector : AggregationTemporalitySelectorProt
     public var aggregationTemporalitySelector: (InstrumentType) -> AggregationTemporality
 }
 
-public enum AggregationTemporality {
+public enum AggregationTemporality: Codable {
     case delta
     case cumulative
     

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/Data/ExemplarData.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/Data/ExemplarData.swift
@@ -6,7 +6,7 @@
 import Foundation
 import OpenTelemetryApi
 
-public class ExemplarData: Equatable {
+public class ExemplarData: Equatable, Encodable {
     internal init(epochNanos: UInt64, filteredAttributes: [String: AttributeValue], spanContext: SpanContext? = nil) {
         self.filteredAttributes = filteredAttributes
         self.epochNanos = epochNanos

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/Data/PointData.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/Data/PointData.swift
@@ -6,7 +6,7 @@
 import Foundation
 import OpenTelemetryApi
 
-public class PointData: Equatable {
+public class PointData: Equatable, Encodable {
     internal init(startEpochNanos: UInt64, endEpochNanos: UInt64, attributes: [String: AttributeValue], exemplars: [ExemplarData]) {
         self.startEpochNanos = startEpochNanos
         self.endEpochNanos = endEpochNanos

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/Data/StableMetricData.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/Data/StableMetricData.swift
@@ -6,7 +6,7 @@
 import Foundation
 import OpenTelemetryApi
 
-public enum MetricDataType {
+public enum MetricDataType: Codable {
     case LongGauge
     case DoubleGauge
     case LongSum
@@ -16,7 +16,7 @@ public enum MetricDataType {
     case ExponentialHistogram
 }
 
-public struct StableMetricData: Equatable {
+public struct StableMetricData: Equatable, Encodable {
     public private(set) var resource: Resource
     public private(set) var instrumentationScopeInfo: InstrumentationScopeInfo
     public private(set) var name: String
@@ -28,7 +28,7 @@ public struct StableMetricData: Equatable {
 
     public static let empty = StableMetricData(resource: Resource.empty, instrumentationScopeInfo: InstrumentationScopeInfo(), name: "", description: "", unit: "", type: .Summary, isMonotonic: false, data: StableMetricData.Data(aggregationTemporality: .cumulative, points: [PointData]()))
 
-    public class Data: Equatable {
+    public class Data: Equatable, Encodable {
         public private(set) var points: [PointData]
         public private(set) var aggregationTemporality: AggregationTemporality
 


### PR DESCRIPTION
# Add stdout metrics exporter

Adds the stdout metrics exporter alongside the trace and log stdout exporter.

## Questions:

I've added `Encodable`/`Codable` to some of the types to make the JSON encoding a little easier. This doesn't match the pattern in `StdoutSpanExporter` which uses a wrapper that implements `Codable`. The `StdoutLogExporter` relies on the `ReadableLogRecord` being `Codable`. Is there a pattern that we want to standardize on for the std out exporters?

The `StdoutSpanExporter` encodes each `SpanData` as a separate JSON object whereas the `StdoutLogExporter` encodes the array of `ReadableLogRecord` instead of the individual objects. Do we want to standardize on one of these patterns for all of the std out exporters? I couldn't discern from the spec if either of these is the "correct" way to do it.

The other two std out exporters lack tests and so I've not added any for this one. Is this a blocker to merging?

## Sample Output:

```
----------------------------------------
Name: name
Description: description
Unit: m
IsMonotonic: true
Resource: Resource(attributes: ["telemetry.sdk.name": opentelemetry, "service.name": unknown_service:xctest, "telemetry.sdk.language": swift, "telemetry.sdk.version": 1.12.1])
InstrumentationScopeInfo: InstrumentationScopeInfo(name: "name", version: Optional("1.0"), schemaUrl: Optional("https://honeycomb.io"))
Type: DoubleSum
AggregationTemporality: cumulative
DataPoints:
  - StartEpochNanos: 199
    EndEpochNanos: 199
    Attributes: ["attribute": 1.0]
    Exemplars:
      - EpochNanos: 0
        SpanContext: SpanContext{traceId=TraceId{traceId=00000000000000000000000000000000}, spanId=SpanId{spanId=0000000000000000}, traceFlags=TraceFlags{sampled=false}}, isRemote=false
        FilteredAttributes: ["filtered attribute": two]
        Value: 1.0
----------------------------------------
```

```
{"description":"description","isMonotonic":true,"resource":{"attributes":{"telemetry.sdk.version":{"string":{"_0":"1.12.1"}},"telemetry.sdk.language":{"string":{"_0":"swift"}},"telemetry.sdk.name":{"string":{"_0":"opentelemetry"}},"service.name":{"string":{"_0":"unknown_service:xctest"}}}},"type":{"DoubleSum":{}},"data":{"points":[{"attributes":{"attribute":{"double":{"_0":1}}},"exemplars":[{"spanContext":{"traceState":{"entries":[]},"traceId":{"idHi":0,"idLo":0},"spanId":{"id":0},"isRemote":false,"traceFlags":{"options":0}},"filteredAttributes":{"filtered attribute":{"string":{"_0":"two"}}},"epochNanos":0}],"startEpochNanos":199,"endEpochNanos":199}],"aggregationTemporality":{"cumulative":{}}},"name":"name","unit":"m","instrumentationScopeInfo":{"schemaUrl":"https:\/\/honeycomb.io","name":"name","version":"1.0"}}
```