### PR TITLE
fix: replace circular in podspec with correct dependency.

### DIFF
--- a/OpenTelemetry-Swift-Instrumentation-URLSession.podspec
+++ b/OpenTelemetry-Swift-Instrumentation-URLSession.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |spec|
   spec.watchos.deployment_target = "6.0"
   spec.module_name = "URLSession"
 
-  spec.dependency 'OpenTelemetry-Swift-Instrumentation-URLSession', spec.version.to_s
+  spec.dependency 'OpenTelemetry-Swift-Instrumentation-NetworkStatus', spec.version.to_s
   spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s
   spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name URLSession -package-name opentelemetry_swift_urlsession" }
 


### PR DESCRIPTION
I think this _might_ be the underlying cause of issue #794. It fixes a different problem that gets flagged with `pod spec lint`. When I modify cocoapods to print proper error messages and run `pod spec lint OpenTelemetry-Swift-Api.podspec --verbose`, it flags this same error, even though it's in a different file.

`pod spec lint` still fails, because it's loading the released versions of the specs from github instead of the local versions.

However, `pod spec lint --quick` fails before this change, and passes after.

I'm trying to find a better way to test these, but since this fix is so obvious, I don't think it should wait.