### PR TITLE
chore: exclude unhandled files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,8 @@ let package = Package(
         "OpenTelemetryApi",
         .product(name: "Logging", package: "swift-log"),
       ],
-      path: "Sources/Bridges/OTelSwiftLog"
+      path: "Sources/Bridges/OTelSwiftLog",
+      exclude: ["README.md"]
     ),
     .target(
       name: "SwiftMetricsShim",
@@ -131,7 +132,8 @@ let package = Package(
     .target(
       name: "PersistenceExporter",
       dependencies: ["OpenTelemetrySdk"],
-      path: "Sources/Exporters/Persistence"
+      path: "Sources/Exporters/Persistence",
+      exclude: ["README.md"]
     ),
     .target(
       name: "BaggagePropagationProcessor",
@@ -227,7 +229,8 @@ let package = Package(
     .executableTarget(
       name: "StableMetricSample",
       dependencies: ["OpenTelemetrySdk", "OpenTelemetryProtocolExporterGrpc", "StdoutExporter"],
-      path: "Examples/Stable Metric Sample"
+      path: "Examples/Stable Metric Sample",
+      exclude: ["README.md"]
     ),
   ]
 ).addPlatformSpecific()
@@ -356,7 +359,7 @@ extension Package {
             "ZipkinExporter", "ResourceExtension", "SignPostIntegration",
           ],
           path: "Examples/OTLP Exporter",
-          exclude: ["README.md"]
+          exclude: ["README.md", "prometheus.yaml", "collector-config.yaml", "docker-compose.yaml", "images"]
         ),
         .executableTarget(
           name: "OTLPHTTPExporter",
@@ -370,7 +373,7 @@ extension Package {
             ),
           ],
           path: "Examples/OTLP HTTP Exporter",
-          exclude: ["README.md"]
+          exclude: ["README.md", "collector-config.yaml", "docker-compose.yaml", "prometheus.yaml", "images"]
         ),
         .target(
           name: "SignPostIntegration",


### PR DESCRIPTION
## Summary

Small PR to remove some warnings regarding unhandled files. One one warning remains about the readme from dependency swift-nio-ssl, which we cannot exclude.

```
opentelemetry-swift % swift build
warning: 'swift-nio-ssl': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/billyzh/Documents/opentelemetry-swift/.build/checkouts/swift-nio-ssl/Sources/NIOSSL/PrivacyInfo.xcprivacy
[1/1] Planning build
Building for debugging...
[3/3] Write swift-version--58304C5D6DBC2206.txt
Build complete! (4.15s)
```

## Previous warnings

```
opentelemetry-swift % swift build
warning: 'opentelemetry-swift': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/billyzh/Documents/opentelemetry-swift/Sources/Exporters/Persistence/README.md
warning: 'opentelemetry-swift': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/billyzh/Documents/opentelemetry-swift/Sources/Bridges/OTelSwiftLog/README.md
warning: 'opentelemetry-swift': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/billyzh/Documents/opentelemetry-swift/Examples/Stable Metric Sample/README.md
warning: 'opentelemetry-swift': found 5 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP Exporter/images/zipkin-spans.png
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP Exporter/prometheus.yaml
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP Exporter/docker-compose.yaml
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP Exporter/collector-config.yaml
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP Exporter/images/prometheus-metrics.png
warning: 'opentelemetry-swift': found 5 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP HTTP Exporter/prometheus.yaml
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP HTTP Exporter/docker-compose.yaml
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP HTTP Exporter/images/prometheus-metrics.png
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP HTTP Exporter/images/zipkin-spans.png
    /Users/billyzh/Documents/opentelemetry-swift/Examples/OTLP HTTP Exporter/collector-config.yaml
warning: 'swift-nio-ssl': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/billyzh/Documents/opentelemetry-swift/.build/checkouts/swift-nio-ssl/Sources/NIOSSL/PrivacyInfo.xcprivacy
[1/1] Planning build
Building for debugging...
[3/3] Write swift-version--58304C5D6DBC2206.txt
Build complete! (4.16s)
```

## Tests
Ran unit tests