### PR TITLE
add support for setting exemplar filter

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Stable/Exemplar/ExemplarFilter.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/Exemplar/ExemplarFilter.swift
@@ -12,6 +12,8 @@ public protocol ExemplarFilter {
 }
 
 public struct AlwaysOnFilter: ExemplarFilter {
+  public init() {}
+
   public func shouldSampleMeasurement(value: Double, attributes: [String: OpenTelemetryApi.AttributeValue]) -> Bool {
     return true
   }

--- a/Sources/OpenTelemetrySdk/Metrics/Stable/StableMeterProviderBuilder.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Stable/StableMeterProviderBuilder.swift
@@ -35,6 +35,11 @@ public class StableMeterProviderBuilder {
     return self
   }
 
+  public func setExemplarFilter(exemplarFilter: ExemplarFilter) -> Self {
+    self.exemplarFilter = exemplarFilter
+    return self
+  }
+
   public func build() -> StableMeterProviderSdk {
     StableMeterProviderSdk(registeredViews: registeredViews, metricReaders: metricReaders, clock: clock, resource: resource, exemplarFilter: exemplarFilter)
   }


### PR DESCRIPTION
Exposes the ability to set the exemplar filter on the meter provider builder.