### PR TITLE
Fix thread race conditions in new metrics

### DIFF
--- a/Examples/OTLP HTTP Exporter/main.swift
+++ b/Examples/OTLP HTTP Exporter/main.swift
@@ -75,20 +75,20 @@
   createSpans()
 
 // Metrics
-let otlpMetricExporter = StableOtlpHTTPMetricExporter(endpoint: defaultStableOtlpHTTPMetricsEndpoint())
-let meterProvider = StableMeterProviderSdk.builder()
+let otlpMetricExporter = OtlpHttpMetricExporter(endpoint: defaultOtlpHttpMetricsEndpoint())
+let meterProvider = MeterProviderSdk.builder()
   .registerMetricReader(
-    reader: StablePeriodicMetricReaderBuilder(
+    reader: PeriodicMetricReaderBuilder(
       exporter: otlpMetricExporter).setInterval(timeInterval: 60)
       .build()
   )
   .registerView(
     selector: InstrumentSelector.builder().setInstrument(name: ".*").build(),
-    view: StableView.builder().build()
+    view: View.builder().build()
   )
   .build()
 
-OpenTelemetry.registerStableMeterProvider(meterProvider: meterProvider)
+OpenTelemetry.registerMeterProvider(meterProvider: meterProvider)
 
 let labels1 = ["dim1": AttributeValue.string("value1")]
 

--- a/Sources/Importers/SwiftMetricsShim/Locks.swift
+++ b/Sources/Importers/SwiftMetricsShim/Locks.swift
@@ -200,3 +200,29 @@ extension ReadWriteLock {
     try withWriterLock(body)
   }
 }
+
+public final class Locked<Value> : @unchecked Sendable {
+    
+    private var internalValue: Value
+    
+    private let lock = Lock()
+    
+    public var protectedValue: Value {
+        get {
+            lock.withLock { internalValue }
+        }
+        _modify {
+            lock.lock()
+            defer { lock.unlock() }
+            yield &internalValue
+        }
+    }
+    
+    public init(initialValue: Value) {
+        self.internalValue = initialValue
+    }
+    
+    public func locking<T>(_ block: (inout Value) throws -> T) rethrows -> T {
+        try lock.withLock { try block(&internalValue) }
+    }
+}

