### PR TITLE
Fix infinite recursion bug when getting tracer

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/TracerProvider.swift
+++ b/Sources/OpenTelemetryApi/Trace/TracerProvider.swift
@@ -13,24 +13,40 @@ public protocol TracerProvider {
   ///   - instrumentationVersion:  The version of the instrumentation library (e.g., "semver:1.0.0"). Optional
   ///   - schemaUrl: The schema url. Optional
   ///   - attributes: attributes to be associated with span created by this tracer. Optional
-  func get(
-    instrumentationName: String,
-    instrumentationVersion: String?,
-    schemaUrl: String?,
-    attributes: [String: AttributeValue]?
-  ) -> any Tracer
+  func get(instrumentationName: String,
+           instrumentationVersion: String?,
+           schemaUrl: String?,
+           attributes: [String: AttributeValue]?) -> any Tracer
 }
 
 public extension TracerProvider {
+  func get(instrumentationName: String) -> any Tracer {
+    get(
+      instrumentationName: instrumentationName,
+      instrumentationVersion: nil,
+      schemaUrl: nil,
+      attributes: nil
+    )
+  }
+
   func get(instrumentationName: String,
-           instrumentationVersion: String? = nil,
-           schemaUrl: String? = nil,
-           attributes: [String: AttributeValue]? = nil) -> any Tracer {
-    return get(
+           instrumentationVersion: String?) -> any Tracer {
+    get(
+      instrumentationName: instrumentationName,
+      instrumentationVersion: instrumentationVersion,
+      schemaUrl: nil,
+      attributes: nil
+    )
+  }
+
+  func get(instrumentationName: String,
+           instrumentationVersion: String?,
+           schemaUrl: String?) -> any Tracer {
+    get(
       instrumentationName: instrumentationName,
       instrumentationVersion: instrumentationVersion,
       schemaUrl: schemaUrl,
-      attributes: attributes
+      attributes: nil
     )
   }
 }


### PR DESCRIPTION
`tracerProvider.get(instrumentationName: "Foo")` results in an infinitely recursive call after recent changes in https://github.com/open-telemetry/opentelemetry-swift/commit/5839cb581053ad36659acc79302615bc2f75de98

![image](https://github.com/user-attachments/assets/25e50b6e-b5aa-49cb-a505-cbcaffd40b2f)
