### PR TITLE
Fix links to help wanted and good first issue labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ The package includes some example projects with basic functionality:
 * `OTLP Exporter` - Shows the OTLP exporter reporting traces to Zipkin and metrics to a Prometheus via the otel-collector
 
 ## Contributing
-We'd love your help!. Use tags [help wanted][help wanted] and
-[good first issue][good first issues] to get started with the project. 
+We'd love your help! Use labels [![help wanted](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-swift?query=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22&label=help%20wanted&color=rgb(0%2C%20134%2C%20114)&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-swift/issues?q=state%3Aopen%20label%3A%22help%20wanted%22) and [![good first issue](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-swift?query=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22&label=good%20first%20issue&color=rgb(112%2C%2087%2C%20255)&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-swift/issues?q=state%3Aopen%20label%3A%22good%20first%20issue%22) 
+ to get started with the project. 
 For an overview of how to contribute, see the contributing guide in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 We have a weekly SIG meeting! See the [community page](https://github.com/open-telemetry/community#swift-sdk) for meeting details and notes.


### PR DESCRIPTION
Uses https://shields.io/badges/git-hub-issue-custom-search-in-repo to generate a badge with number of issues for the "help wanted" and "good first issue" label.