### PR TITLE
Add OSSignposterIntegration to use OSSignposter API

### DIFF
--- a/Examples/OTLP Exporter/main.swift
+++ b/Examples/OTLP Exporter/main.swift
@@ -42,7 +42,10 @@
 
   let tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: instrumentationScopeName, instrumentationVersion: instrumentationScopeVersion)
 
-  if #available(macOS 10.14, *), #available(iOS 12.0, *) {
+  if #available(macOS 12, *), #available(iOS 15.0, *) {
+    let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
+    tracerProviderSDK?.addSpanProcessor(OSSignposterIntegration())
+  } else {
     let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
     tracerProviderSDK?.addSpanProcessor(SignPostIntegration())
   }

--- a/Examples/OTLP Exporter/main.swift
+++ b/Examples/OTLP Exporter/main.swift
@@ -42,7 +42,7 @@
 
   let tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: instrumentationScopeName, instrumentationVersion: instrumentationScopeVersion)
 
-  if #available(macOS 12, *), #available(iOS 15.0, *) {
+  if #available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *) {
     let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
     tracerProviderSDK?.addSpanProcessor(OSSignposterIntegration())
   } else {

--- a/Examples/OTLP HTTP Exporter/main.swift
+++ b/Examples/OTLP HTTP Exporter/main.swift
@@ -35,7 +35,10 @@
 
   let tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: instrumentationScopeName, instrumentationVersion: instrumentationScopeVersion)
 
-  if #available(macOS 10.14, *), #available(iOS 12.0, *) {
+  if #available(macOS 12, *), #available(iOS 15.0, *) {
+    let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
+    tracerProviderSDK?.addSpanProcessor(OSSignposterIntegration())
+  } else {
     let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
     tracerProviderSDK?.addSpanProcessor(SignPostIntegration())
   }

--- a/Examples/OTLP HTTP Exporter/main.swift
+++ b/Examples/OTLP HTTP Exporter/main.swift
@@ -35,7 +35,7 @@
 
   let tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: instrumentationScopeName, instrumentationVersion: instrumentationScopeVersion)
 
-  if #available(macOS 12, *), #available(iOS 15.0, *) {
+  if #available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *) {
     let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
     tracerProviderSDK?.addSpanProcessor(OSSignposterIntegration())
   } else {

--- a/Examples/Simple Exporter/main.swift
+++ b/Examples/Simple Exporter/main.swift
@@ -41,7 +41,10 @@
 
   tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: instrumentationScopeName, instrumentationVersion: instrumentationScopeVersion) as! TracerSdk
 
-  if #available(iOS 12.0, macOS 10.14, *) {
+  if #available(macOS 12, *), #available(iOS 15.0, *) {
+    let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
+    tracerProviderSDK?.addSpanProcessor(OSSignposterIntegration())
+  } else {
     let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
     tracerProviderSDK?.addSpanProcessor(SignPostIntegration())
   }

--- a/Examples/Simple Exporter/main.swift
+++ b/Examples/Simple Exporter/main.swift
@@ -41,7 +41,7 @@
 
   tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: instrumentationScopeName, instrumentationVersion: instrumentationScopeVersion) as! TracerSdk
 
