### PR TITLE
fix: OtlpHttpLogRecordExporter request headers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mw99/DataCompression",
       "state" : {
-        "revision" : "5ab15951321b08b74511601cbd0497667649d70b",
-        "version" : "3.8.0"
+        "revision" : "16f858982a077451ce3bdbd9144d3073ec85b6e4",
+        "version" : "3.9.0"
       }
     },
     {

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -69,16 +69,7 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter {
       }
 
     var request = createRequest(body: body, endpoint: endpoint)
-    if let headers = envVarHeaders {
-      headers.forEach { key, value in
-        request.addValue(value, forHTTPHeaderField: key)
-      }
-
-    } else if let headers = config.headers {
-      headers.forEach { key, value in
-        request.addValue(value, forHTTPHeaderField: key)
-      }
-    }
+    
     exporterMetrics?.addSeen(value: sendingLogRecords.count)
     request.timeoutInterval = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
     httpClient.send(request: request) { [weak self] result in


### PR DESCRIPTION
This addresses the same issue as https://github.com/open-telemetry/opentelemetry-swift/pull/877
Headers values are added twice which concatenates the same value again over the existing for the same header.

`createRequest(body:endpoint:)` in `OtlpHttpExporterBase` already considers `envVarHeaders` and `config.headers`
Additional looping on those headers in `OtlpHttpTraceExporter` after the request is created is appending the same value again.

Tests are also added