### PR TITLE
added 'getAttributes' and 'setAttributes' to spans

### DIFF
--- a/Examples/Logging Tracer/LoggingSpan.swift
+++ b/Examples/Logging Tracer/LoggingSpan.swift
@@ -56,7 +56,7 @@ class LoggingSpan: Span {
     setAttribute(key: keyValuePair.0, value: keyValuePair.1)
   }
 
-  func setAttributes(
+  public func setAttributes(
     _ attributes: [String: OpenTelemetryApi.AttributeValue]
   ) {
     attributes.forEach { key, value in

--- a/Examples/Logging Tracer/LoggingSpan.swift
+++ b/Examples/Logging Tracer/LoggingSpan.swift
@@ -56,6 +56,14 @@ class LoggingSpan: Span {
     setAttribute(key: keyValuePair.0, value: keyValuePair.1)
   }
 
+  func setAttributes(
+    _ attributes: [String: OpenTelemetryApi.AttributeValue]
+  ) {
+    attributes.forEach { key, value in
+      setAttribute(key: key, value: value)
+    }
+  }
+
   public func addEvent(name: String) {
     Logger.log("Span.addEvent(\(name))")
   }

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "8c5e99d0255c373e0330730d191a3423c57373fb",
-        "version" : "1.24.2"
+        "revision" : "a56a157218877ef3e9625f7e1f7b2cb7e46ead1b",
+        "version" : "1.26.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-        "version" : "1.5.4"
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "ce594e71e92a1610015017f83f402894df540e51",
-        "version" : "2.4.4"
+        "revision" : "4c83e1cdf4ba538ef6e43a9bbd0bcc33a0ca46e3",
+        "version" : "2.7.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "dca6594f65308c761a9c409e09fbf35f48d50d34",
-        "version" : "2.77.0"
+        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
+        "version" : "2.83.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "8d8eb609929aee75336a0a3d2417280786265868",
-        "version" : "1.32.0"
+        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
+        "version" : "1.36.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "38ac8221dd20674682148d6451367f89c2652980",
-        "version" : "1.21.0"
+        "revision" : "cd1e89816d345d2523b11c55654570acd5cd4c56",
+        "version" : "1.24.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
       }
     },
     {

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
@@ -85,6 +85,8 @@ class PropagatedSpan: Span {
 
   func setAttribute(key: String, value: AttributeValue?) {}
 
+  func setAttributes(_ attributes: [String: AttributeValue]) {}
+
   func addEvent(name: String) {}
 
   func addEvent(name: String, timestamp: Date) {}

--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -36,6 +36,11 @@ public protocol SpanBase: AnyObject, CustomStringConvertible {
   ///   - value: Attribute value.
   func setAttribute(key: String, value: AttributeValue?)
 
+  /// inserts attributes dictionary into the span.
+  /// - Parameters:
+  ///   - attributes: dictionary of attributes
+  func setAttributes(_ attributes: [String: AttributeValue])
+
   /// Adds an event to the Span
   /// - Parameter name: the name of the event.
   func addEvent(name: String)

--- a/Sources/OpenTelemetrySdk/Trace/ReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/ReadableSpan.swift
@@ -23,4 +23,7 @@ public protocol ReadableSpan: Span {
 
   /// Returns the latecy of the  Span. If still active then returns now() - start time.
   var latency: TimeInterval { get }
+
+  /// get attributes
+  func getAttributes() -> [String: AttributeValue]
 }

--- a/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -250,6 +250,12 @@ public class RecordEventsReadableSpan: ReadableSpan {
     }
   }
 
+  public func setAttributes(_ attributes: [String: AttributeValue]) {
+    attributes.forEach { (key: String, value: AttributeValue) in
+      setAttribute(key: key, value: value)
+    }
+  }
+
   public func addEvent(name: String) {
     addEvent(event: SpanData.Event(name: name, timestamp: clock.now))
   }
@@ -305,6 +311,12 @@ public class RecordEventsReadableSpan: ReadableSpan {
 
   public var description: String {
     return "RecordEventsReadableSpan{}"
+  }
+
+  public func getAttributes() -> [String: AttributeValue] {
+    lock.withReaderLock {
+      return attributes.attributes
+    }
   }
 
   func getTotalRecordedEvents() -> Int {

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/ReadableSpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/ReadableSpanMock.swift
@@ -54,6 +54,12 @@ class ReadableSpanMock: ReadableSpan {
 
   func setAttribute(key: String, value: AttributeValue?) {}
 
+  func getAttributes() -> [String : OpenTelemetryApi.AttributeValue] {
+    return [:]
+  }
+
+  func setAttributes(_ attributes: [String : OpenTelemetryApi.AttributeValue]) {}
+
   func addEvent(name: String) {}
 
   func addEvent(name: String, attributes: [String: AttributeValue]) {}

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
@@ -8,6 +8,7 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 
 class SpanMock: Span {
+
   var name: String = ""
 
   var kind: SpanKind {
@@ -29,6 +30,8 @@ class SpanMock: Span {
   func updateName(name: String) {}
 
   func setAttribute(key: String, value: AttributeValue?) {}
+
+  func setAttributes(_ attributes: [String : OpenTelemetryApi.AttributeValue]) {}
 
   func addEvent(name: String) {}
 

--- a/Tests/OpenTelemetrySdkTests/Trace/RecordEventsReadableSpanTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/RecordEventsReadableSpanTests.swift
@@ -224,6 +224,45 @@ class RecordEventsReadableSpanTest: XCTestCase {
     }())
   }
 
+  func testSetAttributes() {
+    let span = createTestRootSpan()
+
+    let attributes: [String: AttributeValue] = ["hello": .string("world"),
+                                                "count": .int(2)]
+
+    let attributes2: [String: AttributeValue] = ["fiz": .string("buzz"),
+                                                 "pi": .double(3.14)]
+    span.setAttributes(attributes)
+
+    XCTAssertEqual(attributes, span.getAttributes())
+
+    span.setAttributes(attributes2)
+
+    var attributes3 : [String: AttributeValue] = [:]
+
+    attributes3.merge(attributes) { (_, new) in new }
+    attributes3.merge(attributes2) { (_, new) in new }
+
+    XCTAssertEqual(attributes3, span.getAttributes())
+  }
+
+
+  func testGetAttributes() {
+    let span = createTestRootSpan()
+    
+    let attributes: [String: AttributeValue] = ["hello": .string("world"),
+                                                "count": .int(2)]
+    
+    span.setAttributes(attributes)
+    
+    var spanAttributes = span.getAttributes()
+
+    spanAttributes["newAttribute"] = .string("oops!")
+
+    XCTAssertNotEqual(spanAttributes, span.getAttributes())
+
+  }
+
   func testAddEvent() {
     let span = createTestRootSpan()
     span.addEvent(name: "event1")


### PR DESCRIPTION
Our span implementation is missing some useful methods available in other SDKs. 
- `getAttributes` on `ReadableSpan` allows decisions to be made on spanEnd such as filtering based off attributes.
- `setAttributes` on `Span` provides convenience. 