### PR TITLE
 Add HTTPClient protocol for customizable HTTP behavior

### DIFF
--- a/Examples/Custom HTTPClient/README.md
+++ b/Examples/Custom HTTPClient/README.md
@@ -1,0 +1,166 @@
+# Custom HTTPClient Example
+
+This example demonstrates how to use a custom HTTPClient implementation with OpenTelemetry HTTP exporters for authentication and other custom behaviors.
+
+## Token Refresh HTTPClient
+
+```swift
+import Foundation
+import OpenTelemetryProtocolExporterHttp
+
+class AuthTokenHTTPClient: HTTPClient {
+    private let session: URLSession
+    private var authToken: String?
+    private let tokenRefreshURL: URL
+    
+    init(session: URLSession = URLSession.shared, tokenRefreshURL: URL) {
+        self.session = session
+        self.tokenRefreshURL = tokenRefreshURL
+    }
+    
+    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+        var authorizedRequest = request
+        
+        // Add auth token if available
+        if let token = authToken {
+            authorizedRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        
+        let task = session.dataTask(with: authorizedRequest) { [weak self] data, response, error in
+            if let httpResponse = response as? HTTPURLResponse {
+                // Check if token expired (401)
+                if httpResponse.statusCode == 401 {
+                    self?.refreshTokenAndRetry(request: request, completion: completion)
+                    return
+                }
+                
+                // Handle response normally
+                if let error = error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(httpResponse))
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }
+        task.resume()
+    }
+    
+    private func refreshTokenAndRetry(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+        // Implement your token refresh logic here
+        var tokenRequest = URLRequest(url: tokenRefreshURL)
+        tokenRequest.httpMethod = "POST"
+        
+        let task = session.dataTask(with: tokenRequest) { [weak self] data, response, error in
+            if let data = data,
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let newToken = json["access_token"] as? String {
+                self?.authToken = newToken
+                // Retry original request with new token
+                self?.send(request: request, completion: completion)
+            } else {
+                completion(.failure(error ?? URLError(.userAuthenticationRequired)))
+            }
+        }
+        task.resume()
+    }
+}
+
+// Usage
+let customHTTPClient = AuthTokenHTTPClient(tokenRefreshURL: URL(string: "https://auth.example.com/token")!)
+let exporter = OtlpHttpTraceExporter(
+    endpoint: URL(string: "https://api.example.com/v1/traces")!,
+    httpClient: customHTTPClient
+)
+```
+
+## Retry HTTPClient
+
+```swift
+class RetryHTTPClient: HTTPClient {
+    private let baseClient: HTTPClient
+    private let maxRetries: Int
+    
+    init(baseClient: HTTPClient = BaseHTTPClient(), maxRetries: Int = 3) {
+        self.baseClient = baseClient
+        self.maxRetries = maxRetries
+    }
+    
+    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+        sendWithRetry(request: request, attempt: 0, completion: completion)
+    }
+    
+    private func sendWithRetry(request: URLRequest, attempt: Int, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+        baseClient.send(request: request) { [weak self] result in
+            switch result {
+            case .success(let response):
+                if response.statusCode >= 500 && attempt < self?.maxRetries ?? 0 {
+                    // Retry on server errors
+                    DispatchQueue.global().asyncAfter(deadline: .now() + pow(2.0, Double(attempt))) {
+                        self?.sendWithRetry(request: request, attempt: attempt + 1, completion: completion)
+                    }
+                } else {
+                    completion(result)
+                }
+            case .failure:
+                if attempt < self?.maxRetries ?? 0 {
+                    DispatchQueue.global().asyncAfter(deadline: .now() + pow(2.0, Double(attempt))) {
+                        self?.sendWithRetry(request: request, attempt: attempt + 1, completion: completion)
+                    }
+                } else {
+                    completion(result)
+                }
+            }
+        }
+    }
+}
+```
+
+## Custom Headers HTTPClient
+
+```swift
+class CustomHeadersHTTPClient: HTTPClient {
+    private let baseClient: HTTPClient
+    private let customHeaders: [String: String]
+    
+    init(baseClient: HTTPClient = BaseHTTPClient(), customHeaders: [String: String]) {
+        self.baseClient = baseClient
+        self.customHeaders = customHeaders
+    }
+    
+    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+        var modifiedRequest = request
+        
+        // Add custom headers
+        for (key, value) in customHeaders {
+            modifiedRequest.setValue(value, forHTTPHeaderField: key)
+        }
+        
+        baseClient.send(request: modifiedRequest, completion: completion)
+    }
+}
+
+// Usage
+let customClient = CustomHeadersHTTPClient(
+    customHeaders: [
+        "X-API-Key": "your-api-key",
+        "X-Client-Version": "1.0.0"
+    ]
+)
+let exporter = OtlpHttpLogExporter(
+    endpoint: URL(string: "https://api.example.com/v1/logs")!,
+    httpClient: customClient
+)
+```
+
+## Benefits
+
+Using custom HTTPClient implementations allows you to:
+
+- **Authentication**: Implement OAuth2, API key, or other authentication schemes
+- **Retries**: Add exponential backoff retry logic for resilient telemetry export
+- **Custom Headers**: Add API keys, client versions, or other required headers
+- **Request Modification**: Transform requests before sending (e.g., compression, encryption)
+- **Response Handling**: Custom error handling and response processing
+- **Testing**: Mock HTTP clients for unit testing exporters

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/HTTPClient.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/HTTPClient.swift
@@ -1,7 +1,7 @@
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
- */
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
 
 import Foundation
 
