### PR TITLE
Fix Linux builds that aren't using the Swift 6 language mode

### DIFF
--- a/Sources/OpenTelemetrySdk/Common/WorkerThread.swift
+++ b/Sources/OpenTelemetrySdk/Common/WorkerThread.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if (swift(>=6) && os(Linux)) || OPENTELEMETRY_SWIFT_LINUX_COMPAT
+#if (compiler(>=6) && os(Linux)) || OPENTELEMETRY_SWIFT_LINUX_COMPAT
   // https://github.com/open-telemetry/opentelemetry-swift/issues/615 prevents Linux builds from succeeding due to a regression in Swift 6 when subclassing Thread. We can work around this by using a block based Thread.
   class WorkerThread {
     var thread: Thread!


### PR DESCRIPTION
I used `#if swift(>=6)` when determining when to use the workaround, but I should have used `#if compiler(>=6)` so building with the Swift 5 language mode in the Swift 6 compiler would still work.