### PR TITLE
Added tests to `uploadTask` instrumentation

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.0'
+        xcode-version: '16.4'
     - name: Build and Test for macOS
       run: swift test --enable-code-coverage
     - name: Upload Code coverage
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.0'
+        xcode-version: '16.4'
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for iOS
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.0'
+        xcode-version: '16.4'
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for tvOS
@@ -72,7 +72,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.0'
+        xcode-version: '16.4'
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for watchOS
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.0'
+        xcode-version: '16.4'
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for visionOS

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.4'
+        xcode-version: latest-stable
     - name: Build and Test for macOS
       run: swift test --enable-code-coverage
     - name: Upload Code coverage
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.4'
+        xcode-version: latest-stable
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for iOS
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.4'
+        xcode-version: latest-stable
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for tvOS
@@ -72,7 +72,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.4'
+        xcode-version: latest-stable
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for watchOS
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
-        xcode-version: '16.4'
+        xcode-version: latest-stable
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for visionOS

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -29,6 +29,9 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      with:
+        xcode-version: '16.0'
     - name: Build and Test for macOS
       run: swift test --enable-code-coverage
     - name: Upload Code coverage
@@ -41,6 +44,9 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      with:
+        xcode-version: '16.0'
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for iOS
@@ -51,6 +57,9 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      with:
+        xcode-version: '16.0'
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for tvOS
@@ -61,6 +70,9 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      with:
+        xcode-version: '16.0'
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for watchOS
@@ -71,6 +83,9 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      with:
+        xcode-version: '16.0'
     - name: Install Homebrew kegs
       run: make setup-brew
     - name: Build for visionOS

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME="opentelemetry-swift-Package"
 
 XCODEBUILD_OPTIONS_IOS=\
 	-configuration Debug \
-	-destination 'platform=iOS Simulator,OS=latest' \
+	-destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -10,7 +10,7 @@ XCODEBUILD_OPTIONS_IOS=\
 
 XCODEBUILD_OPTIONS_TVOS=\
 	-configuration Debug \
-	-destination 'platform=tvOS Simulator,OS=latest' \
+	-destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -18,7 +18,7 @@ XCODEBUILD_OPTIONS_TVOS=\
 
 XCODEBUILD_OPTIONS_WATCHOS=\
 	-configuration Debug \
-	-destination 'platform=watchOS Simulator,OS=latest' \
+	-destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm),OS=11.5' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -26,7 +26,7 @@ XCODEBUILD_OPTIONS_WATCHOS=\
 
 XCODEBUILD_OPTIONS_VISIONOS=\
 	-configuration Debug \
-	-destination 'platform=visionOS Simulator,OS=latest' \
+	-destination 'platform=visionOS Simulator,name=Apple Vision Pro,OS=2.0' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME="opentelemetry-swift-Package"
 
 XCODEBUILD_OPTIONS_IOS=\
 	-configuration Debug \
-	-destination platform='iOS Simulator,name=iPhone 16,OS=18.0' \
+	-destination 'platform=iOS Simulator,OS=latest' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -10,7 +10,7 @@ XCODEBUILD_OPTIONS_IOS=\
 
 XCODEBUILD_OPTIONS_TVOS=\
 	-configuration Debug \
-	-destination platform='tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.0' \
+	-destination 'platform=tvOS Simulator,OS=latest' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -18,7 +18,7 @@ XCODEBUILD_OPTIONS_TVOS=\
 
 XCODEBUILD_OPTIONS_WATCHOS=\
 	-configuration Debug \
-	-destination platform='watchOS Simulator,name=Apple Watch Series 10 (46mm),OS=11.0' \
+	-destination 'platform=watchOS Simulator,OS=latest' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -26,7 +26,7 @@ XCODEBUILD_OPTIONS_WATCHOS=\
 
 XCODEBUILD_OPTIONS_VISIONOS=\
 	-configuration Debug \
-	-destination platform='visionOS Simulator,name=Apple Vision Pro,OS=2.0' \
+	-destination 'platform=visionOS Simulator,OS=latest' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ XCODEBUILD_OPTIONS_WATCHOS=\
 
 XCODEBUILD_OPTIONS_VISIONOS=\
 	-configuration Debug \
-	-destination 'platform=visionOS Simulator,name=Apple Vision Pro,OS=2.0' \
+	-destination 'platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ XCODEBUILD_OPTIONS_WATCHOS=\
 
 XCODEBUILD_OPTIONS_VISIONOS=\
 	-configuration Debug \
-	-destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+	-destination 'platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME="opentelemetry-swift-Package"
 
 XCODEBUILD_OPTIONS_IOS=\
 	-configuration Debug \
-	-destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+	-destination 'platform=iOS Simulator,name=iPhone 16' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -10,7 +10,7 @@ XCODEBUILD_OPTIONS_IOS=\
 
 XCODEBUILD_OPTIONS_TVOS=\
 	-configuration Debug \
-	-destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5' \
+	-destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -18,7 +18,7 @@ XCODEBUILD_OPTIONS_TVOS=\
 
 XCODEBUILD_OPTIONS_WATCHOS=\
 	-configuration Debug \
-	-destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm),OS=11.5' \
+	-destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \
@@ -26,7 +26,7 @@ XCODEBUILD_OPTIONS_WATCHOS=\
 
 XCODEBUILD_OPTIONS_VISIONOS=\
 	-configuration Debug \
-	-destination 'platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5' \
+	-destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -417,6 +417,41 @@ class URLSessionInstrumentationTests: XCTestCase {
     XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
   }
 
+  public func testUploadTaskWithUrlBlock() {
+    let url = URL(string: "http://localhost:33333/success")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+
+    let session = URLSession(configuration: URLSessionConfiguration.default, delegate: sessionDelegate, delegateQueue: nil)
+    let task = session.uploadTask(
+        with: request,
+        from: "UploadData".data(using: .utf8)!
+    )
+    task.resume()
+    URLSessionInstrumentationTests.semaphore.wait()
+
+    XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled)
+    XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled)
+
+    XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
+  }
+
+  public func testUploadFileTaskWithUrlBlock() {
+    let url = URL(string: "http://localhost:33333/success")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    let session = URLSession(configuration: URLSessionConfiguration.default, delegate: sessionDelegate, delegateQueue: nil)
+
+    let task = session.uploadTask(with: URLRequest(url: url), fromFile: url)
+    task.resume()
+    URLSessionInstrumentationTests.semaphore.wait()
+
+    XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled)
+    XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled)
+
+    XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
+  }
+
   public func testDownloadTaskWithRequestBlock() {
     let url = URL(string: "http://localhost:33333/success")!
     let request = URLRequest(url: url)


### PR DESCRIPTION
# Overview
Added some tests to prevent [this kind of issues](https://github.com/open-telemetry/opentelemetry-swift/pull/873) when using `URLSessionInstrumentation`

## Extra
-> Tests were failing due to changes in how the [macos-15 runners work](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-simulators). Basically, [runtimes were removed](https://github.com/actions/runner-images/issues/12758#issuecomment-3187480561) and the default Xcode behavior changed. Therefore, I added a step to explicitly select a specific Xcode version (in this case, Xcode 16.4) and updated the `Makefile` so that each build/test uses the runtime associated with Xcode 16.4 (iOS/tvOS 18.5, watchOS 11.5, and visionOS 2.5).