### PR TITLE
Fixed Tag & Release workflow not being able to push to CocoaPods

### DIFF
--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -7,7 +7,7 @@ on :
       - closed
 jobs:
   CheckRelease:
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     steps:
       - name: Check if merge is release branch
         id: check-release


### PR DESCRIPTION
# Overview 
This PR fixes the Tag & Note (`Tag-And-Release.yml`) workflow by switching the runner to macOS.
The job was failing when trying to push to CocoaPods because it was using a Linux runner, and CocoaPods isn’t available there.

More information about this issue can be found [here](https://github.com/open-telemetry/opentelemetry-swift/pull/769).