### PR TITLE
Fix memory leaks in `DeviceDataSource`

### DIFF
--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift
@@ -34,6 +34,14 @@ public class DeviceDataSource: IDeviceDataSource {
 
             let machine = UnsafeMutablePointer<CChar>.allocate(capacity: desiredLen[0])
             let len: UnsafeMutablePointer<Int>! = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+
+            defer {
+                hwName.deallocate()
+                desiredLen.deallocate()
+                machine.deallocate()
+                len.deallocate()
+            }
+        
             len[0] = desiredLen[0]
 
             let modelRequestError = sysctl(hwName, 2, machine, len, nil, 0)


### PR DESCRIPTION
# Overview
The implementation of `DeviceDataSource.model` allocates memory using `UnsafeMutablePointer.allocate(capacity:)` but does not properly release it, leading to memory leaks.

This fixes #677 