### PR TITLE
Add cocoapods for Exporters and Instrumentation libraries

### DIFF
--- a/.github/workflows/Create-Release-PR.yml
+++ b/.github/workflows/Create-Release-PR.yml
@@ -32,6 +32,11 @@ jobs:
       run: | 
         sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Api.podspec    
         sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Sdk.podspec    
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-DataCompression.podspec    
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Protocol-Exporter-Common.podspec    
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Protocol-Exporter-Http.podspec    
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-SdkResourceExtension.podspec    
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-StoutExporter.podspec    
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -39,4 +39,9 @@ jobs:
         run: |
           pod trunk push OpenTelemetry-Swift-Api.podspec --allow-warnings 
           pod trunk push OpenTelemetry-Swift-Sdk.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-DataCompression.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-Protocol-Exporter-Common.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-SdkResourceExtension.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-Protocol-Exporter-Http.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-StdoutExporter.podspec --allow-warnings --synchronous
         

--- a/OpenTelemetry-Swift-DataCompression.podspec
+++ b/OpenTelemetry-Swift-DataCompression.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-DataCompression"
+  spec.version = "1.13.0"
+  spec.summary = "Swift OpenTelemetry Data Compression"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Exporters/DataCompression/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "DataCompression"
+
+  spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name DataCompression -package-name opentelemetry_swift_data_compression" }
+
+end

--- a/OpenTelemetry-Swift-Protocol-Exporter-Common.podspec
+++ b/OpenTelemetry-Swift-Protocol-Exporter-Common.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-Protocol-Exporter-Common"
+  spec.version = "1.13.0"
+  spec.summary = "Swift OpenTelemetry Protocol Exporter Common"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Exporters/OpenTelemetryProtocolCommon/**/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "OpenTelemetryProtocolExporterCommon"
+
+  spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
+  spec.dependency 'SwiftProtobuf', '~> 1.28'
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name OpenTelemetryProtocolExporterCommon -package-name opentelemetry_swift_exporter_common" }
+
+end

--- a/OpenTelemetry-Swift-Protocol-Exporter-Http.podspec
+++ b/OpenTelemetry-Swift-Protocol-Exporter-Http.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-Protocol-Exporter-Http"
+  spec.version = "1.13.0"
+  spec.summary = "Swift OpenTelemetry Protocol Exporter Common"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Exporters/OpenTelemetryProtocolHttp/**/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "OpenTelemetryProtocolExporterHttp"
+
+  spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Protocol-Exporter-Common', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-DataCompression', spec.version.to_s
+  spec.dependency 'SwiftProtobuf', '~> 1.28'
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name OpenTelemetryProtocolExporterHttp -package-name opentelemetry_swift_exporter_http" }
+
+end

--- a/OpenTelemetry-Swift-SdkResourceExtension.podspec
+++ b/OpenTelemetry-Swift-SdkResourceExtension.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-SdkResourceExtension"
+  spec.version = "1.13.0"
+  spec.summary = "Swift OpenTelemetry Resource Extension"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Instrumentation/SDKResourceExtension/**/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "ResourceExtension"
+
+  spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name ResourceExtension -package-name opentelemetry_swift_resource_extension" }
+
+end

--- a/OpenTelemetry-Swift-StdoutExporter.podspec
+++ b/OpenTelemetry-Swift-StdoutExporter.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-StdoutExporter"
+  spec.version = "1.13.0"
+  spec.summary = "Swift OpenTelemetry Standard output Exporter"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Exporters/Stdout/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "StdoutExporter"
+
+  spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name StdoutExporter -package-name opentelemetry_swift_stdout_exporter" }
+
+end


### PR DESCRIPTION
Currently there are only two published cocoapods (the SDK and the API) for developers using cocoapods for their dependency management they would not be able to use common instrumentation and span exporters.

This PR ads several such as the HTTP exporter which is commonly used.