### PR TITLE
Fix `exception.type` when recording Swift Errors

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/SpanException.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanException.swift
@@ -14,7 +14,7 @@ public protocol SpanException {
 
 extension NSError: SpanException {
   public var type: String {
-    String(reflecting: self)
+    String(code)
   }
 
   public var message: String? {


### PR DESCRIPTION
# Overview
This PR fixes an issue where `NSError` instances created by casting from `Error` would result in `SpanException.type` being set to the description of the Swift error, instead of the expected type.

# Details
In cases where the `Error` type does not conform to `CustomNSError`, the cast to `NSError` always defaults to:
- `domain`: `"Swift.Error"`
- `code`: 0

This fix ensures that `SpanException.type` uses the `NSError.code` (converted to a string), which aligns with the idea of this functionality.

Fixes #741 
