### PR TITLE
Safeguard parameters in BatchSpanProcessor init

### DIFF
--- a/Sources/OpenTelemetrySdk/Logs/Processors/BatchLogRecordProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Processors/BatchLogRecordProcessor.swift
@@ -45,7 +45,12 @@ public class BatchLogRecordProcessor: LogRecordProcessor {
       safeMaxExportBatchSize = 512
     }
 
-    worker = BatchWorker(logRecordExporter: logRecordExporter, scheduleDelay: scheduleDelay, exportTimeout: exportTimeout, maxQueueSize: maxQueueSize, maxExportBatchSize: maxExportBatchSize, willExportCallback: willExportCallback)
+    worker = BatchWorker(logRecordExporter: logRecordExporter,
+                         scheduleDelay: safeScheduleDelay,
+                         exportTimeout: safeExportTimeout,
+                         maxQueueSize: safeMaxQueueSize,
+                         maxExportBatchSize: safeMaxExportBatchSize,
+                         willExportCallback: willExportCallback)
 
     worker.start()
   }

--- a/Sources/OpenTelemetrySdk/Logs/Processors/BatchLogRecordProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Processors/BatchLogRecordProcessor.swift
@@ -9,7 +9,42 @@ import OpenTelemetryApi
 public class BatchLogRecordProcessor: LogRecordProcessor {
   fileprivate var worker: BatchWorker
 
-  public init(logRecordExporter: LogRecordExporter, scheduleDelay: TimeInterval = 5, exportTimeout: TimeInterval = 30, maxQueueSize: Int = 2048, maxExportBatchSize: Int = 512, willExportCallback: ((inout [ReadableLogRecord]) -> Void)? = nil) {
+  let safeScheduleDelay: TimeInterval
+  let safeExportTimeout: TimeInterval
+  let safeMaxQueueSize: Int
+  let safeMaxExportBatchSize: Int
+
+  public init(logRecordExporter: LogRecordExporter,
+              scheduleDelay: TimeInterval = 5,
+              exportTimeout: TimeInterval = 30,
+              maxQueueSize: Int = 2048,
+              maxExportBatchSize: Int = 512,
+              willExportCallback: ((inout [ReadableLogRecord]) -> Void)? = nil) {
+    if scheduleDelay >= 0 {
+      safeScheduleDelay = scheduleDelay
+    } else {
+      print("scheduleDelay (\(scheduleDelay)) < 0, fallback to default 5.")
+      safeScheduleDelay = 5
+    }
+    if exportTimeout >= 0 {
+      safeExportTimeout = exportTimeout
+    } else {
+      print("exportTimeout (\(exportTimeout)) < 0, fallback to default 30.")
+      safeExportTimeout = 30
+    }
+    if maxQueueSize > 0 {
+      safeMaxQueueSize = maxQueueSize
+    } else {
+      print("maxQueueSize (\(maxQueueSize)) <= 0, fallback to default 2048.")
+      safeMaxQueueSize = 2048
+    }
+    if maxExportBatchSize > 0 {
+      safeMaxExportBatchSize = maxExportBatchSize
+    } else {
+      print("maxExportBatchSize (\(maxExportBatchSize)) <= 0, fallback to default 512.")
+      safeMaxExportBatchSize = 512
+    }
+
     worker = BatchWorker(logRecordExporter: logRecordExporter, scheduleDelay: scheduleDelay, exportTimeout: exportTimeout, maxQueueSize: maxQueueSize, maxExportBatchSize: maxExportBatchSize, willExportCallback: willExportCallback)
 
     worker.start()

--- a/Sources/OpenTelemetrySdk/Trace/SpanProcessors/BatchSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanProcessors/BatchSpanProcessor.swift
@@ -25,6 +25,11 @@ public struct BatchSpanProcessor: SpanProcessor {
     String(describing: Self.self)
   }
 
+  let safeScheduleDelay: TimeInterval
+  let safeExportTimeout: TimeInterval
+  let safeMaxQueueSize: Int
+  let safeMaxExportBatchSize: Int
+
   public init(spanExporter: SpanExporter,
               meterProvider: (any StableMeterProvider)? = nil,
               scheduleDelay: TimeInterval = 5,
@@ -32,15 +37,30 @@ public struct BatchSpanProcessor: SpanProcessor {
               maxQueueSize: Int = 2048,
               maxExportBatchSize: Int = 512,
               willExportCallback: ((inout [SpanData]) -> Void)? = nil) {
-    assert(scheduleDelay >= 0, "scheduleDelay (\(scheduleDelay)) < 0, fallback to default 5.")
-    assert(exportTimeout >= 0, "exportTimeout (\(exportTimeout)) < 0, fallback to default 30.")
-    assert(maxQueueSize > 0, "maxQueueSize (\(maxQueueSize)) <= 0, fallback to default 2048.")
-    assert(maxExportBatchSize > 0, "maxExportBatchSize (\(maxExportBatchSize)) <= 0, fallback to default 512.")
-
-    let safeScheduleDelay: TimeInterval = scheduleDelay >= 0 ? scheduleDelay : 5
-    let safeExportTimeout: TimeInterval = exportTimeout >= 0 ? exportTimeout : 30
-    let safeMaxQueueSize: Int = maxQueueSize > 0 ? maxQueueSize : 2048
-    let safeMaxExportBatchSize: Int = maxExportBatchSize > 0 ? maxExportBatchSize : 512
+    if scheduleDelay >= 0 {
+      safeScheduleDelay = scheduleDelay
+    } else {
+      print("scheduleDelay (\(scheduleDelay)) < 0, fallback to default 5.")
+      safeScheduleDelay = 5
+    }
+    if exportTimeout >= 0 {
+      safeExportTimeout = exportTimeout
+    } else {
+      print("exportTimeout (\(exportTimeout)) < 0, fallback to default 30.")
+      safeExportTimeout = 30
+    }
+    if maxQueueSize > 0 {
+      safeMaxQueueSize = maxQueueSize
+    } else {
+      print("maxQueueSize (\(maxQueueSize)) <= 0, fallback to default 2048.")
+      safeMaxQueueSize = 2048
+    }
+    if maxExportBatchSize > 0 {
+      safeMaxExportBatchSize = maxExportBatchSize
+    } else {
+      print("maxExportBatchSize (\(maxExportBatchSize)) <= 0, fallback to default 512.")
+      safeMaxExportBatchSize = 512
+    }
 
     worker = BatchWorker(spanExporter: spanExporter,
                          meterProvider: meterProvider,

--- a/Sources/OpenTelemetrySdk/Trace/SpanProcessors/BatchSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanProcessors/BatchSpanProcessor.swift
@@ -32,12 +32,22 @@ public struct BatchSpanProcessor: SpanProcessor {
               maxQueueSize: Int = 2048,
               maxExportBatchSize: Int = 512,
               willExportCallback: ((inout [SpanData]) -> Void)? = nil) {
+    assert(scheduleDelay >= 0, "scheduleDelay (\(scheduleDelay)) < 0, fallback to default 5.")
+    assert(exportTimeout >= 0, "exportTimeout (\(exportTimeout)) < 0, fallback to default 30.")
+    assert(maxQueueSize > 0, "maxQueueSize (\(maxQueueSize)) <= 0, fallback to default 2048.")
+    assert(maxExportBatchSize > 0, "maxExportBatchSize (\(maxExportBatchSize)) <= 0, fallback to default 512.")
+
+    let safeScheduleDelay: TimeInterval = scheduleDelay >= 0 ? scheduleDelay : 5
+    let safeExportTimeout: TimeInterval = exportTimeout >= 0 ? exportTimeout : 30
+    let safeMaxQueueSize: Int = maxQueueSize > 0 ? maxQueueSize : 2048
+    let safeMaxExportBatchSize: Int = maxExportBatchSize > 0 ? maxExportBatchSize : 512
+
     worker = BatchWorker(spanExporter: spanExporter,
                          meterProvider: meterProvider,
-                         scheduleDelay: scheduleDelay,
-                         exportTimeout: exportTimeout,
-                         maxQueueSize: maxQueueSize,
-                         maxExportBatchSize: maxExportBatchSize,
+                         scheduleDelay: safeScheduleDelay,
+                         exportTimeout: safeExportTimeout,
+                         maxQueueSize: safeMaxQueueSize,
+                         maxExportBatchSize: safeMaxExportBatchSize,
                          willExportCallback: willExportCallback)
     worker.start()
   }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/SpanAdapterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/SpanAdapterTests.swift
@@ -23,7 +23,7 @@ class SpanAdapterTests: XCTestCase {
     spanContext = SpanContext.create(traceId: traceId, spanId: spanId, traceFlags: TraceFlags(), traceState: tracestate)
   }
 
-  func testToPRotoResourceSpans() {
+  func testToProtoResourceSpans() {
     let libInfo = InstrumentationScopeInfo(name: "testScope", version: "semver:0.0.1")
 
     let event = RecordEventsReadableSpan.startSpan(context: spanContext, name: "GET /api/endpoint", instrumentationScopeInfo: libInfo, kind: SpanKind.server, parentContext: nil, hasRemoteParent: false, spanLimits: SpanLimits(), spanProcessor: NoopSpanProcessor(), clock: MillisClock(), resource: Resource(), attributes: AttributesDictionary(capacity: 0), links: [], totalRecordedLinks: 0, startTime: Date())

--- a/Tests/OpenTelemetrySdkTests/Logs/BatchLogRecordProcessorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Logs/BatchLogRecordProcessorTests.swift
@@ -121,6 +121,43 @@ class BatchLogRecordProcessorTests: XCTestCase {
     // Interestingly, this will always succeed on macOS even if you intentionally create a strong reference cycle between the BatchWorker and the Thread's closure. I assume either calling cancel or the thread exiting releases the closure which breaks the cycle. This is not the case on Linux where the test will fail as expected.
     XCTAssertNil(exporter)
   }
+
+  func testInitializeWithDefaultParameters() {
+    let processor = BatchLogRecordProcessor(logRecordExporter: WaitingLogRecordExporter(numberToWaitFor: 0))
+    XCTAssertEqual(processor.safeScheduleDelay, 5)
+    XCTAssertEqual(processor.safeExportTimeout, 30)
+    XCTAssertEqual(processor.safeMaxQueueSize, 2048)
+    XCTAssertEqual(processor.safeMaxExportBatchSize, 512)
+  }
+
+  func testInitializeWithValidParameters() {
+    let processor = BatchLogRecordProcessor(
+      logRecordExporter: WaitingLogRecordExporter(numberToWaitFor: 0),
+      scheduleDelay: 99,
+      exportTimeout: 99,
+      maxQueueSize: 99,
+      maxExportBatchSize: 99
+    )
+    XCTAssertEqual(processor.safeScheduleDelay, 99)
+    XCTAssertEqual(processor.safeExportTimeout, 99)
+    XCTAssertEqual(processor.safeMaxQueueSize, 99)
+    XCTAssertEqual(processor.safeMaxExportBatchSize, 99)
+  }
+
+  func testInitializeWithInvalidParameters() {
+    let processor = BatchLogRecordProcessor(
+      logRecordExporter: WaitingLogRecordExporter(numberToWaitFor: 0),
+      scheduleDelay: -99,
+      exportTimeout: -99,
+      maxQueueSize: 0,
+      maxExportBatchSize: 0
+    )
+    // Fallback to default parameters
+    XCTAssertEqual(processor.safeScheduleDelay, 5)
+    XCTAssertEqual(processor.safeExportTimeout, 30)
+    XCTAssertEqual(processor.safeMaxQueueSize, 2048)
+    XCTAssertEqual(processor.safeMaxExportBatchSize, 512)
+  }
 }
 
 class BlockingLogRecordExporter: LogRecordExporter {


### PR DESCRIPTION
## Summary

- Add parameter validation and fallback defaults to `BatchSpanProcessor` initializer.
- Use `assert` statements in debug builds to catch invalid input.
- Automatically fallback to documented default values if input is invalid.
- This improves the library's robustness and prevents misconfiguration from causing runtime failures, while keeping the production behavior silent and predictable.

## Details

- If `scheduleDelay` < 0, fallback to 5.
- If `exportTimeout` < 0, fallback to 30.
- If `maxQueueSize` <= 0, fallback to 2048.
- If `maxExportBatchSize` <= 0, fallback to 512.

## Motivation

This change was motivated by a real-world crash. One time I accidentally passed `maxExportBatchSize = 0` when initializing a `BatchSpanProcessor`, which caused the app to crash at runtime, which root cause is the following code in `BatchWorker`:

```swift
stride(from: 0, to: spanList.endIndex, by: maxExportBatchSize).forEach { ... }
```

If `maxExportBatchSize` is less than or equal to 0, the stride step becomes invalid, causing an immediate crash.

To prevent this, we now validate all parameters and fallback to safe defaults if any are invalid, ensuring that the stride step and other logic always receive a positive value.

## Unit tests

```
Test Case '-[OpenTelemetrySdkTests.BatchSpansProcessorTests testInitializeWithDefaultParameters]' started.
Test Case '-[OpenTelemetrySdkTests.BatchSpansProcessorTests testInitializeWithDefaultParameters]' passed (0.000 seconds).
Test Case '-[OpenTelemetrySdkTests.BatchSpansProcessorTests testInitializeWithInvalidParameters]' started.
Test Case '-[OpenTelemetrySdkTests.BatchSpansProcessorTests testInitializeWithInvalidParameters]' passed (0.000 seconds).
Test Case '-[OpenTelemetrySdkTests.BatchSpansProcessorTests testInitializeWithValidParameters]' started.
Test Case '-[OpenTelemetrySdkTests.BatchSpansProcessorTests testInitializeWithValidParameters]' passed (0.000 seconds).

Test Case '-[OpenTelemetrySdkTests.BatchLogRecordProcessorTests testInitializeWithDefaultParameters]' started.
Test Case '-[OpenTelemetrySdkTests.BatchLogRecordProcessorTests testInitializeWithDefaultParameters]' passed (0.001 seconds).
Test Case '-[OpenTelemetrySdkTests.BatchLogRecordProcessorTests testInitializeWithInvalidParameters]' started.
Swift/Integers.swift:3268: Fatal error: Not enough bits to represent the passed value
Test Case '-[OpenTelemetrySdkTests.BatchLogRecordProcessorTests testInitializeWithInvalidParameters]' passed (0.000 seconds).
Test Case '-[OpenTelemetrySdkTests.BatchLogRecordProcessorTests testInitializeWithValidParameters]' started.
Test Case '-[OpenTelemetrySdkTests.BatchLogRecordProcessorTests testInitializeWithValidParameters]' passed (0.000 seconds).
```

_No breaking changes._