--- a/Sources/Importers/SwiftMetricsShim/MetricHandlers.swift
+++ b/Sources/Importers/SwiftMetricsShim/MetricHandlers.swift
@@ -9,21 +9,21 @@ import OpenTelemetryApi
 class SwiftCounterMetric: CounterHandler, SwiftMetric {
   let metricName: String
   let metricType: MetricType = .counter
-  var counter: LongCounter
+  let counter: Locked<LongCounter>
   let labels: [String: AttributeValue]
 
   required init(name: String,
                 labels: [String: String],
                 meter: any OpenTelemetryApi.Meter) {
     metricName = name
-    counter = meter.counterBuilder(name: name).build()
+    counter = .init(initialValue: meter.counterBuilder(name: name).build())
     self.labels = labels.mapValues { value in
       return AttributeValue.string(value)
     }
   }
 
   func increment(by: Int64) {
-    counter.add(value: Int(by), attributes: labels)
+    counter.protectedValue.add(value: Int(by), attributes: labels)
   }
 
   func reset() {}

--- a/Sources/OpenTelemetrySdk/Common/ComponentRegistry.swift
+++ b/Sources/OpenTelemetrySdk/Common/ComponentRegistry.swift
@@ -12,7 +12,7 @@ class ComponentRegistry<T> {
   private var componentByNameVersion = [String: [String: T]]()
   private var componentByNameSchema = [String: [String: T]]()
   private var componentByNameVersionSchema = [String: [String: [String: T]]]()
-  private var allComponents = [T]()
+  private let allComponents = ReadWriteLocked<[T]>(initialValue: [])
 
   private let builder: (InstrumentationScopeInfo) -> T
 
@@ -84,11 +84,13 @@ class ComponentRegistry<T> {
 
   private func buildComponent(_ scope: InstrumentationScopeInfo) -> T {
     let component = builder(scope)
-    allComponents.append(component)
+    allComponents.writeLocking {
+      $0.append(component)
+    }
     return component
   }
 
   public func getComponents() -> [T] {
-    return [T](allComponents)
+    return [T](allComponents.protectedValue)
   }
 }

--- a/Sources/OpenTelemetrySdk/Internal/Locks.swift
+++ b/Sources/OpenTelemetrySdk/Internal/Locks.swift
@@ -41,42 +41,38 @@
   #error("Unsupported platform")
 #endif
 
-/// A threading lock based on `libpthread` instead of `libdispatch`.
-///
-/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
-/// of lock is safe to use with `libpthread`-based threading models, such as the
-/// one used by NIO.
+/// A threading lock based on `os_unfair_lock`
 final class Lock {
-  private let mutex: UnsafeMutablePointer<pthread_mutex_t> = UnsafeMutablePointer.allocate(capacity: 1)
+  private let unfairLock: os_unfair_lock_t
 
   /// Create a new lock.
-  public init() {
-    let err = pthread_mutex_init(mutex, nil)
-    precondition(err == 0, "pthread_mutex_init failed with error \(err)")
+  init() {
+    unfairLock = .allocate(capacity: 1)
+    unfairLock.initialize(to: os_unfair_lock_s())
   }
 
   deinit {
-    let err = pthread_mutex_destroy(self.mutex)
-    precondition(err == 0, "pthread_mutex_destroy failed with error \(err)")
-    self.mutex.deallocate()
+    os_unfair_lock_assert_not_owner(unfairLock)
+    self.unfairLock.deinitialize(count: 1)
+    self.unfairLock.deallocate()
   }
 
   /// Acquire the lock.
   ///
   /// Whenever possible, consider using `withLock` instead of this method and
   /// `unlock`, to simplify lock handling.
-  public func lock() {
-    let err = pthread_mutex_lock(mutex)
-    precondition(err == 0, "pthread_mutex_lock failed with error \(err)")
+  func lock() {
+    os_unfair_lock_assert_not_owner(unfairLock)
+    os_unfair_lock_lock(unfairLock)
   }
 
   /// Release the lock.
   ///
   /// Whenever possible, consider using `withLock` instead of this method and
   /// `lock`, to simplify lock handling.
-  public func unlock() {
-    let err = pthread_mutex_unlock(mutex)
-    precondition(err == 0, "pthread_mutex_unlock failed with error \(err)")
+  func unlock() {
+    os_unfair_lock_assert_owner(unfairLock)
+    os_unfair_lock_unlock(unfairLock)
   }
 }
 
@@ -163,7 +159,7 @@ extension ReadWriteLock {
   /// - Parameter body: The block to execute while holding the lock.
   /// - Returns: The value returned by the block.
   @inlinable
-  func withReaderLock<T>(_ body: () throws -> T) rethrows -> T {
+  public func withReaderLock<T>(_ body: () throws -> T) rethrows -> T {
     lockRead()
     defer {
       self.unlock()
@@ -180,7 +176,7 @@ extension ReadWriteLock {
   /// - Parameter body: The block to execute while holding the lock.
   /// - Returns: The value returned by the block.
   @inlinable
-  func withWriterLock<T>(_ body: () throws -> T) rethrows -> T {
+  public func withWriterLock<T>(_ body: () throws -> T) rethrows -> T {
     lockWrite()
     defer {
       self.unlock()
@@ -199,4 +195,62 @@ extension ReadWriteLock {
   func withWriterLockVoid(_ body: () throws -> Void) rethrows {
     try withWriterLock(body)
   }
+}
+
+public final class Locked<Value> : @unchecked Sendable {
+    
+    private var internalValue: Value
+    
+    private let lock = Lock()
+    
+    public var protectedValue: Value {
+        get {
+            lock.withLock { internalValue }
+        }
+        _modify {
+            lock.lock()
+            defer { lock.unlock() }
+            yield &internalValue
+        }
+    }
+    
+    public init(initialValue: Value) {
+        self.internalValue = initialValue
+    }
+    
+    public func locking<T>(_ block: (inout Value) throws -> T) rethrows -> T {
+        try lock.withLock { try block(&internalValue) }
+    }
+}
+
+public final class ReadWriteLocked<Value> : @unchecked Sendable {
+    
+    private var internalValue: Value
+    
+    private let rwlock = ReadWriteLock()
+    
+    public var protectedValue: Value {
+        get {
+            rwlock.withReaderLock { internalValue }
+        }
+        _modify {
+            rwlock.lockWrite()
+            defer { rwlock.unlock() }
+            yield &internalValue
+        }
+    }
+    
+    public init(initialValue: Value) {
+        self.internalValue = initialValue
+    }
+    
+    public func readLocking<T>(_ block: (Value) throws -> T) rethrows -> T {
+        try rwlock.withReaderLock{ try block(internalValue) }
+    }
+    
+    public func writeLocking<T>(_ block: (inout Value) throws -> T) rethrows -> T {
+        try rwlock.withWriterLock{ try block(&internalValue) }
+    }
+    
+    
 }

--- a/Sources/OpenTelemetrySdk/Logs/LoggerBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Logs/LoggerBuilderSdk.swift
@@ -7,8 +7,8 @@ import Foundation
 import OpenTelemetryApi
 
 public class LoggerBuilderSdk: LoggerBuilder {
-  private var registry: ComponentRegistry<LoggerSdk>
-  private var instrumentationScopeName: String
+  private let registry: ComponentRegistry<LoggerSdk>
+  private let instrumentationScopeName: String
   private var eventDomain: String?
   private var schemaUrl: String?
   private var attributes: [String: AttributeValue]?

--- a/Sources/OpenTelemetrySdk/Logs/LoggerProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Logs/LoggerProviderSdk.swift
@@ -8,7 +8,7 @@ import OpenTelemetryApi
 
 public class LoggerProviderSdk: LoggerProvider {
   private var sharedState: LoggerSharedState
-  private var loggerRegistry: ComponentRegistry<LoggerSdk>
+  private let loggerRegistry: ComponentRegistry<LoggerSdk>
   public init(clock: Clock = MillisClock(),
               resource: Resource = EnvVarResource.get(),
               logLimits: LogLimits = LogLimits(),

--- a/Sources/OpenTelemetrySdk/Metrics/DoubleCounterMeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/DoubleCounterMeterBuilderSdk.swift
@@ -7,14 +7,14 @@ import Foundation
 import OpenTelemetryApi
 
 public class DoubleCounterMeterBuilderSdk: InstrumentBuilder, DoubleCounterBuilder {
-  init(meterProviderSharedState: inout MeterProviderSharedState,
-       meterSharedState: inout MeterSharedState,
+  init(meterProviderSharedState: MeterProviderSharedState,
+       meterSharedState: MeterSharedState,
        name: String,
        description: String,
        unit: String) {
     super.init(
-      meterProviderSharedState: &meterProviderSharedState,
-      meterSharedState: &meterSharedState,
+      meterProviderSharedState: meterProviderSharedState,
+      meterSharedState: meterSharedState,
       type: .counter,
       valueType: .double,
       description: description,

--- a/Sources/OpenTelemetrySdk/Metrics/DoubleGaugeBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/DoubleGaugeBuilderSdk.swift
@@ -7,10 +7,10 @@ import Foundation
 import OpenTelemetryApi
 
 public class DoubleGaugeBuilderSdk: InstrumentBuilder, DoubleGaugeBuilder {
-  init(meterProviderSharedState: inout MeterProviderSharedState, meterSharedState: inout MeterSharedState, name: String) {
+  init(meterProviderSharedState: MeterProviderSharedState, meterSharedState: MeterSharedState, name: String) {
     super.init(
-      meterProviderSharedState: &meterProviderSharedState,
-      meterSharedState: &meterSharedState,
+      meterProviderSharedState: meterProviderSharedState,
+      meterSharedState: meterSharedState,
       type: .observableGauge,
       valueType: .double,
       description: "",

--- a/Sources/OpenTelemetrySdk/Metrics/DoubleHistogramMeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/DoubleHistogramMeterBuilderSdk.swift
@@ -7,14 +7,14 @@ import Foundation
 import OpenTelemetryApi
 
 public class DoubleHistogramMeterBuilderSdk: InstrumentBuilder, DoubleHistogramBuilder {
-  init(meterProviderSharedState: inout MeterProviderSharedState,
-       meterSharedState: inout MeterSharedState,
+  init(meterProviderSharedState: MeterProviderSharedState,
+       meterSharedState: MeterSharedState,
        name: String,
        description: String = "",
        unit: String = "") {
     super.init(
-      meterProviderSharedState: &meterProviderSharedState,
-      meterSharedState: &meterSharedState,
+      meterProviderSharedState: meterProviderSharedState,
+      meterSharedState: meterSharedState,
       type: .histogram,
       valueType: .double,
       description: description,

--- a/Sources/OpenTelemetrySdk/Metrics/DoubleUpDownCounterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/DoubleUpDownCounterBuilderSdk.swift
@@ -7,14 +7,14 @@ import Foundation
 import OpenTelemetryApi
 
 public class DoubleUpDownCounterBuilderSdk: InstrumentBuilder, DoubleUpDownCounterBuilder {
-  init(meterProviderSharedState: inout MeterProviderSharedState,
-       meterSharedState: inout MeterSharedState,
+  init(meterProviderSharedState: MeterProviderSharedState,
+       meterSharedState: MeterSharedState,
        name: String,
        description: String,
        unit: String) {
     super.init(
-      meterProviderSharedState: &meterProviderSharedState,
-      meterSharedState: &meterSharedState,
+      meterProviderSharedState: meterProviderSharedState,
+      meterSharedState: meterSharedState,
       type: .upDownCounter,
       valueType: .double,
       description: description,

--- a/Sources/OpenTelemetrySdk/Metrics/Exemplar/ReservoirCell.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Exemplar/ReservoirCell.swift
@@ -8,7 +8,7 @@ import OpenTelemetryApi
 
 public class ReservoirCell {
   let clock: Clock
-  let attributes = ReadWriteLocked< [String: AttributeValue]>(initialValue: [:])
+  let attributes = ReadWriteLocked<[String: AttributeValue]>(initialValue: [:])
   var spanContext: SpanContext?
   var recordTime: UInt64 = 0
 

--- a/Sources/OpenTelemetrySdk/Metrics/InstrumentBuilder.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/InstrumentBuilder.swift
@@ -16,7 +16,7 @@ public class InstrumentBuilder {
   var instrumentName: String
   var explicitBucketBoundariesAdvice: [Double]?
 
-  init(meterProviderSharedState: inout MeterProviderSharedState, meterSharedState: inout MeterSharedState, type: InstrumentType, valueType: InstrumentValueType, description: String, unit: String, instrumentName: String) {
+  init(meterProviderSharedState: MeterProviderSharedState, meterSharedState: MeterSharedState, type: InstrumentType, valueType: InstrumentValueType, description: String, unit: String, instrumentName: String) {
     self.meterProviderSharedState = meterProviderSharedState
     self.meterSharedState = meterSharedState
     self.type = type
@@ -40,8 +40,8 @@ public extension InstrumentBuilder {
     return self
   }
 
-  internal func swapBuilder<T: InstrumentBuilder>(_ builder: (inout MeterProviderSharedState, inout MeterSharedState, String, String, String) -> T) -> T {
-    let newBuilder = builder(&meterProviderSharedState, &meterSharedState, instrumentName, description, unit)
+  internal func swapBuilder<T: InstrumentBuilder>(_ builder: (MeterProviderSharedState, MeterSharedState, String, String, String) -> T) -> T {
+    let newBuilder = builder(meterProviderSharedState, meterSharedState, instrumentName, description, unit)
     newBuilder.explicitBucketBoundariesAdvice = self.explicitBucketBoundariesAdvice
     return newBuilder
   }

--- a/Sources/OpenTelemetrySdk/Metrics/LongCounterMeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/LongCounterMeterBuilderSdk.swift
@@ -7,12 +7,12 @@ import Foundation
 import OpenTelemetryApi
 
 public class LongCounterMeterBuilderSdk: InstrumentBuilder, LongCounterBuilder {
-  init(meterProviderSharedState: inout MeterProviderSharedState,
-       meterSharedState: inout MeterSharedState,
+  init(meterProviderSharedState: MeterProviderSharedState,
+       meterSharedState: MeterSharedState,
        name: String) {
     super.init(
-      meterProviderSharedState: &meterProviderSharedState,
-      meterSharedState: &meterSharedState,
+      meterProviderSharedState: meterProviderSharedState,
+      meterSharedState: meterSharedState,
       type: .counter,
       valueType: .long,
       description: "",

--- a/Sources/OpenTelemetrySdk/Metrics/LongGaugeBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/LongGaugeBuilderSdk.swift
@@ -7,10 +7,10 @@ import Foundation
 import OpenTelemetryApi
 
 public class LongGaugeBuilderSdk: InstrumentBuilder, LongGaugeBuilder {
-  init(meterProviderSharedState: inout MeterProviderSharedState, meterSharedState: inout MeterSharedState, name: String, description: String, unit: String) {
+  init(meterProviderSharedState: MeterProviderSharedState, meterSharedState: MeterSharedState, name: String, description: String, unit: String) {
     super.init(
-      meterProviderSharedState: &meterProviderSharedState,
-      meterSharedState: &meterSharedState,
+      meterProviderSharedState: meterProviderSharedState,
+      meterSharedState: meterSharedState,
       type: .observableGauge,
       valueType: .long,
       description: description,

--- a/Sources/OpenTelemetrySdk/Metrics/LongHistogramMeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/LongHistogramMeterBuilderSdk.swift
@@ -7,14 +7,14 @@ import Foundation
 import OpenTelemetryApi
 
 public class LongHistogramMeterBuilderSdk: InstrumentBuilder, LongHistogramBuilder {
-  init(meterProviderSharedState: inout MeterProviderSharedState,
-       meterSharedState: inout MeterSharedState,
+  init(meterProviderSharedState: MeterProviderSharedState,
+       meterSharedState: MeterSharedState,
        instrumentName: String,
        description: String,
        unit: String) {
     super.init(
-      meterProviderSharedState: &meterProviderSharedState,
-      meterSharedState: &meterSharedState,
+      meterProviderSharedState: meterProviderSharedState,
+      meterSharedState: meterSharedState,
       type: .histogram,
       valueType: .long,
       description: description,

--- a/Sources/OpenTelemetrySdk/Metrics/LongUpDownCounterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/LongUpDownCounterBuilderSdk.swift
@@ -7,12 +7,12 @@ import Foundation
 import OpenTelemetryApi
 
 public class LongUpDownCounterBuilderSdk: InstrumentBuilder, LongUpDownCounterBuilder {
-  init(meterProviderSharedState: inout MeterProviderSharedState,
-       meterSharedState: inout MeterSharedState,
+  init(meterProviderSharedState: MeterProviderSharedState,
+       meterSharedState: MeterSharedState,
        name: String) {
     super.init(
-      meterProviderSharedState: &meterProviderSharedState,
-      meterSharedState: &meterSharedState,
+      meterProviderSharedState: meterProviderSharedState,
+      meterSharedState: meterSharedState,
       type: .upDownCounter,
       valueType: .long,
       description: "",

--- a/Sources/OpenTelemetrySdk/Metrics/MeterBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterBuilderSdk.swift
@@ -7,14 +7,14 @@ import Foundation
 import OpenTelemetryApi
 
 public class MeterBuilderSdk: MeterBuilder {
-  private let registry: ComponentRegistry<MeterSdk>
+  private let registry: ReadWriteLocked<ComponentRegistry<MeterSdk>>
   private let instrumentationScopeName: String
   private var instrumentationVersion: String?
   private var attributes: [String: AttributeValue]?
   private var schemaUrl: String?
 
   init(registry: ComponentRegistry<MeterSdk>, instrumentationScopeName: String) {
-    self.registry = registry
+    self.registry = .init(initialValue:registry)
     self.instrumentationScopeName = instrumentationScopeName
   }
 
@@ -34,6 +34,6 @@ public class MeterBuilderSdk: MeterBuilder {
   }
 
   public func build() -> MeterSdk {
-    return registry.get(name: instrumentationScopeName, version: instrumentationVersion, schemaUrl: schemaUrl)
+    return registry.protectedValue.get(name: instrumentationScopeName, version: instrumentationVersion, schemaUrl: schemaUrl)
   }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/MeterProviderSdk.swift
@@ -19,7 +19,7 @@ public class MeterProviderSdk: MeterProvider {
   var registeredReaders = [RegisteredReader]()
   var registeredViews = [RegisteredView]()
 
-  var componentRegistry: ComponentRegistry<MeterSdk>!
+  let componentRegistry: ComponentRegistry<MeterSdk>!
 
   public func get(name: String) -> MeterSdk {
     meterBuilder(name: name).build()
@@ -57,11 +57,11 @@ public class MeterProviderSdk: MeterProvider {
 
     meterProviderSharedState = MeterProviderSharedState(clock: clock, resource: resource, startEpochNanos: startEpochNano, exemplarFilter: exemplarFilter)
 
-    componentRegistry = ComponentRegistry { scope in
+    componentRegistry = ComponentRegistry { [meterProviderSharedState, registeredReaders] scope in
       MeterSdk(
-        meterProviderSharedState: &self.meterProviderSharedState,
+        meterProviderSharedState: meterProviderSharedState,
         instrumentScope: scope,
-        registeredReaders: &self.registeredReaders
+        registeredReaders: registeredReaders
       )
     }
 

--- a/Tests/OpenTelemetryApiTests/Baggage/DefaultBaggageManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/DefaultBaggageManagerTests.swift
@@ -68,7 +68,6 @@ class DefaultBaggageManagerTests: DefaultBaggageManagerTestsInfo {
 
     func testWithContextUsingWrap() {
       let expec = expectation(description: "testWithContextUsingWrap")
-      _ = DispatchSemaphore(value: 0)
       OpenTelemetry.instance.contextProvider.withActiveBaggage(baggage) {
         XCTAssertTrue(defaultBaggageManager.getCurrentBaggage() === baggage)
         Task {

--- a/Tests/OpenTelemetrySdkTests/Metrics/Aggregation/DoubleBase2ExponentialHistogramAggregatorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Aggregation/DoubleBase2ExponentialHistogramAggregatorTests.swift
@@ -87,8 +87,6 @@ class DoubleBase2ExponentialHistogramAggregatorTests: XCTestCase {
     let aggregator = DoubleBase2ExponentialHistogramAggregator(maxBuckets: 160, maxScale: 20, reservoirSupplier: { self.reservoir })
     let attr: [String: AttributeValue] = ["test": .string("value")]
 
-    _ = DoubleExemplarData(value: 1.0, epochNanos: 2, filteredAttributes: attr)
-
     let handle = aggregator.createHandle() as! DoubleBase2ExponentialHistogramAggregator.Handle
     handle.recordDouble(value: 0, attributes: attr)
 

--- a/Tests/OpenTelemetrySdkTests/Metrics/Exemplar/ReservoirCellTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Exemplar/ReservoirCellTests.swift
@@ -22,7 +22,7 @@ class ReservoirCellTests: XCTestCase {
     reservoirCell.recordLongValue(value: 10, attributes: attributes)
 
     XCTAssertEqual(reservoirCell.longValue, 10)
-    XCTAssertEqual(reservoirCell.attributes, attributes)
+    XCTAssertEqual(reservoirCell.attributes.protectedValue, attributes)
     XCTAssertEqual(reservoirCell.spanContext, nil)
   }
 
@@ -31,7 +31,7 @@ class ReservoirCellTests: XCTestCase {
     reservoirCell.recordDoubleValue(value: 3.14, attributes: attributes)
 
     XCTAssertEqual(reservoirCell.doubleValue, 3.14)
-    XCTAssertEqual(reservoirCell.attributes, attributes)
+    XCTAssertEqual(reservoirCell.attributes.protectedValue, attributes)
     XCTAssertEqual(reservoirCell.spanContext, nil)
   }
 
@@ -46,7 +46,7 @@ class ReservoirCellTests: XCTestCase {
     XCTAssertEqual(result?.filteredAttributes, attributes)
     XCTAssertEqual(result?.spanContext, nil)
 
-    XCTAssertEqual(reservoirCell.attributes, [:])
+    XCTAssertEqual(reservoirCell.attributes.protectedValue, [:])
     XCTAssertEqual(reservoirCell.longValue, 0)
     XCTAssertEqual(reservoirCell.spanContext, nil)
     XCTAssertEqual(reservoirCell.recordTime, 0)
@@ -63,7 +63,7 @@ class ReservoirCellTests: XCTestCase {
     XCTAssertEqual(result?.filteredAttributes, attributes)
     XCTAssertEqual(result?.spanContext, nil)
 
-    XCTAssertEqual(reservoirCell.attributes, [:])
+    XCTAssertEqual(reservoirCell.attributes.protectedValue, [:])
     XCTAssertEqual(reservoirCell.doubleValue, 0)
     XCTAssertEqual(reservoirCell.spanContext, nil)
     XCTAssertEqual(reservoirCell.recordTime, 0)
@@ -75,7 +75,7 @@ class ReservoirCellTests: XCTestCase {
 
     reservoirCell.reset()
 
-    XCTAssertEqual(reservoirCell.attributes, [:])
+    XCTAssertEqual(reservoirCell.attributes.protectedValue, [:])
     XCTAssertEqual(reservoirCell.longValue, 0)
     XCTAssertEqual(reservoirCell.doubleValue, 0)
     XCTAssertEqual(reservoirCell.spanContext, nil)

--- a/Tests/OpenTelemetrySdkTests/Metrics/MeterProviderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/MeterProviderSdkTests.swift
@@ -9,10 +9,6 @@ import XCTest
 class MeterProviderSdkTests: XCTestCase {
   var meterProvider = MeterProviderSdk.builder().build()
 
-  func testDefaultGet() {
-    XCTAssertTrue(meterProvider.get(name: "test") is DefaultMeter)
-  }
-
   func testGetSameInstanceForName_WithoutVersion() {
     XCTAssert(meterProvider.get(name: "test") as AnyObject === meterProvider.get(name: "test") as AnyObject)
     XCTAssert(meterProvider.get(name: "test") as AnyObject === meterProvider.meterBuilder(name: "test").build() as AnyObject)


### PR DESCRIPTION
Updated SDK locks to use a more similar to Apple Concurrency's Mutex approach, which allows being used in the future when we transition to Swift 6. It also allows the compiler to help with the errors as the type itself includes the lock.
Removed inout to properties that dont need it.
Updated some properties to constants when mutability is not needed
Cleaned also most warnings