-  if #available(macOS 12, *), #available(iOS 15.0, *) {
+  if #available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *) {
     let tracerProviderSDK = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk
     tracerProviderSDK?.addSpanProcessor(OSSignposterIntegration())
   } else {

--- a/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
+++ b/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if !os(watchOS)
+
+  import Foundation
+  import os
+  import OpenTelemetryApi
+  import OpenTelemetrySdk
+
+  /// A span processor that decorates spans with the origin attribute
+  @available(macOS 12, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+  public class OSSignposterIntegration: SpanProcessor {
+
+    private static var osSignpostStateKey: UInt8 = 0
+
+    public let isStartRequired = true
+    public let isEndRequired = true
+    public let osSignposter = OSSignposter(subsystem: "OpenTelemetry", category: .pointsOfInterest)
+
+    public init() {}
+
+    public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
+      let signpostID = osSignposter.makeSignpostID()
+      let osSignpostState = osSignposter.beginInterval("Span", id: signpostID, "\(span.name, privacy: .public)")
+      objc_setAssociatedObject(span, &OSSignposterIntegration.osSignpostStateKey, osSignpostState, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    public func onEnd(span: ReadableSpan) {
+      if let state = objc_getAssociatedObject(span, &OSSignposterIntegration.osSignpostStateKey) as? OSSignpostIntervalState {
+        osSignposter.endInterval("Span", state)
+        objc_setAssociatedObject(span, &OSSignposterIntegration.osSignpostStateKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+      }
+    }
+
+    public func forceFlush(timeout: TimeInterval? = nil) {}
+    public func shutdown(explicitTimeout: TimeInterval?) {}
+  }
+#endif

--- a/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
+++ b/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
@@ -3,42 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if !os(watchOS)
+import Foundation
+import os
+import OpenTelemetryApi
+import OpenTelemetrySdk
 
-  import Foundation
-  import os
-  import OpenTelemetryApi
-  import OpenTelemetrySdk
+/// A span processor that decorates spans with the origin attribute
+@available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+public class OSSignposterIntegration: SpanProcessor {
 
-  /// A span processor that decorates spans with the origin attribute
-  @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-  public class OSSignposterIntegration: SpanProcessor {
+  public let isStartRequired = true
+  public let isEndRequired = true
+  public let osSignposter = OSSignposter(subsystem: "OpenTelemetry", category: .pointsOfInterest)
+  public let ossignposterQueue = DispatchQueue(label: "org.opentelemetry.ossignposterIntegration")
+  private var spanIdToStateMap: [String: OSSignpostIntervalState] = [:]
 
-    public let isStartRequired = true
-    public let isEndRequired = true
-    public let osSignposter = OSSignposter(subsystem: "OpenTelemetry", category: .pointsOfInterest)
-    public let ossignposterQueue = DispatchQueue(label: "org.opentelemetry.ossignposterIntegration")
-    private var spanIdToStateMap: [String: OSSignpostIntervalState] = [:]
+  public init() {}
 
-    public init() {}
-
-    public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
-      let state = osSignposter.beginInterval("Span", id: .exclusive, "\(span.name, privacy: .public)")
-      ossignposterQueue.sync {
-        spanIdToStateMap[span.context.spanId.hexString] = state
-      }
+  public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
+    let state = osSignposter.beginInterval("Span", id: .exclusive, "\(span.name, privacy: .public)")
+    ossignposterQueue.sync {
+      spanIdToStateMap[span.context.spanId.hexString] = state
     }
-
-    public func onEnd(span: ReadableSpan) {
-      let state = ossignposterQueue.sync {
-        spanIdToStateMap.removeValue(forKey: span.context.spanId.hexString)
-      }
-      if let state {
-        osSignposter.endInterval("Span", state)
-      }
-    }
-
-    public func forceFlush(timeout: TimeInterval? = nil) {}
-    public func shutdown(explicitTimeout: TimeInterval?) {}
   }
-#endif
+
+  public func onEnd(span: ReadableSpan) {
+    let state = ossignposterQueue.sync {
+      spanIdToStateMap.removeValue(forKey: span.context.spanId.hexString)
+    }
+    if let state {
+      osSignposter.endInterval("Span", state)
+    }
+  }
+
+  public func forceFlush(timeout: TimeInterval? = nil) {}
+  public func shutdown(explicitTimeout: TimeInterval?) {}
+}

--- a/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
+++ b/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
@@ -38,4 +38,5 @@ public class OSSignposterIntegration: SpanProcessor {
 
   public func forceFlush(timeout: TimeInterval? = nil) {}
   public func shutdown(explicitTimeout: TimeInterval?) {}
+
 }

--- a/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
+++ b/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
@@ -11,7 +11,7 @@
   import OpenTelemetrySdk
 
   /// A span processor that decorates spans with the origin attribute
-  @available(macOS 12, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+  @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
   public class OSSignposterIntegration: SpanProcessor {
 
     public let isStartRequired = true

--- a/Sources/Instrumentation/SignPostIntegration/README.md
+++ b/Sources/Instrumentation/SignPostIntegration/README.md
@@ -3,13 +3,35 @@
 This package creates `os_signpost` `begin` and `end` calls when spans are started or ended. It allows automatic integration of applications
 instrumented with opentelemetry to show their spans in a profiling app like `Instruments`. It also exports the `OSLog` it uses for posting so the user can add extra signpost events. This functionality is shown in `Simple Exporter` example
 
+## Version Notice
+
+- **iOS 15+, macOS 12+, tvOS 15+, watchOS 8+**:  
+  Use **`OSSignposterIntegration`**, which utilizes the modern `OSSignposter` API for improved efficiency and compatibility.
+- **Older systems**:  
+  Use **`SignPostIntegration`**, which relies on the traditional `os_signpost` API.
 
 ## Usage 
 
-Just add SignpostIntegration as any other Span Processor:
+Add the appropriate span processor based on your deployment target:
 
+### For iOS 15+, macOS 12+, tvOS 15+, watchOS 8+:
+
+```swift
+OpenTelemetry.instance.tracerProvider.addSpanProcessor(OSSignposterIntegration())
 ```
-OpenTelemetry.instance.tracerProvider.addSpanProcessor(SignPostIntegration())`
+
+### For older systems
+
+```swift
+OpenTelemetry.instance.tracerProvider.addSpanProcessor(SignPostIntegration())
 ```
 
+### Or, to select automatically at runtime:
 
+```swift
+if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
+    OpenTelemetry.instance.tracerProvider.addSpanProcessor(OSSignposterIntegration())
+} else {
+    OpenTelemetry.instance.tracerProvider.addSpanProcessor(SignPostIntegration())
+}
+```


### PR DESCRIPTION
## Summary

- This PR introduces a new `OSSignposterIntegration` span processor, which leverages the modern [OSSignposter](https://developer.apple.com/documentation/os/ossignposter) API available on iOS 15+, macOS 12+, tvOS 15+, and watchOS 8+.
- Resolves #582

## Details

- Adds `OSSignposterIntegration` as an alternative to the existing `SignPostIntegration` for platforms supporting the new API.
- This implementation provides improved integration with Apple’s latest signpost APIs and more efficient span interval handling.
- Use a dictionary to store the states and ensures thread safety with a serial queue.
- Maintains backward compatibility: users can choose the appropriate integration at runtime using `#available` checks.
- We can't remove the old `SignPostIntegration` yet since the new API is only available on iOS 15.0+, while this project's iOS minimum version is 13.0.

## Usage

```swift
if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
    OpenTelemetry.instance.tracerProvider.addSpanProcessor(OSSignposterIntegration())
} else {
    OpenTelemetry.instance.tracerProvider.addSpanProcessor(SignPostIntegration())
}
```

## Screenshot

<img width="1520" alt="Screenshot 2025-06-22 at 16 40 26" src="https://github.com/user-attachments/assets/583c91bf-660f-461b-b004-8c88499f84fa" />
