### PR TITLE
Add visionOS support

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -64,6 +64,16 @@ jobs:
       run: make build-for-testing-watchos
     - name: Test for watchOS
       run: make test-without-building-watchos
+  visionOS:
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Install Homebrew kegs
+      run: make setup-brew
+    - name: Build for visionOS
+      run: make build-for-testing-visionos
+    - name: Test for visionOS
+      run: make test-without-building-visionos
   linux:
     runs-on: ubuntu-latest
     container: swift:5.10@sha256:8d7965d8b1757b46fee0ce603505b71e424a443e2002d502dfebd288a7f9a109

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ XCODEBUILD_OPTIONS_WATCHOS=\
     -retry-tests-on-failure \
 	-workspace .
 
+XCODEBUILD_OPTIONS_VISIONOS=\
+	-configuration Debug \
+	-destination platform='visionOS Simulator,name=Apple Vision Pro,OS=2.0' \
+	-scheme $(PROJECT_NAME) \
+	-test-iterations 5 \
+    -retry-tests-on-failure \
+	-workspace .
+
 .PHONY: setup-brew
 setup-brew:
 	brew update && brew install xcbeautify
@@ -40,6 +48,10 @@ build-tvos:
 build-watchos:
 	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_WATCHOS) build | xcbeautify
 
+.PHONY: build-visionOS
+build-visionos:
+	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_VISIONOS) build | xcbeautify
+
 .PHONY: build-for-testing-ios
 build-for-testing-ios:
 	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_IOS) build-for-testing | xcbeautify
@@ -51,6 +63,10 @@ build-for-testing-tvos:
 .PHONY: build-for-testing-watchos
 build-for-testing-watchos:
 	set -o pipefail && xcodebuild OTHER_LDFLAGS="$(OTHER_LDFLAGS) -fprofile-instr-generate" $(XCODEBUILD_OPTIONS_WATCHOS) build-for-testing | xcbeautify
+
+.PHONY: build-for-testing-visionos
+build-for-testing-visionos:
+	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_VISIONOS) build-for-testing | xcbeautify
 
 .PHONY: test-ios
 test-ios:
@@ -64,6 +80,10 @@ test-tvos:
 test-watchos:
 	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_WATCHOS) test | xcbeautify
 
+.PHONY: test-visionos
+test-visionos:
+	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_VISIONOS) test | xcbeautify
+
 .PHONY: test-without-building-ios
 test-without-building-ios:
 	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_IOS) test-without-building | xcbeautify
@@ -75,3 +95,7 @@ test-without-building-tvos:
 .PHONY: test-without-building-watchos
 test-without-building-watchos:
 	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_WATCHOS) test-without-building | xcbeautify
+
+.PHONY: test-without-building-visionos
+test-without-building-visionos:
+	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_VISIONOS) test-without-building | xcbeautify

--- a/OpenTelemetry-Swift-Api.podspec
+++ b/OpenTelemetry-Swift-Api.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "OpenTelemetryApi"
   # This is necessary because we use the `package` keyword to access some properties in `OpenTelemetryApi`
   # This keyword was introduced in Swift 5.9 and it's tightly bound to SPM.

--- a/OpenTelemetry-Swift-BaggagePropagationProcessor.podspec
+++ b/OpenTelemetry-Swift-BaggagePropagationProcessor.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "BaggagePropagationProcessor"
 
   spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s

--- a/OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
+++ b/OpenTelemetry-Swift-Instrumentation-NetworkStatus.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "NetworkStatus"
 
   spec.ios.frameworks = 'CoreTelephony'

--- a/OpenTelemetry-Swift-Instrumentation-URLSession.podspec
+++ b/OpenTelemetry-Swift-Instrumentation-URLSession.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "URLSession"
 
   spec.dependency 'OpenTelemetry-Swift-Instrumentation-NetworkStatus', spec.version.to_s

--- a/OpenTelemetry-Swift-PersistenceExporter.podspec
+++ b/OpenTelemetry-Swift-PersistenceExporter.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "PersistenceExporter"
 
   spec.dependency 'OpenTelemetry-Swift-Sdk', spec.version.to_s

--- a/OpenTelemetry-Swift-Protocol-Exporter-Common.podspec
+++ b/OpenTelemetry-Swift-Protocol-Exporter-Common.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "OpenTelemetryProtocolExporterCommon"
 
   spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s

--- a/OpenTelemetry-Swift-Protocol-Exporter-Http.podspec
+++ b/OpenTelemetry-Swift-Protocol-Exporter-Http.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "OpenTelemetryProtocolExporterHttp"
 
   spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s

--- a/OpenTelemetry-Swift-Sdk.podspec
+++ b/OpenTelemetry-Swift-Sdk.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "OpenTelemetrySdk"
   spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s
 end

--- a/OpenTelemetry-Swift-SdkResourceExtension.podspec
+++ b/OpenTelemetry-Swift-SdkResourceExtension.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "ResourceExtension"
 
   spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s

--- a/OpenTelemetry-Swift-StdoutExporter.podspec
+++ b/OpenTelemetry-Swift-StdoutExporter.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.tvos.deployment_target = "13.0"
   spec.watchos.deployment_target = "6.0"
