### PR TITLE
added public init to SpanData to support custom Span Processors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "8c5e99d0255c373e0330730d191a3423c57373fb",
-        "version" : "1.24.2"
+        "revision" : "a56a157218877ef3e9625f7e1f7b2cb7e46ead1b",
+        "version" : "1.26.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-        "version" : "1.5.4"
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "ce594e71e92a1610015017f83f402894df540e51",
-        "version" : "2.4.4"
+        "revision" : "4c83e1cdf4ba538ef6e43a9bbd0bcc33a0ca46e3",
+        "version" : "2.7.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "dca6594f65308c761a9c409e09fbf35f48d50d34",
-        "version" : "2.77.0"
+        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
+        "version" : "2.83.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "8d8eb609929aee75336a0a3d2417280786265868",
-        "version" : "1.32.0"
+        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
+        "version" : "1.36.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "38ac8221dd20674682148d6451367f89c2652980",
-        "version" : "1.21.0"
+        "revision" : "cd1e89816d345d2523b11c55654570acd5cd4c56",
+        "version" : "1.24.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
       }
     },
     {

--- a/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
@@ -75,6 +75,50 @@ public struct SpanData: Equatable, Codable {
   /// greater than the configured maximum value. See SpanLimits.maxNumberOfAttributes
   public private(set) var totalAttributeCount: Int = 0
 
+  public init(
+    traceId: TraceId,
+    spanId: SpanId,
+    traceFlags: TraceFlags = TraceFlags(),
+    traceState: TraceState = TraceState(),
+    parentSpanId: SpanId? = nil,
+    resource: Resource = Resource(),
+    instrumentationScope: InstrumentationScopeInfo = InstrumentationScopeInfo(),
+    name: String,
+    kind: SpanKind,
+    startTime: Date,
+    attributes: [String : AttributeValue] = [String: AttributeValue](),
+    events: [Event] = [Event](),
+    links: [Link] = [Link](),
+    status: Status,
+    endTime: Date,
+    hasRemoteParent: Bool,
+    hasEnded: Bool,
+    totalRecordedEvents: Int,
+    totalRecordedLinks: Int,
+    totalAttributeCount: Int
+  ) {
+    self.traceId = traceId
+    self.spanId = spanId
+    self.traceFlags = traceFlags
+    self.traceState = traceState
+    self.parentSpanId = parentSpanId
+    self.resource = resource
+    self.instrumentationScope = instrumentationScope
+    self.name = name
+    self.kind = kind
+    self.startTime = startTime
+    self.attributes = attributes
+    self.events = events
+    self.links = links
+    self.status = status
+    self.endTime = endTime
+    self.hasRemoteParent = hasRemoteParent
+    self.hasEnded = hasEnded
+    self.totalRecordedEvents = totalRecordedEvents
+    self.totalRecordedLinks = totalRecordedLinks
+    self.totalAttributeCount = totalAttributeCount
+  }
+
   public static func == (lhs: SpanData, rhs: SpanData) -> Bool {
     return lhs.traceId == rhs.traceId &&
       lhs.spanId == rhs.spanId &&

--- a/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
@@ -89,10 +89,10 @@ public struct SpanData: Equatable, Codable {
     attributes: [String: AttributeValue] = [String: AttributeValue](),
     events: [Event] = [Event](),
     links: [Link] = [Link](),
-    status: Status,
+    status: Status = .unset,
     endTime: Date,
-    hasRemoteParent: Bool,
-    hasEnded: Bool,
+    hasRemoteParent: Bool = false,
+    hasEnded: Bool = false,
     totalRecordedEvents: Int = 0,
     totalRecordedLinks: Int = 0,
     totalAttributeCount: Int = 0

--- a/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
@@ -93,9 +93,9 @@ public struct SpanData: Equatable, Codable {
     endTime: Date,
     hasRemoteParent: Bool,
     hasEnded: Bool,
-    totalRecordedEvents: Int,
-    totalRecordedLinks: Int,
-    totalAttributeCount: Int
+    totalRecordedEvents: Int = 0,
+    totalRecordedLinks: Int = 0,
+    totalAttributeCount: Int = 0
   ) {
     self.traceId = traceId
     self.spanId = spanId

--- a/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Data/SpanData.swift
@@ -86,7 +86,7 @@ public struct SpanData: Equatable, Codable {
     name: String,
     kind: SpanKind,
     startTime: Date,
-    attributes: [String : AttributeValue] = [String: AttributeValue](),
+    attributes: [String: AttributeValue] = [String: AttributeValue](),
     events: [Event] = [Event](),
     links: [Link] = [Link](),
     status: Status,


### PR DESCRIPTION
SpanData's init is internal, which make it impossible to support Elastic's custom span processor. 

The recent changes to the tracing sdk made the 'isRecording' flag immutable, which prevents the hack I was using to update the span in my custom processor after calling `span.end()`.  