@@ -9,11 +9,22 @@ import Foundation
   import FoundationNetworking
 #endif
 
-/// Client for sending requests over HTTP.
-final class HTTPClient {
+/// Protocol for sending HTTP requests, allowing custom implementations for authentication and other behaviors.
+public protocol HTTPClient {
+  /// Sends an HTTP request and calls the completion handler with the result.
+  /// - Parameters:
+  ///   - request: The URLRequest to send
+  ///   - completion: Completion handler called with Result<HTTPURLResponse, Error>
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void)
+}
+
+/// Default implementation of HTTPClient using URLSession.
+public final class BaseHTTPClient: HTTPClient {
   private let session: URLSession
 
-  convenience init() {
+  /// Creates a BaseHTTPClient with default ephemeral session configuration.
+  public convenience init() {
     let configuration: URLSessionConfiguration = .ephemeral
     // NOTE: RUMM-610 Default behaviour of `.ephemeral` session is to cache requests.
     // To not leak requests memory (including their `.httpBody` which may be significant)
@@ -24,12 +35,14 @@ final class HTTPClient {
     self.init(session: URLSession(configuration: configuration))
   }
 
-  init(session: URLSession) {
+  /// Creates a BaseHTTPClient with a custom URLSession.
+  /// - Parameter session: The URLSession to use for HTTP requests
+  public init(session: URLSession) {
     self.session = session
   }
 
-  func send(request: URLRequest,
-            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+  public func send(request: URLRequest,
+                   completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
     let task = session.dataTask(with: request) { data, response, error in
       completion(httpClientResult(for: (data, response, error)))
     }
@@ -38,23 +51,25 @@ final class HTTPClient {
 }
 
 /// An error returned if `URLSession` response state is inconsistent (like no data, no response and no error).
-/// The code execution in `URLSessionTransport` should never reach its initialization.
-struct URLSessionTransportInconsistencyException: Error {}
+struct HTTPClientError: Error, CustomStringConvertible {
+  let description: String
+}
 
-/// As `URLSession` returns 3-values-tuple for request execution, this function applies consistency constraints and turns
-/// it into only two possible states of `HTTPTransportResult`.
-private func httpClientResult(
-  for urlSessionTaskCompletion: (Data?, URLResponse?, Error?)
-) -> Result<HTTPURLResponse, Error> {
-  let (_, response, error) = urlSessionTaskCompletion
+/// Maps `URLSessionDataTask` response to `HTTPClient` response.
+func httpClientResult(for taskResult: (Data?, URLResponse?, Error?)) -> Result<HTTPURLResponse, Error> {
+  let (_, response, error) = taskResult
 
-  if let error {
+  if let error = error {
     return .failure(error)
   }
 
-  if let httpResponse = response as? HTTPURLResponse {
-    return .success(httpResponse)
+  guard let httpResponse = response as? HTTPURLResponse else {
+    return .failure(
+      HTTPClientError(
+        description: "Failed to receive HTTPURLResponse: \(String(describing: response))"
+      )
+    )
   }
 
-  return .failure(URLSessionTransportInconsistencyException())
+  return .success(httpResponse)
 }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
@@ -24,14 +24,30 @@ public class OtlpHttpExporterBase {
 
   // MARK: - Init
 
-  public init(endpoint: URL, config: OtlpConfiguration = OtlpConfiguration(), useSession: URLSession? = nil, envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+  // New initializer with HTTPClient support
+  public init(endpoint: URL,
+              config: OtlpConfiguration = OtlpConfiguration(),
+              httpClient: HTTPClient = BaseHTTPClient(),
+              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+    self.envVarHeaders = envVarHeaders
+    self.endpoint = endpoint
+    self.config = config
+    self.httpClient = httpClient
+  }
+
+  // Deprecated initializer for backward compatibility
+  @available(*, deprecated, message: "Use init(endpoint:config:httpClient:envVarHeaders:) instead")
+  public init(endpoint: URL,
+              config: OtlpConfiguration = OtlpConfiguration(),
+              useSession: URLSession? = nil,
+              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
     self.envVarHeaders = envVarHeaders
     self.endpoint = endpoint
     self.config = config
     if let providedSession = useSession {
-      httpClient = HTTPClient(session: providedSession)
+      self.httpClient = BaseHTTPClient(session: providedSession)
     } else {
-      httpClient = HTTPClient()
+      self.httpClient = BaseHTTPClient()
     }
   }
 

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -23,11 +23,11 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter {
 
   override public init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
                        config: OtlpConfiguration = OtlpConfiguration(),
-                       useSession: URLSession? = nil,
+                       httpClient: HTTPClient = BaseHTTPClient(),
                        envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
     super.init(endpoint: endpoint,
                config: config,
-               useSession: useSession,
+               httpClient: httpClient,
                envVarHeaders: envVarHeaders)
   }
 
@@ -36,14 +36,14 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter {
   ///    - endpoint: Exporter endpoint injected as dependency
   ///    - config: Exporter configuration including type of exporter
   ///    - meterProvider: Injected `StableMeterProvider` for metric
-  ///    - useSession: Overridden `URLSession` if any
+  ///    - httpClient: Custom HTTPClient implementation
   ///    - envVarHeaders: Extra header key-values
   public convenience init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
                           config: OtlpConfiguration = OtlpConfiguration(),
                           meterProvider: any MeterProvider,
-                          useSession: URLSession? = nil,
+                          httpClient: HTTPClient = BaseHTTPClient(),
                           envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
-    self.init(endpoint: endpoint, config: config, useSession: useSession,
+    self.init(endpoint: endpoint, config: config, httpClient: httpClient,
               envVarHeaders: envVarHeaders)
     exporterMetrics = ExporterMetrics(type: "log",
                                       meterProvider: meterProvider,

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -41,12 +41,12 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter {
               aggregationTemporalitySelector: AggregationTemporalitySelector =
                 AggregationTemporality.alwaysCumulative(),
               defaultAggregationSelector: DefaultAggregationSelector = AggregationSelector.instance,
-              useSession: URLSession? = nil,
+              httpClient: HTTPClient = BaseHTTPClient(),
               envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
     self.aggregationTemporalitySelector = aggregationTemporalitySelector
     self.defaultAggregationSelector = defaultAggregationSelector
 
-    super.init(endpoint: endpoint, config: config, useSession: useSession,
+    super.init(endpoint: endpoint, config: config, httpClient: httpClient,
                envVarHeaders: envVarHeaders)
   }
 
@@ -57,7 +57,7 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter {
   ///    - meterProvider: Injected `StableMeterProvider` for metric
   ///    - aggregationTemporalitySelector: aggregator
   ///    - defaultAggregationSelector: default aggregator
-  ///    - useSession: Overridden `URLSession` if any
+  ///    - httpClient: Custom HTTPClient implementation
   ///    - envVarHeaders: Extra header key-values
   public convenience init(endpoint: URL,
                           config: OtlpConfiguration = OtlpConfiguration(),
@@ -66,13 +66,13 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter {
                             AggregationTemporality.alwaysCumulative(),
                           defaultAggregationSelector: DefaultAggregationSelector = AggregationSelector
                             .instance,
-                          useSession: URLSession? = nil,
+                          httpClient: HTTPClient = BaseHTTPClient(),
                           envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
     self.init(endpoint: endpoint,
               config: config,
               aggregationTemporalitySelector: aggregationTemporalitySelector,
               defaultAggregationSelector: defaultAggregationSelector,
-              useSession: useSession,
+              httpClient: httpClient,
               envVarHeaders: envVarHeaders)
     exporterMetrics = ExporterMetrics(type: "metric",
                                       meterProvider: meterProvider,

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
@@ -22,14 +22,13 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter {
   private let exporterLock = Lock()
   private var exporterMetrics: ExporterMetrics?
 
-  override
-  public init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
-              config: OtlpConfiguration = OtlpConfiguration(),
-              useSession: URLSession? = nil,
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+  override public init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
+                       config: OtlpConfiguration = OtlpConfiguration(),
+                       httpClient: HTTPClient = BaseHTTPClient(),
+                       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
     super.init(endpoint: endpoint,
                config: config,
-               useSession: useSession,
+               httpClient: httpClient,
                envVarHeaders: envVarHeaders)
   }
 
@@ -38,14 +37,14 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter {
   ///    - endpoint: Exporter endpoint injected as dependency
   ///    - config: Exporter configuration including type of exporter
   ///    - meterProvider: Injected `StableMeterProvider` for metric
-  ///    - useSession: Overridden `URLSession` if any
+  ///    - httpClient: Custom HTTPClient implementation
   ///    - envVarHeaders: Extra header key-values
   public convenience init(endpoint: URL,
                           config: OtlpConfiguration,
                           meterProvider: any MeterProvider,
-                          useSession: URLSession? = nil,
+                          httpClient: HTTPClient = BaseHTTPClient(),
                           envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
-    self.init(endpoint: endpoint, config: config, useSession: useSession,
+    self.init(endpoint: endpoint, config: config, httpClient: httpClient,
               envVarHeaders: envVarHeaders)
     exporterMetrics = ExporterMetrics(type: "span",
                                       meterProvider: meterProvider,

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHTTPExporterBaseTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHTTPExporterBaseTests.swift
@@ -42,8 +42,9 @@
         endpoint: URL(
           string: "http://example.com"
         )!,
-                                            config: config
-)
+        config: config,
+        httpClient: BaseHTTPClient()
+      )
 
       let body = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest.with {
         $0.resourceSpans = SpanAdapter.toProtoResourceSpans(spanDataList: spans)
@@ -68,8 +69,9 @@
         endpoint: URL(
           string: "http://example.com"
         )!,
-                                            config: config
-)
+        config: config,
+        httpClient: BaseHTTPClient()
+      )
 
       let body = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest.with {
         $0.resourceSpans = SpanAdapter.toProtoResourceSpans(spanDataList: spans)
@@ -94,8 +96,9 @@
         endpoint: URL(
           string: "http://example.com"
         )!,
-                                            config: config
-)
+        config: config,
+        httpClient: BaseHTTPClient()
+      )
 
       let body = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest.with {
         $0.resourceSpans = SpanAdapter.toProtoResourceSpans(spanDataList: spans)

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpTraceExporterTests.swift
@@ -64,7 +64,7 @@ class OtlpHttpTraceExporterTests: XCTestCase {
   // There is a more complete test as part of the DataDog exporter test
   func testHttpClient() {
     let endpoint = URL(string: "http://localhost:\(testServer.serverPort)/some-route")!
-    let httpClient = HTTPClient()
+    let httpClient = BaseHTTPClient()
     var request = URLRequest(url: endpoint)
     request.httpMethod = HTTPMethod.GET.rawValue
 


### PR DESCRIPTION
Hi maintainers,
I needed to add auth headers to OTLP requests and found there's no way to do it without forking. So I made HTTPClient a protocol.

## The problem

We use bearer tokens that expire every hour. Currently have to fork the whole library just to add `Authorization` headers. Saw #676 has the same issue.

## What I changed

- HTTPClient is now a protocol
- Renamed the old class to BaseHTTPClient (default implementation)
- Exporters can now accept any HTTPClient implementation
- Added examples showing how to do auth, retries, etc

## Usage

```swift
class MyHTTPClient: HTTPClient {
    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
        var req = request
        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
        // ... rest of implementation
    }
}

let exporter = OtlpHttpTraceExporter(
    endpoint: myEndpoint,
    httpClient: MyHTTPClient()
)
```

## Compatibility

Nothing breaks. If you don't pass httpClient, it uses BaseHTTPClient which is the same as before.

Let me know if you want any changes. Thanks!