+  spec.visionos.deployment_target = "1.0"
   spec.module_name = "StdoutExporter"
 
   spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s

--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,7 @@ let package = Package(
         .product(
           name: "DataCompression",
           package: "DataCompression",
-          condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS])
+          condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .visionOS])
         ),
       ],
       path: "Sources/Exporters/OpenTelemetryProtocolHttp"
@@ -181,7 +181,7 @@ let package = Package(
         .product(
           name: "DataCompression",
           package: "DataCompression",
-          condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS])
+          condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .visionOS])
         ),
         .product(name: "NIO", package: "swift-nio"),
         .product(name: "NIOHTTP1", package: "swift-nio"),
@@ -366,7 +366,7 @@ extension Package {
             .product(
               name: "DataCompression",
               package: "DataCompression",
-              condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS])
+              condition: .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .visionOS])
             ),
           ],
           path: "Examples/OTLP HTTP Exporter",

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     .iOS(.v13),
     .tvOS(.v13),
     .watchOS(.v6),
+    .visionOS(.v1),
   ],
   products: [
     .library(name: "OpenTelemetryApi", targets: ["OpenTelemetryApi"]),

--- a/Sources/Exporters/Jaeger/Adapter.swift
+++ b/Sources/Exporters/Jaeger/Adapter.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
   import OpenTelemetryApi

--- a/Sources/Exporters/Jaeger/Jaeger Thrift/agent+Exts.swift
+++ b/Sources/Exporters/Jaeger/Jaeger Thrift/agent+Exts.swift
@@ -5,7 +5,7 @@
  *  @generated
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
 

--- a/Sources/Exporters/Jaeger/Jaeger Thrift/agent.swift
+++ b/Sources/Exporters/Jaeger/Jaeger Thrift/agent.swift
@@ -5,7 +5,7 @@
  *  @generated
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
 

--- a/Sources/Exporters/Jaeger/Jaeger Thrift/jaeger+Exts.swift
+++ b/Sources/Exporters/Jaeger/Jaeger Thrift/jaeger+Exts.swift
@@ -5,7 +5,7 @@
  *  @generated
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
 

--- a/Sources/Exporters/Jaeger/Jaeger Thrift/jaeger.swift
+++ b/Sources/Exporters/Jaeger/Jaeger Thrift/jaeger.swift
@@ -5,7 +5,7 @@
  *  @generated
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
 

--- a/Sources/Exporters/Jaeger/JaegerSpanExporter.swift
+++ b/Sources/Exporters/Jaeger/JaegerSpanExporter.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
   import OpenTelemetrySdk

--- a/Sources/Exporters/Jaeger/Sender.swift
+++ b/Sources/Exporters/Jaeger/Sender.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
   import Network

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/Lock.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/Lock.swift
@@ -31,7 +31,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
   import Darwin
 #elseif canImport(Glibc)
   import Glibc

--- a/Sources/Importers/OpenTracingShim/Locks.swift
+++ b/Sources/Importers/OpenTracingShim/Locks.swift
@@ -31,7 +31,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
   import Darwin
 #elseif canImport(Glibc)
   import Glibc

--- a/Sources/Importers/SwiftMetricsShim/Locks.swift
+++ b/Sources/Importers/SwiftMetricsShim/Locks.swift
@@ -31,7 +31,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
   import Darwin
 #elseif canImport(Glibc)
   import Glibc

--- a/Sources/Instrumentation/SignPostIntegration/SignPostIntegration.swift
+++ b/Sources/Instrumentation/SignPostIntegration/SignPostIntegration.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
   import os

--- a/Sources/OpenTelemetrySdk/Internal/Locks.swift
+++ b/Sources/OpenTelemetrySdk/Internal/Locks.swift
@@ -31,7 +31,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
   import Darwin
 #elseif canImport(Glibc)
   import Glibc

--- a/Tests/ExportersTests/Jaeger/AdapterTests.swift
+++ b/Tests/ExportersTests/Jaeger/AdapterTests.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(visionOS)
 
   import Foundation
 


### PR DESCRIPTION
# Add visionOS Support

- This PR adds comprehensive visionOS support, enabling developers to integrate `opentelemetry-swift` to visionOS applications.
- https://github.com/open-telemetry/opentelemetry-swift/issues/512

## Changes

- Added `.visionOS(.v1)` to the list of supported platforms in `Package.swift`.
- Updated to include visionOS deployment target for all CocoaPods specifications.
- Added build and test targets in `Makefile` for visionOS (`build-visionOS`, `build-for-testing-visionos`, `test-visionos`, `test-without-building-visionos`)
- Added visionOS build and test job to the CI pipeline for GitHub Actions.
- Updated multiple classes to ensure compatibility with visionOS.

## Testing

- Verified visionOS support by integrating into a sample visionOS app (see screenshot below) and ensuring all CI tests pass across supported platforms.

![Simulator Screenshot - Apple Vision Pro (at 2732x2048) - 2025-07-01 at 14 26 50](https://github.com/user-attachments/assets/8f9eb06e-187b-4735-a5fe-052f90f7276a)