### PR TITLE
add podspecs for more targets

### DIFF
--- a/.github/workflows/Create-Release-PR.yml
+++ b/.github/workflows/Create-Release-PR.yml
@@ -30,13 +30,17 @@ jobs:
        ' > Sources/OpenTelemetrySdk/Version.swift
     - name: update Podspec
       run: | 
-        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Api.podspec    
-        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Sdk.podspec    
-        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-DataCompression.podspec    
-        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Protocol-Exporter-Common.podspec    
-        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Protocol-Exporter-Http.podspec    
-        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-SdkResourceExtension.podspec    
-        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-StdoutExporter.podspec    
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Api.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Sdk.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-BaggagePropagationProcessor.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-DataCompression.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Instrumentation-URLSession.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Protocol-Exporter-Common.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Protocol-Exporter-Http.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-SdkResourceExtension.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-StdoutExporter.podspec
+        sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-PersistenceExporter.podspec
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -39,9 +39,13 @@ jobs:
         run: |
           pod trunk push OpenTelemetry-Swift-Api.podspec --allow-warnings 
           pod trunk push OpenTelemetry-Swift-Sdk.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-BaggagePropagationProcessor.podspec --allow-warnings --synchronous
           pod trunk push OpenTelemetry-Swift-DataCompression.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-Instrumentation-URLSession.podspec --allow-warnings --synchronous
           pod trunk push OpenTelemetry-Swift-Protocol-Exporter-Common.podspec --allow-warnings --synchronous
           pod trunk push OpenTelemetry-Swift-SdkResourceExtension.podspec --allow-warnings --synchronous
           pod trunk push OpenTelemetry-Swift-Protocol-Exporter-Http.podspec --allow-warnings --synchronous
+          pod trunk push OpenTelemetry-Swift-PersistenceExporter.podspec --allow-warnings --synchronous
           pod trunk push OpenTelemetry-Swift-StdoutExporter.podspec --allow-warnings --synchronous
         

--- a/OpenTelemetry-Swift-BaggagePropagationProcessor.podspec
+++ b/OpenTelemetry-Swift-BaggagePropagationProcessor.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-BaggagePropagationProcessor"
+  spec.version = "1.15.0"
+  spec.summary = "Swift OpenTelemetry Baggage Propagation Processor"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Contrib/Processors/BaggagePropagationProcessor/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "BaggagePropagationProcessor"
+
+  spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name BaggagePropagationProcessor -package-name opentelemetry_swift_baggage_propagation_processor" }
+
+end

--- a/OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
+++ b/OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-Instrumentation-NetworkStatus"
+  spec.version = "1.15.0"
+  spec.summary = "Swift OpenTelemetry Network Status Instrumentation"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Instrumentation/NetworkStatus/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "NetworkStatus"
+
+  spec.frameworks = 'CoreTelephony'
+  spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name NetworkStatus -package-name opentelemetry_swift_network_status" }
+
+end

--- a/OpenTelemetry-Swift-Instrumentation-URLSession.podspec
+++ b/OpenTelemetry-Swift-Instrumentation-URLSession.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-Instrumentation-URLSession"
+  spec.version = "1.15.0"
+  spec.summary = "Swift OpenTelemetry URLSession Instrumentation"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Instrumentation/URLSession/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "URLSession"
+
+  spec.dependency 'OpenTelemetry-Swift-Instrumentation-URLSession', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name URLSession -package-name opentelemetry_swift_urlsession" }
+
+end

--- a/OpenTelemetry-Swift-PersistenceExporter.podspec
+++ b/OpenTelemetry-Swift-PersistenceExporter.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-PersistenceExporter"
+  spec.version = "1.15.0"
+  spec.summary = "Swift OpenTelemetry Persistence Exporter"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+  spec.source_files = "Sources/Exporters/Persistence/**/*.swift"
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "PersistenceExporter"
+
+  spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name PersistenceExporter -package-name opentelemetry_swift_persistence_exporter" }
+
+end


### PR DESCRIPTION
This PR adds podspecs for more of the targets that are already in `Package.swift`. I did my best to choose names consistent with the existing podspecs.

I tested these by making a local project using cocoapods, adding these targets as dependencies, and pointing them to the local checkout of the repo.

Note: When pointing at the released versions of the existing pods, I was able to use version 1.13, but 1.15 was not found, so I think there may be some problem with the release workflow. I tried to verify on cocoapods.org, but the repo didn't show up there at all.