### PR TITLE
added delegate instrumentation exclude list

### DIFF
--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -370,7 +370,12 @@ class URLSessionInstrumentationTests: XCTestCase {
     task.resume()
     URLSessionInstrumentationTests.semaphore.wait()
 
+
+#if os(watchOS)
+    XCTAssertEqual(1, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
+#else
     XCTAssertEqual(0, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
+#endif
     XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled)
     XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
   }
@@ -605,7 +610,11 @@ class URLSessionInstrumentationTests: XCTestCase {
 
     _ = try await URLSession.shared.data(for: request)
 
+#if os(watchOS)
+    XCTAssertEqual(1, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
+#else
     XCTAssertEqual(0, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
+#endif
     XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled)
     XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
   }


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-swift/issues/823

NSURLSessionInstrumentation fix. "__NSCFURLProxySessionConnection" was double instrumented creating two spans for the same network request. preventing it from being instrumented as a delegate prevented the duplication.

also fixed replaced explicit set (to implicit)  of `configuration` var per swiftlint

### Testing
Use the `Network Sample` example to reproduce this issue.  Comment out the other example requests besides `simpleNetworkCallWithDelegate()` and you'll be able to observe a duplicate trace being reported in the logs, before applying this fix. 

Note: This PR prevents a duplicate trace from being recorded, but due to the addition of `__NSCFURLProxySessionConnection` being added to the call chain, `processAndLogRequest` is still called twice. 
This should be investigated further. 