### PR TITLE
limited CoreTelephone dependency in NetworkStatus podspec to only iOS

### DIFF
--- a/OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
+++ b/OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
@@ -13,9 +13,12 @@ Pod::Spec.new do |spec|
 
   spec.swift_version = "5.10"
   spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
   spec.module_name = "NetworkStatus"
 
-  spec.frameworks = 'CoreTelephony'
+  spec.ios.frameworks = 'CoreTelephony'
+
   spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
   spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name NetworkStatus -package-name opentelemetry_swift_network_status" }
 

--- a/OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
+++ b/OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
@@ -13,8 +13,6 @@ Pod::Spec.new do |spec|
 
   spec.swift_version = "5.10"
   spec.ios.deployment_target = "13.0"
-  spec.tvos.deployment_target = "13.0"
-  spec.watchos.deployment_target = "6.0"
   spec.module_name = "NetworkStatus"
 
   spec.frameworks = 'CoreTelephony'


### PR DESCRIPTION
The NetworkStatus only uses CoreTelephony in portions only enabled for iOS.