### PR TITLE
Fix build-watchos target to use XCODEBUILD_OPTIONS_WATCHOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-tvos:
 
 .PHONY: build-watchos
 build-watchos:
-	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_IOS) build | xcbeautify
+	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_WATCHOS) build | xcbeautify
 
 .PHONY: build-for-testing-ios
 build-for-testing-ios:


### PR DESCRIPTION
## Summary

Fixes an issue in the Makefile where the `build-watchos` target was incorrectly using `XCODEBUILD_OPTIONS_IOS` instead of the appropriate `XCODEBUILD_OPTIONS_WATCHOS`.

## Changes

- Replaced `XCODEBUILD_OPTIONS_IOS` with `XCODEBUILD_OPTIONS_WATCHOS` in the `build-watchos` target.