### PR TITLE
Use let instead of var for non-mutated variables

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -196,7 +196,7 @@ public extension Span {
   ///   - reasonPhrase: Http reason phrase.
   func putHttpStatusCode(statusCode: Int, reasonPhrase: String) {
     setAttribute(key: .httpStatusCode, value: statusCode)
-    var newStatus: Status = switch statusCode {
+    let newStatus: Status = switch statusCode {
     case 200 ..< 400:
       .ok
     case 400 ..< 600:

--- a/Sources/OpenTelemetryApi/Trace/TraceFlags.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceFlags.swift
@@ -75,7 +75,7 @@ public struct TraceFlags: Equatable, CustomStringConvertible, Codable {
   /// Sets the sampling bit in the options.
   /// - Parameter isSampled: the sampling bit
   public func settingIsSampled(_ isSampled: Bool) -> TraceFlags {
-    var optionsCopy: UInt8 = if isSampled {
+    let optionsCopy: UInt8 = if isSampled {
       options | TraceFlags.isSampled
     } else {
       options & ~TraceFlags.isSampled

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
@@ -197,7 +197,7 @@ class SpanBuilderSdk: SpanBuilder {
   private func getParentContext(parentType: ParentType, explicitParent: Span?, remoteParent: SpanContext?) -> SpanContext? {
     let currentSpan = OpenTelemetry.instance.contextProvider.activeSpan
 
-    var parentContext: SpanContext? = switch parentType {
+    let parentContext: SpanContext? = switch parentType {
     case .noParent:
       nil
     case .currentSpan:


### PR DESCRIPTION
## Summary

This PR addresses following Swift compiler warnings to improve readability and robustness.

```
variable 'xx' was never mutated; consider changing to 'let' constant
```