### PR TITLE
Move tracer to Configuration to support tracer config changes after swizzle

### DIFF
--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -43,8 +43,6 @@ public class URLSessionInstrumentation {
   ]
   .compactMap { NSClassFromString($0) }
 
-  public private(set) var tracer: Tracer
-
   public var startedRequestSpans: [Span] {
     var spans = [Span]()
     URLSessionLogger.runningSpansQueue.sync {
@@ -55,7 +53,6 @@ public class URLSessionInstrumentation {
 
   public init(configuration: URLSessionInstrumentationConfiguration) {
     self.configuration = configuration
-    tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: "NSURLSession", instrumentationVersion: "0.0.1")
     injectInNSURLClasses()
   }
 

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -25,7 +25,8 @@ public struct URLSessionInstrumentationConfiguration {
               receivedResponse: ((URLResponse, DataOrFile?, Span) -> Void)? = nil,
               receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)? = nil,
               delegateClassesToInstrument: [AnyClass]? = nil,
-              baggageProvider: ((inout URLRequest, Span?) -> (Baggage)?)? = nil) {
+              baggageProvider: ((inout URLRequest, Span?) -> (Baggage)?)? = nil,
+              tracer: Tracer? = nil) {
     self.shouldRecordPayload = shouldRecordPayload
     self.shouldInstrument = shouldInstrument
     self.shouldInjectTracingHeaders = shouldInjectTracingHeaders
@@ -37,8 +38,12 @@ public struct URLSessionInstrumentationConfiguration {
     self.receivedError = receivedError
     self.delegateClassesToInstrument = delegateClassesToInstrument
     self.baggageProvider = baggageProvider
+    self.tracer = tracer ??
+      OpenTelemetry.instance.tracerProvider.get(instrumentationName: "NSURLSession", instrumentationVersion: "0.0.1")
   }
 
+  public var tracer: Tracer
+ 
   // Instrumentation Callbacks
 
   /// Implement this callback to filter which requests you want to instrument, all by default

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -70,7 +70,8 @@ class URLSessionLogger {
     if let customSpanName = instrumentation.configuration.nameSpan?(request) {
       spanName = customSpanName
     }
-    let spanBuilder = instrumentation.tracer.spanBuilder(spanName: spanName)
+    let tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: "NSURLSession", instrumentationVersion: "0.0.1")
+    let spanBuilder = tracer.spanBuilder(spanName: spanName)
     spanBuilder.setSpanKind(spanKind: .client)
     attributes.forEach {
       spanBuilder.setAttribute(key: $0.key, value: $0.value)

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -70,8 +70,7 @@ class URLSessionLogger {
     if let customSpanName = instrumentation.configuration.nameSpan?(request) {
       spanName = customSpanName
     }
-    let tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: "NSURLSession", instrumentationVersion: "0.0.1")
-    let spanBuilder = tracer.spanBuilder(spanName: spanName)
+    let spanBuilder = instrumentation.configuration.tracer.spanBuilder(spanName: spanName)
     spanBuilder.setSpanKind(spanKind: .client)
     attributes.forEach {
       spanBuilder.setAttribute(key: $0.key, value: $0.value)


### PR DESCRIPTION
Closes #756 

Instead of storing reference to current Tracer on the UrlSessionInstrumentationClass, move it to the UrlSessionInstrumentationConfiguration object. This allows runtime changes to the underlying TracerProvider after the UrlSession has already been swizzled