### PR TITLE
feat: sessions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mw99/DataCompression",
       "state" : {
-        "revision" : "5ab15951321b08b74511601cbd0497667649d70b",
-        "version" : "3.8.0"
+        "revision" : "16f858982a077451ce3bdbd9144d3073ec85b6e4",
+        "version" : "3.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
     .library(name: "InMemoryExporter", targets: ["InMemoryExporter"]),
     .library(name: "OTelSwiftLog", targets: ["OTelSwiftLog"]),
     .library(name: "BaggagePropagationProcessor", targets: ["BaggagePropagationProcessor"]),
+    .library(name: "Sessions", targets: ["Sessions"]),
     .executable(name: "ConcurrencyContext", targets: ["ConcurrencyContext"]),
     .executable(name: "loggingTracer", targets: ["LoggingTracer"]),
     .executable(name: "StableMetricSample", targets: ["StableMetricSample"]),
@@ -143,6 +144,15 @@ let package = Package(
       ],
       path: "Sources/Contrib/Processors/BaggagePropagationProcessor"
     ),
+    .target(
+      name: "Sessions",
+      dependencies: [
+        "OpenTelemetryApi",
+        "OpenTelemetrySdk",
+      ],
+      path: "Sources/Instrumentation/Sessions",
+      exclude: ["README.md"]
+    ),
     .testTarget(
       name: "OTelSwiftLogTests",
       dependencies: ["OTelSwiftLog"],
@@ -207,6 +217,15 @@ let package = Package(
         "BaggagePropagationProcessor",
         "InMemoryExporter",
       ]
+    ),
+    .testTarget(
+      name: "SessionTests",
+      dependencies: [
+        "Sessions",
+        "OpenTelemetrySdk",
+        "OpenTelemetryTestUtils",
+      ],
+      path: "Tests/InstrumentationTests/SessionTests"
     ),
     .executableTarget(
       name: "LoggingTracer",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Metrics is implemented using an outdated spec, is fully functional but will chan
 * `NetworkStatus`
 * `SDKResourceExtension`
 * `SignPostIntegration`
+* `SessionsEventInstrumentation`
 
 ### Third-party exporters
 In addition to the specified OpenTelemetry exporters, some third-party exporters have been contributed and can be found in the following repos: 

--- a/Sources/Instrumentation/Sessions/README.md
+++ b/Sources/Instrumentation/Sessions/README.md
@@ -1,0 +1,166 @@
+# Session Instrumentation
+
+Automatic session tracking for OpenTelemetry Swift applications. Creates unique session identifiers, tracks session lifecycle events, and automatically adds session context to all telemetry data.
+
+## Features
+
+- **Automatic Session Management** - Creates and manages session lifecycles with configurable timeouts
+- **Session Events** - Emits OpenTelemetry log records for session start/end events
+- **Span Attribution** - Automatically adds session IDs to all spans via span processor
+- **Persistence** - Sessions persist across app restarts using UserDefaults
+- **Thread Safety** - All components are thread-safe for concurrent access
+
+## Setup
+
+**Basic Setup** (default 30-minute timeout):
+```swift
+import Sessions
+import OpenTelemetrySdk
+
+let sessionInstrumentation = SessionEventInstrumentation()
+let sessionSpanProcessor = SessionSpanProcessor()
+
+let tracerProvider = TracerProviderBuilder()
+    .add(spanProcessor: sessionSpanProcessor)
+    .build()
+```
+
+**Custom Configuration**:
+```swift
+let sessionConfig = SessionConfigBuilder()
+    .with(sessionTimeout: 45 * 60) // 45 minutes
+    .build()
+let sessionManager = SessionManager(configuration: sessionConfig)
+SessionManagerProvider.register(sessionManager: sessionManager)
+```
+
+**Getting Session Information**:
+```swift
+// Get current session (extends session if active)
+let session = SessionManagerProvider.getInstance().getSession()
+print("Session ID: \(session.id)")
+
+// Peek at session without extending it
+if let session = SessionManagerProvider.getInstance().peekSession() {
+    print("Current session: \(session.id)")
+}
+```
+
+## Components
+
+### SessionManager
+Manages session lifecycle with automatic expiration and renewal.
+```swift
+let manager = SessionManager(configuration: SessionConfig(sessionTimeout: 1800))
+let session = manager.getSession() // Creates or extends session
+let session = manager.peekSession() // Peek without extending
+```
+
+### SessionManagerProvider
+Provides thread-safe singleton access to SessionManager.
+```swift
+// Register a custom session manager
+let manager = SessionManager(configuration: SessionConfig(sessionTimeout: 3600))
+SessionManagerProvider.register(sessionManager: manager)
+
+// Access from anywhere
+let session = SessionManagerProvider.getInstance().getSession()
+```
+
+### SessionSpanProcessor
+Automatically adds session IDs to all spans.
+```swift
+let processor = SessionSpanProcessor(sessionManager: sessionManager)
+// Adds session.id and session.previous_id attributes to spans
+```
+
+### SessionEventInstrumentation
+Creates OpenTelemetry log records for session lifecycle events.
+```swift
+let instrumentation = SessionEventInstrumentation()
+// Emits session.start and session.end log records
+```
+
+### Session Model
+Represents a session with ID, timestamps, and expiration logic.
+```swift
+let session = Session(
+    id: "unique-session-id",
+    expireTime: Date(timeIntervalSinceNow: 1800),
+    previousId: "previous-session-id"
+)
+
+print("Expired: \(session.isExpired())")
+print("Duration: \(session.duration ?? 0)")
+```
+
+## Configuration
+
+### SessionConfig
+
+| Field | Type | Description | Default | Required |
+|-------|------|-------------|---------|----------|
+| `sessionTimeout` | `Int` | Duration in seconds after which a session expires if left inactive | `1800` (30 min) | No |
+
+```swift
+let config = SessionConfigBuilder()
+    .with(sessionTimeout: 30 * 60)
+    .build()
+```
+
+### Session Timeout Behavior
+
+- Sessions automatically expire after the configured timeout period of inactivity
+- Accessing a session via `getSession()` extends the expiration time
+- Expired sessions trigger `session.end` events and create new sessions with `previous_id` links
+
+## Session Events
+
+Emits OpenTelemetry log records following semantic conventions:
+
+**session.start Event**:
+```json
+{
+  "body": "session.start",
+  "attributes": {
+    "session.id": "550e8400-e29b-41d4-a716-446655440000",
+    "session.start_time": 1692123456.789,
+    "session.previous_id": "previous-session-id"
+  }
+}
+```
+
+**session.end Event**:
+```json
+{
+  "body": "session.end",
+  "attributes": {
+    "session.id": "550e8400-e29b-41d4-a716-446655440000",
+    "session.start_time": 1692123456.789,
+    "session.end_time": 1692125256.789,
+    "session.duration": 1800.0,
+    "session.previous_id": "previous-session-id"
+  }
+}
+```
+
+## Persistence
+
+Sessions are automatically persisted to UserDefaults and restored on app restart:
+- Active sessions continue from their previous state
+- Expired sessions create new sessions with proper `previous_id` linking
+- Session data is saved periodically (every 30 seconds) to minimize disk I/O
+
+## Thread Safety
+
+All components are designed for concurrent access:
+- `SessionManager` uses locks for thread-safe session access
+- `SessionManagerProvider` provides thread-safe singleton access
+- `SessionStore` handles concurrent persistence operations safely
+
+## Best Practices
+
+1. **Use SessionManagerProvider** - Register your session manager as a singleton for consistent access
+2. **Configure Appropriate Timeouts** - Set session timeouts based on your app's usage patterns
+3. **Add Span Processor Early** - Register the SessionSpanProcessor before creating spans
+4. **Handle Session Events** - Set up SessionEventInstrumentation to capture session lifecycle

--- a/Sources/Instrumentation/Sessions/Session.swift
+++ b/Sources/Instrumentation/Sessions/Session.swift
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Represents an OpenTelemetry session with lifecycle management.
+///
+/// A session tracks user activity with automatic expiration and renewal capabilities.
+/// Sessions include unique identifiers, timestamps, and linkage to previous sessions.
+///
+/// Example:
+/// ```swift
+/// let session = Session(
+///     id: UUID().uuidString,
+///     expireTime: Date(timeIntervalSinceNow: 1800),
+///     previousId: "previous-session-id"
+/// )
+///
+/// if session.isExpired() {
+///     print("Session ended at: \(session.endTime!)")
+///     print("Duration: \(session.duration!) seconds")
+/// }
+/// ```
+public struct Session: Equatable {
+  /// Unique identifier for the session
+  public let id: String
+  /// Expiration time for the session
+  public let expireTime: Date
+  /// Unique identifier of the user's previous session, if any
+  public let previousId: String?
+  /// Start time of the session
+  public let startTime: Date
+  /// The duration in seconds after which this session expires if inactive
+  public let sessionTimeout: Int
+
+  /// Creates a new session
+  /// - Parameters:
+  ///   - id: Unique identifier for the session
+  ///   - expireTime: Expiration time for the session
+  ///   - previousId: Unique identifier of the user's previous session, if any
+  ///   - startTime: Start time of the session, defaults to current time
+  ///   - sessionTimeout: Duration in seconds after which the session expires if inactive
+  public init(id: String,
+              expireTime: Date,
+              previousId: String? = nil,
+              startTime: Date = Date(),
+              sessionTimeout: Int = SessionConfig.default.sessionTimeout) {
+    self.id = id
+    self.expireTime = expireTime
+    self.previousId = previousId
+    self.startTime = startTime
+    self.sessionTimeout = sessionTimeout
+  }
+
+  /// Two sessions are considered equal if they have the same ID, prevID, startTime, and expiry timestamp
+  public static func == (lhs: Session, rhs: Session) -> Bool {
+    return lhs.expireTime == rhs.expireTime &&
+      lhs.id == rhs.id &&
+      lhs.previousId == rhs.previousId &&
+      lhs.startTime == rhs.startTime &&
+      lhs.sessionTimeout == rhs.sessionTimeout
+  }
+
+  /// Checks if the session has expired
+  /// - Returns: True if the current time is past the session's expireTime time
+  public func isExpired() -> Bool {
+    return expireTime <= Date()
+  }
+
+  /// The time when the session ended (only available for expired sessions).
+  ///
+  /// For expired sessions, this returns the calculated end time based on when the session
+  /// was last active. For active sessions, this returns nil.
+  /// - Returns: The session end time, or nil if the session is still active
+  public var endTime: Date? {
+    guard isExpired() else { return nil }
+    return expireTime.addingTimeInterval(-Double(sessionTimeout))
+  }
+
+  /// The total duration the session was active (only available for expired sessions).
+  ///
+  /// Calculates the time between session start and end. Only available for expired sessions.
+  /// - Returns: The session duration in seconds, or nil if the session is still active
+  public var duration: TimeInterval? {
+    guard let endTime = endTime else { return nil }
+    return endTime.timeIntervalSince(startTime)
+  }
+}

--- a/Sources/Instrumentation/Sessions/SessionConfig.swift
+++ b/Sources/Instrumentation/Sessions/SessionConfig.swift
@@ -1,0 +1,76 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Configuration object for session management settings.
+///
+/// Controls session behavior including timeout duration and expiration handling.
+/// Sessions automatically expire after the specified timeout period of inactivity.
+///
+/// Example:
+/// ```swift
+/// // Direct initialization
+/// let config = SessionConfig(sessionTimeout: 45 * 60) // 45 minutes
+/// 
+/// // Using builder pattern
+/// let config = SessionConfig.builder()
+///   .with(sessionTimeout: 45 * 60)
+///   .build()
+/// 
+/// let manager = SessionManager(configuration: config)
+/// ```
+public struct SessionConfig {
+  /// Duration in seconds after which a session expires if left inactive
+  public let sessionTimeout: Int
+  
+  /// Creates a new session configuration
+  /// - Parameter sessionTimeout: Duration in seconds after which a session expires if left inactive (default 30 minutes)
+  public init(sessionTimeout: Int = 30 * 60) {
+    self.sessionTimeout = sessionTimeout
+  }
+  
+  /// Default configuration with 30-minute session timeout
+  public static let `default` = SessionConfig()
+}
+
+/// Builder for creating SessionConfig instances with a fluent API.
+///
+/// Provides a convenient way to configure session settings using method chaining.
+///
+/// Example:
+/// ```swift
+/// let config = SessionConfig.builder()
+///   .with(sessionTimeout: 45 * 60)
+///   .build()
+/// ```
+public class SessionConfigBuilder {
+  public private(set) var sessionTimeout: Int = 30 * 60
+  
+  public init() {}
+  
+  /// Sets the session timeout duration
+  /// - Parameter sessionTimeout: Duration in seconds after which a session expires if left inactive
+  /// - Returns: The builder instance for method chaining
+  public func with(sessionTimeout: Int) -> Self {
+    self.sessionTimeout = sessionTimeout
+    return self
+  }
+  
+  /// Builds the SessionConfig with the configured settings
+  /// - Returns: A new SessionConfig instance
+  public func build() -> SessionConfig {
+    return SessionConfig(sessionTimeout: sessionTimeout)
+  }
+}
+
+/// Extension to SessionConfig for builder pattern support
+extension SessionConfig {
+  /// Creates a new SessionConfigBuilder instance
+  /// - Returns: A new builder for creating SessionConfig
+  public static func builder() -> SessionConfigBuilder {
+    return SessionConfigBuilder()
+  }
+}

--- a/Sources/Instrumentation/Sessions/SessionConstants.swift
+++ b/Sources/Instrumentation/Sessions/SessionConstants.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// Constants for OpenTelemetry session instrumentation.
+///
+/// Provides standardized attribute names and event types following OpenTelemetry
+/// semantic conventions for session tracking.
+///
+/// Reference: https://opentelemetry.io/docs/specs/semconv/general/session/
+public class SessionConstants {
+  // MARK: - OpenTelemetry Semantic Conventions
+  
+  /// Event name for session start events
+  public static let sessionStartEvent = "session.start"
+  /// Event name for session end events  
+  public static let sessionEndEvent = "session.end"
+  /// Attribute name for session identifier
+  public static let id = "session.id"
+  /// Attribute name for previous session identifier
+  public static let previousId = "session.previous_id"
+
+  // MARK: - Extension Attributes
+  
+  /// Attribute name for session start timestamp
+  public static let startTime = "session.start_time"
+  /// Attribute name for session end timestamp
+  public static let endTime = "session.end_time"
+  /// Attribute name for session duration
+  public static let duration = "session.duration"
+
+  // MARK: - Internal Constants
+  
+  /// Notification name for session events
+  public static let sessionEventNotification = "SessionEventInstrumentation.SessionEvent"
+}

--- a/Sources/Instrumentation/Sessions/SessionEventInstrumentation.swift
+++ b/Sources/Instrumentation/Sessions/SessionEventInstrumentation.swift
@@ -1,0 +1,165 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+
+/// Instrumentation for tracking and logging session lifecycle events.
+///
+/// This class is responsible for creating OpenTelemetry log records for session start and end events.
+/// It handles sessions that are created both before and after the instrumentation is initialized by
+/// using a queue mechanism and notification system.
+///
+/// The instrumentation follows these key patterns:
+/// - Sessions created before instrumentation is applied are stored in a static queue
+/// - Sessions created after instrumentation is applied trigger notifications
+/// - All session events are converted to OpenTelemetry log records with appropriate attributes
+/// - Session end events include duration and end time attributes
+public class SessionEventInstrumentation {
+  private let logger: Logger
+
+  /// Queue for storing sessions that were created before instrumentation was initialized.
+  /// This allows capturing session events that occur during application startup before
+  /// the OpenTelemetry SDK is fully initialized.
+  internal static var queue: [Session] = []
+
+  /// Notification name for new session events.
+  /// Used to broadcast session creation and expiration events after instrumentation is applied.
+  static let sessionEventNotification = Notification.Name(SessionConstants.sessionEventNotification)
+
+  static let instrumentationKey = "io.opentelemetry.sessions"
+
+  /// Flag to track if the instrumentation has been applied.
+  /// Controls whether new sessions are queued or immediately processed via notifications.
+  public internal(set) static var isApplied = false
+
+  public init() {
+    self.logger = OpenTelemetry.instance.loggerProvider.get(instrumentationScopeName: SessionEventInstrumentation.instrumentationKey)
+    
+    guard !SessionEventInstrumentation.isApplied else {
+      return
+    }
+
+    SessionEventInstrumentation.isApplied = true
+    // Process any queued sessions
+    processQueuedSessions()
+
+    // Start observing for new session notifications
+    NotificationCenter.default.addObserver(
+      forName: SessionEventInstrumentation.sessionEventNotification,
+      object: nil,
+      queue: nil
+    ) { notification in
+      if let session = notification.object as? Session {
+        self.createSessionEvent(session: session)
+      }
+    }
+  }
+
+  /// Process any sessions that were queued before instrumentation was applied.
+  ///
+  /// This method is called during the `apply()` process to handle any sessions that
+  /// were created before the instrumentation was initialized. It creates log records
+  /// for all queued sessions and then clears the queue.
+  private func processQueuedSessions() {
+    let sessions = SessionEventInstrumentation.queue
+
+    if sessions.isEmpty {
+      return
+    }
+
+    for session in sessions {
+      createSessionEvent(session: session)
+    }
+
+    SessionEventInstrumentation.queue.removeAll()
+  }
+
+  /// Create session start or end log record, depending on if the session is expired.
+  ///
+  /// This method routes the session to the appropriate handler based on its expiration status.
+  /// - Parameter session: The session to create an event for
+  private func createSessionEvent(session: Session) {
+    if session.isExpired() {
+      createSessionEndEvent(session: session)
+    } else {
+      createSessionStartEvent(session: session)
+    }
+  }
+
+  /// Create a log record for a `session.start` event.
+  ///
+  /// Creates an OpenTelemetry log record with session attributes including ID, start time,
+  /// and previous session ID (if available).
+  /// - Parameter session: The session that has started
+  private func createSessionStartEvent(session: Session) {
+    var attributes: [String: AttributeValue] = [
+      SessionConstants.id: AttributeValue.string(session.id),
+      SessionConstants.startTime: AttributeValue.double(session.startTime.timeIntervalSince1970)
+    ]
+
+    if let previousId = session.previousId {
+      attributes[SessionConstants.previousId] = AttributeValue.string(previousId)
+    }
+
+    /// Create `session.start` log record according to otel semantic convention
+    /// https://opentelemetry.io/docs/specs/semconv/general/session/
+    logger.logRecordBuilder()
+      .setBody(AttributeValue.string(SessionConstants.sessionStartEvent))
+      .setAttributes(attributes)
+      .emit()
+  }
+
+  /// Create a log record for a `session.end` event.
+  ///
+  /// Creates an OpenTelemetry log record with session attributes including ID, start time,
+  /// end time, duration, and previous session ID (if available).
+  /// - Parameter session: The expired session
+  private func createSessionEndEvent(session: Session) {
+    guard session.isExpired(),
+          let endTime = session.endTime,
+          let duration = session.duration else {
+      return
+    }
+
+    var attributes: [String: AttributeValue] = [
+      SessionConstants.id: AttributeValue.string(session.id),
+      SessionConstants.startTime: AttributeValue.double(session.startTime.timeIntervalSince1970),
+      SessionConstants.endTime: AttributeValue.double(endTime.timeIntervalSince1970),
+      SessionConstants.duration: AttributeValue.double(duration)
+    ]
+
+    if let previousId = session.previousId {
+      attributes[SessionConstants.previousId] = AttributeValue.string(previousId)
+    }
+
+    /// Create `session.end`` log record according to otel semantic convention
+    /// https://opentelemetry.io/docs/specs/semconv/general/session/
+    logger.logRecordBuilder()
+      .setBody(AttributeValue.string(SessionConstants.sessionEndEvent))
+      .setAttributes(attributes)
+      .emit()
+  }
+
+  /// Add a session to the queue or send notification if instrumentation is already applied.
+  ///
+  /// This static method is the main entry point for handling new sessions. It either:
+  /// - Adds the session to the static queue if instrumentation hasn't been applied yet
+  /// - Posts a notification with the session if instrumentation has been applied
+  ///
+  /// - Parameter session: The session to process
+  static func addSession(session: Session) {
+    if isApplied {
+      NotificationCenter.default.post(
+        name: sessionEventNotification,
+        object: session
+      )
+    } else {
+      /// SessionManager creates sessions before SessionEventInstrumentation is applied,
+      /// which the notification observer cannot see. So we need to keep the sessions in a queue.
+      queue.append(session)
+    }
+  }
+}

--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Manages OpenTelemetry sessions with automatic expiration and persistence.
+/// Provides thread-safe access to session information and handles session lifecycle.
+/// Sessions are automatically extended on access and persisted to UserDefaults.
+public class SessionManager {
+  private var configuration: SessionConfig
+  private var session: Session?
+  private var lock = NSLock()
+
+  /// Initializes the session manager and restores any previous session from disk
+  /// - Parameter configuration: Session configuration settings
+  init(configuration: SessionConfig = .default) {
+    self.configuration = configuration
+    restoreSessionFromDisk()
+  }
+
+  /// Gets the current session, creating or extending it as needed
+  /// This method is thread-safe and will extend the session expireTime time
+  /// - Returns: The current active session
+  @discardableResult
+  public func getSession() -> Session {
+    // We only lock once when fetching the current session to expire with thread safety
+    return lock.withLock {
+      refreshSession()
+      return session!
+    }
+  }
+
+  /// Gets the current session without extending its expireTime time
+  /// - Returns: The current session if one exists, nil otherwise
+  public func peekSession() -> Session? {
+    return session
+  }
+
+  /// Creates a new session with a unique identifier
+  private func startSession() {
+    let now = Date()
+    let previousId = session?.id
+    let newId = UUID().uuidString
+
+    /// Queue the previous session for a `session.end` event
+    if session != nil {
+      SessionEventInstrumentation.addSession(session: session!)
+    }
+
+    session = Session(
+      id: newId,
+      expireTime: now.addingTimeInterval(Double(configuration.sessionTimeout)),
+      previousId: previousId,
+      startTime: now,
+      sessionTimeout: configuration.sessionTimeout
+    )
+
+    // Queue the new session for a `session.start`` event
+    SessionEventInstrumentation.addSession(session: session!)
+  }
+
+  /// Refreshes the current session, creating new one if expired or extending existing one
+  private func refreshSession() {
+    if session == nil || session!.isExpired() {
+      // Start new session if none exists or expired
+      startSession()
+    } else {
+      // Otherwise, extend the existing session but preserve the startTime
+      session = Session(
+        id: session!.id,
+        expireTime: Date(timeIntervalSinceNow: Double(configuration.sessionTimeout)),
+        previousId: session!.previousId,
+        startTime: session!.startTime,
+        sessionTimeout: configuration.sessionTimeout
+      )
+    }
+    saveSessionToDisk()
+  }
+
+  /// Schedules the current session to be persisted to UserDefaults
+  private func saveSessionToDisk() {
+    if session != nil {
+      SessionStore.scheduleSave(session: session!)
+    }
+  }
+
+  /// Restores a previously saved session from UserDefaults
+  private func restoreSessionFromDisk() {
+    session = SessionStore.load()
+  }
+}

--- a/Sources/Instrumentation/Sessions/SessionManagerProvider.swift
+++ b/Sources/Instrumentation/Sessions/SessionManagerProvider.swift
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Provides thread-safe singleton access to SessionManager.
+///
+/// Use this provider to ensure consistent session management across your application.
+/// Register a configured SessionManager instance or let it create a default one.
+///
+/// Example:
+/// ```swift
+/// // Register a custom session manager
+/// let customManager = SessionManager(configuration: SessionConfig(sessionTimeout: 3600))
+/// SessionManagerProvider.register(sessionManager: customManager)
+///
+/// // Access from anywhere in your app
+/// let session = SessionManagerProvider.getInstance().getSession()
+/// ```
+public class SessionManagerProvider {
+  private static var _instance: SessionManager?
+  private static let lock = NSLock()
+  
+  /// Registers a SessionManager instance as the singleton.
+  ///
+  /// Call this early in your app lifecycle to ensure consistent session management.
+  /// - Parameter sessionManager: The SessionManager instance to register
+  public static func register(sessionManager: SessionManager) {
+    lock.withLock {
+      _instance = sessionManager
+    }
+  }
+  
+  /// Returns the registered SessionManager instance or creates a default one.
+  ///
+  /// Thread-safe method that returns the singleton SessionManager instance.
+  /// If no instance has been registered, creates one with default configuration.
+  /// - Returns: The singleton SessionManager instance
+  public static func getInstance() -> SessionManager {
+    return lock.withLock {
+      if _instance == nil {
+        _instance = SessionManager()
+      }
+      return _instance!
+    }
+  }
+}

--- a/Sources/Instrumentation/Sessions/SessionSpanProcessor.swift
+++ b/Sources/Instrumentation/Sessions/SessionSpanProcessor.swift
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetrySdk
+import OpenTelemetryApi
+
+/// OpenTelemetry span processor that automatically adds session ID to all spans
+/// This processor ensures that all telemetry data is associated with the current session
+public class SessionSpanProcessor: SpanProcessor {
+  /// Indicates that this processor needs to be called when spans start
+  public var isStartRequired = true
+  /// Indicates that this processor doesn't need to be called when spans end
+  public var isEndRequired: Bool = false
+  /// Reference to the session manager for retrieving current session ID
+  private var sessionManager: SessionManager
+
+  /// Initializes the span processor with a session manager
+  /// - Parameter sessionManager: The session manager to use for retrieving session IDs (defaults to singleton)
+  public init(sessionManager: SessionManager? = nil) {
+    self.sessionManager = sessionManager ?? SessionManagerProvider.getInstance()
+  }
+
+  /// Called when a span starts - adds the current session ID as an attribute
+  /// - Parameters:
+  ///   - parentContext: The parent span context (unused)
+  ///   - span: The span being started
+  public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
+    let session = sessionManager.getSession()
+    span.setAttribute(key: SessionConstants.id, value: session.id)
+    if session.previousId != nil {
+      span.setAttribute(key: SessionConstants.previousId, value: session.previousId!)
+    }
+  }
+
+  /// Called when a span ends - no action needed for session tracking
+  /// - Parameter span: The span being ended
+  public func onEnd(span: any OpenTelemetrySdk.ReadableSpan) {
+    // No action needed
+  }
+
+  /// Shuts down the processor - no cleanup needed
+  /// - Parameter explicitTimeout: Timeout for shutdown (unused)
+  public func shutdown(explicitTimeout: TimeInterval?) {
+    // No cleanup needed
+  }
+
+  /// Forces a flush of any pending data - no action needed
+  /// - Parameter timeout: Timeout for flush (unused)
+  public func forceFlush(timeout: TimeInterval?) {
+    // No action needed
+  }
+}

--- a/Sources/Instrumentation/Sessions/SessionStore.swift
+++ b/Sources/Instrumentation/Sessions/SessionStore.swift
@@ -1,0 +1,106 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Handles persistence of OpenTelemetry sessions to UserDefaults
+/// Provides static methods for saving and loading session data
+internal class SessionStore {
+  /// UserDefaults key for storing session ID
+  static let idKey = "otel-session-id"
+  /// UserDefaults key for storing previous session ID
+  static let previousIdKey = "otel-session-previous-id"
+  /// UserDefaults key for storing session expiry timestamp
+  static let expireTimeKey = "otel-session-expire-time"
+  /// UserDefaults key for storing session start time
+  static let startTimeKey = "otel-session-start-time"
+  /// UserDefaults key for storing session timeout
+  static let sessionTimeoutKey = "otel-session-timeout"
+
+  /// To avoid writing to disk too often, SessionStore only keeps the current session
+  /// in memory and saves to disk on an interval (every 30 seconds).
+
+  /// The most recent session to be saved to disk
+  private static var pendingSession: Session?
+  /// The previous session
+  private static var prevSession: Session?
+  /// The interval period after which the current session is saved to disk
+  private static let saveInterval: TimeInterval = 30 // in seconds
+  /// The timer responsible for saving the current session to disk
+  private static var saveTimer: Timer?
+
+  /// Schedules a session to be saved to UserDefaults on the next timer interval
+  /// - Parameter session: The session to save
+  static func scheduleSave(session: Session) {
+    pendingSession = session
+
+    if saveTimer == nil {
+      // save initial session
+      saveImmediately(session: session)
+
+      // save future sessions on a interval
+      saveTimer = Timer.scheduledTimer(withTimeInterval: saveInterval, repeats: true) { _ in
+        // only write to disk if it is a new sesssion
+        if let pending = pendingSession, prevSession != pending {
+          saveImmediately(session: pending)
+        }
+      }
+    }
+  }
+
+  /// Immediately saves a session to UserDefaults
+  /// - Parameter session: The session to save
+  static func saveImmediately(session: Session) {
+    // Persist session
+    UserDefaults.standard.set(session.id, forKey: idKey)
+    UserDefaults.standard.set(session.expireTime, forKey: expireTimeKey)
+    UserDefaults.standard.set(session.startTime, forKey: startTimeKey)
+    UserDefaults.standard.set(session.previousId, forKey: previousIdKey)
+    UserDefaults.standard.set(session.sessionTimeout, forKey: sessionTimeoutKey)
+
+    // update prev session
+    prevSession = session
+    // clear pending session, since it is now outdated
+    pendingSession = nil
+  }
+
+  /// Loads a previously saved session from UserDefaults
+  /// - Returns: The saved session if ID, startTime, and expireTime exist. nil otherwise
+  static func load() -> Session? {
+    guard let startTime = UserDefaults.standard.object(forKey: startTimeKey) as? Date,
+          let id = UserDefaults.standard.string(forKey: idKey),
+          let expireTime = UserDefaults.standard.object(forKey: expireTimeKey) as? Date,
+          let sessionTimeout = UserDefaults.standard.object(forKey: sessionTimeoutKey) as? Int
+    else {
+      return nil
+    }
+
+    let previousId = UserDefaults.standard.string(forKey: previousIdKey)
+
+    // reset sessions so it does not get overridden in the next scheduled save
+    pendingSession = nil
+    prevSession = Session(
+      id: id,
+      expireTime: expireTime,
+      previousId: previousId,
+      startTime: startTime,
+      sessionTimeout: sessionTimeout
+    )
+    return prevSession
+  }
+
+  /// Cleans up timer and UserDefaults
+  static func teardown() {
+    saveTimer?.invalidate()
+    saveTimer = nil
+    pendingSession = nil
+    prevSession = nil
+    UserDefaults.standard.removeObject(forKey: idKey)
+    UserDefaults.standard.removeObject(forKey: startTimeKey)
+    UserDefaults.standard.removeObject(forKey: expireTimeKey)
+    UserDefaults.standard.removeObject(forKey: previousIdKey)
+    UserDefaults.standard.removeObject(forKey: sessionTimeoutKey)
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionConfigTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionConfigTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Sessions
+
+final class SessionConfigurationTests: XCTestCase {
+  
+  func testDefaultConfiguration() {
+    let config = SessionConfig.default
+    XCTAssertEqual(config.sessionTimeout, 30 * 60) // should be 30 minutes
+  }
+  
+  func testCustomConfiguration() {
+    let config = SessionConfig(sessionTimeout: 3600)
+    XCTAssertEqual(config.sessionTimeout, 3600)
+  }
+  
+  func testBuilderPattern() {
+    let config = SessionConfig.builder()
+      .with(sessionTimeout: 45 * 60)
+      .build()
+    
+    XCTAssertEqual(config.sessionTimeout, 45 * 60)
+  }
+  
+  func testBuilderDefaultValues() {
+    let config = SessionConfig.builder().build()
+    XCTAssertEqual(config.sessionTimeout, 30 * 60) // should be 30 minutes
+  }
+  
+  func testBuilderMethodChaining() {
+    let builder = SessionConfig.builder()
+    let sameBuilder = builder.with(sessionTimeout: 60 * 60)
+    XCTAssertTrue(builder === sameBuilder)
+  }
+  
+  func testBuilderEqualsNormalConfig() {
+    let normalConfig = SessionConfig(sessionTimeout: 45 * 60)
+    let builderConfig = SessionConfig.builder()
+      .with(sessionTimeout: 45 * 60)
+      .build()
+    
+    XCTAssertEqual(normalConfig.sessionTimeout, builderConfig.sessionTimeout)
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionConstantsTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionConstantsTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import Sessions
+
+final class SessionConstantsTests: XCTestCase {
+  func testSessionEventConstants() {
+    XCTAssertEqual(SessionConstants.sessionStartEvent, "session.start")
+    XCTAssertEqual(SessionConstants.sessionEndEvent, "session.end")
+    XCTAssertEqual(SessionConstants.id, "session.id")
+    XCTAssertEqual(SessionConstants.previousId, "session.previous_id")
+    XCTAssertEqual(SessionConstants.startTime, "session.start_time")
+    XCTAssertEqual(SessionConstants.endTime, "session.end_time")
+    XCTAssertEqual(SessionConstants.duration, "session.duration")
+    XCTAssertEqual(SessionConstants.sessionEventNotification, "SessionEventInstrumentation.SessionEvent")
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionEventInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionEventInstrumentationTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+@testable import Sessions
+@testable import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+
+final class SessionEventInstrumentationTests: XCTestCase {
+  let sessionId1 = "test-session-id-1"
+  let sessionId2 = "test-session-id-2"
+  let sessionIdExpired = "test-session-id-expired"
+
+  var startTime1: Date!
+  var startTime2: Date!
+  var logExporter: InMemoryLogRecordExporter!
+
+  lazy var session1 = Session(
+    id: sessionId1,
+    expireTime: Date().addingTimeInterval(3600),
+    previousId: nil,
+    startTime: startTime1
+  )
+
+  lazy var session2 = Session(
+    id: sessionId2,
+    expireTime: Date().addingTimeInterval(3600),
+    previousId: sessionId1,
+    startTime: startTime2
+  )
+
+  lazy var sessionExpired = Session(
+    id: sessionIdExpired,
+    expireTime: Date().addingTimeInterval(-3600)
+  )
+
+  override func setUp() {
+    super.setUp()
+
+    startTime1 = Date()
+    startTime2 = Date().addingTimeInterval(60)
+
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = false
+
+    logExporter = InMemoryLogRecordExporter()
+    let loggerProvider = LoggerProviderBuilder()
+      .with(processors: [SimpleLogRecordProcessor(logRecordExporter: logExporter)])
+      .build()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+
+    NotificationCenter.default.removeObserver(
+      self,
+      name: SessionEventInstrumentation.sessionEventNotification,
+      object: nil
+    )
+  }
+
+  override func tearDown() {
+    super.tearDown()
+
+    NotificationCenter.default.removeObserver(
+      self,
+      name: SessionEventInstrumentation.sessionEventNotification,
+      object: nil
+    )
+
+    OpenTelemetry.registerTracerProvider(tracerProvider: DefaultTracerProvider.instance)
+    OpenTelemetry.registerLoggerProvider(loggerProvider: DefaultLoggerProvider.instance)
+  }
+
+  func testQueueInitiallyEmpty() {
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 0)
+    XCTAssertFalse(SessionEventInstrumentation.isApplied)
+  }
+
+  func testHandleNewSessionAddsToQueue() {
+    SessionEventInstrumentation.addSession(session: session1)
+
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 1)
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].id, sessionId1)
+  }
+
+  func testInstrumentationEmptiesQueue() {
+    SessionEventInstrumentation.addSession(session: session1)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 1)
+    SessionEventInstrumentation.addSession(session: session2)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 2)
+    XCTAssertFalse(SessionEventInstrumentation.isApplied)
+
+    _ = SessionEventInstrumentation()
+
+    XCTAssertTrue(SessionEventInstrumentation.isApplied)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 0)
+  }
+
+  func testQueueDoesNotFillAfterApplied() {
+    // XCTAssertFalse(SessionEventInstrumentation.isApplied)
+    _ = SessionEventInstrumentation()
+
+    SessionEventInstrumentation.addSession(session: session2)
+
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 0)
+  }
+
+  func testNotificationPostedAfterInstrumentationApplied() {
+    let expectation = XCTestExpectation(description: "Session notification posted")
+    var receivedSession: Session?
+
+    NotificationCenter.default.addObserver(
+      forName: SessionEventInstrumentation.sessionEventNotification,
+      object: nil,
+      queue: nil
+    ) { notification in
+      receivedSession = notification.object as? Session
+      expectation.fulfill()
+    }
+
+    _ = SessionEventInstrumentation()
+
+    SessionEventInstrumentation.addSession(session: session1)
+
+    wait(for: [expectation], timeout: 0)
+
+    XCTAssertNotNil(receivedSession)
+    XCTAssertEqual(receivedSession?.id, sessionId1)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 0)
+  }
+
+  func testMultipleInitializationDoesNotProcessQueueTwice() {
+    SessionEventInstrumentation.addSession(session: session1)
+    SessionEventInstrumentation.addSession(session: session2)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 2)
+    
+    _ = SessionEventInstrumentation()
+    XCTAssertTrue(SessionEventInstrumentation.isApplied)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 0)
+    
+    // Second initialization should not process queue again
+    SessionEventInstrumentation.queue = [sessionExpired]
+    _ = SessionEventInstrumentation()
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 1) // Queue unchanged
+  }
+
+  func testMultipleInitializationDoesNotAddDuplicateObservers() {
+    _ = SessionEventInstrumentation()
+    _ = SessionEventInstrumentation()
+    
+    SessionEventInstrumentation.addSession(session: session1)
+    
+    let logRecords = logExporter.getFinishedLogRecords()
+    XCTAssertEqual(logRecords.count, 1)
+    XCTAssertEqual(logRecords[0].body, AttributeValue.string("session.start"))
+  }
+
+  func testSessionStartLogRecord() {
+    SessionEventInstrumentation.addSession(session: session1)
+    _ = SessionEventInstrumentation()
+    
+    let logRecords = logExporter.getFinishedLogRecords()
+    XCTAssertEqual(logRecords.count, 1)
+    
+    let record = logRecords[0]
+    XCTAssertEqual(record.body, AttributeValue.string("session.start"))
+    XCTAssertEqual(record.attributes["session.id"], AttributeValue.string(sessionId1))
+    XCTAssertEqual(record.attributes["session.start_time"], AttributeValue.double(startTime1.timeIntervalSince1970))
+    XCTAssertNil(record.attributes["session.previous_id"])
+  }
+
+  func testSessionStartLogRecordWithPreviousId() {
+    SessionEventInstrumentation.addSession(session: session2)
+    _ = SessionEventInstrumentation()
+    
+    let logRecords = logExporter.getFinishedLogRecords()
+    XCTAssertEqual(logRecords.count, 1)
+    
+    let record = logRecords[0]
+    XCTAssertEqual(record.body, AttributeValue.string("session.start"))
+    XCTAssertEqual(record.attributes["session.id"], AttributeValue.string(sessionId2))
+    XCTAssertEqual(record.attributes["session.start_time"], AttributeValue.double(startTime2.timeIntervalSince1970))
+    XCTAssertEqual(record.attributes["session.previous_id"], AttributeValue.string(sessionId1))
+  }
+
+  func testSessionEndLogRecord() {
+    SessionEventInstrumentation.addSession(session: sessionExpired)
+    _ = SessionEventInstrumentation()
+    
+    let logRecords = logExporter.getFinishedLogRecords()
+    XCTAssertEqual(logRecords.count, 1)
+    
+    let record = logRecords[0]
+    XCTAssertEqual(record.body, AttributeValue.string("session.end"))
+    XCTAssertEqual(record.attributes["session.id"], AttributeValue.string(sessionIdExpired))
+    XCTAssertEqual(record.attributes["session.start_time"], AttributeValue.double(sessionExpired.startTime.timeIntervalSince1970))
+    XCTAssertEqual(record.attributes["session.end_time"], AttributeValue.double(sessionExpired.endTime!.timeIntervalSince1970))
+    XCTAssertEqual(record.attributes["session.duration"], AttributeValue.double(sessionExpired.duration!))
+    XCTAssertNil(record.attributes["session.previous_id"])
+  }
+  
+  func testInstrumentationScopeName() {
+    SessionEventInstrumentation.addSession(session: session1)
+    _ = SessionEventInstrumentation()
+    
+    let logRecords = logExporter.getFinishedLogRecords()
+    XCTAssertEqual(logRecords.first?.instrumentationScopeInfo.name, "io.opentelemetry.sessions")
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionManagerProviderTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionManagerProviderTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import Sessions
+
+final class SessionManagerProviderTests: XCTestCase {
+  
+  override func tearDown() {
+    // Reset singleton state for clean tests
+    SessionManagerProvider.register(sessionManager: SessionManager())
+    super.tearDown()
+  }
+  
+  func testGetInstanceReturnsDefaultManager() {
+    let manager = SessionManagerProvider.getInstance()
+    XCTAssertNotNil(manager)
+  }
+  
+  func testRegisterAndGetInstance() {
+    let customManager = SessionManager(configuration: SessionConfig(sessionTimeout: 3600))
+    SessionManagerProvider.register(sessionManager: customManager)
+    
+    let retrievedManager = SessionManagerProvider.getInstance()
+    XCTAssertTrue(retrievedManager === customManager)
+  }
+  
+  func testSingletonBehavior() {
+    let manager1 = SessionManagerProvider.getInstance()
+    let manager2 = SessionManagerProvider.getInstance()
+    XCTAssertTrue(manager1 === manager2)
+  }
+  
+  func testThreadSafety() {
+    let expectation = XCTestExpectation(description: "Thread safety test")
+    expectation.expectedFulfillmentCount = 10
+    
+    var managers: [SessionManager] = []
+    let queue = DispatchQueue.global(qos: .default)
+    let syncQueue = DispatchQueue(label: "test.sync")
+    
+    for _ in 0..<10 {
+      queue.async {
+        let manager = SessionManagerProvider.getInstance()
+        syncQueue.async {
+          managers.append(manager)
+          expectation.fulfill()
+        }
+      }
+    }
+    
+    wait(for: [expectation], timeout: 1.0)
+    
+    let firstManager = managers.first!
+    for manager in managers {
+      XCTAssertTrue(manager === firstManager)
+    }
+  }
+  
+  func testConcurrentGetInstanceCreatesOnlyOneInstance() {
+    let group = DispatchGroup()
+    var instances: [SessionManager] = []
+    let syncQueue = DispatchQueue(label: "test.instances")
+    
+    for _ in 0..<100 {
+      group.enter()
+      DispatchQueue.global().async {
+        let instance = SessionManagerProvider.getInstance()
+        syncQueue.async {
+          instances.append(instance)
+          group.leave()
+        }
+      }
+    }
+    
+    group.wait()
+    
+    XCTAssertEqual(instances.count, 100)
+    let firstInstance = instances[0]
+    for instance in instances {
+      XCTAssertTrue(instance === firstInstance, "All instances should be the same object")
+    }
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import Sessions
+
+final class SessionManagerTests: XCTestCase {
+  var sessionManager: SessionManager!
+
+  override func setUp() {
+    super.setUp()
+    SessionStore.teardown()
+    sessionManager = SessionManager()
+  }
+
+  override func tearDown() {
+    SessionStore.teardown()
+    super.tearDown()
+  }
+
+  func testGetSession() {
+    let session = sessionManager.getSession()
+    XCTAssertNotNil(session)
+    XCTAssertNotNil(session.id)
+    XCTAssertNotNil(session.expireTime)
+    XCTAssertNil(session.previousId)
+  }
+
+  func testGetSessionId() {
+    let id1 = sessionManager.getSession().id
+    let id2 = sessionManager.getSession().id
+    XCTAssertEqual(id1, id2)
+  }
+
+  func testGetSessionRenewed() {
+    let t1 = sessionManager.getSession().expireTime
+    let t2 = sessionManager.getSession().expireTime
+    XCTAssertGreaterThan(t2, t1)
+  }
+
+  func testStartTimePreservedWhenSessionExtended() {
+    let originalSession = sessionManager.getSession()
+    Thread.sleep(forTimeInterval: 0.1)
+    let extendedSession = sessionManager.getSession()
+
+    XCTAssertEqual(originalSession.id, extendedSession.id)
+    XCTAssertGreaterThan(extendedSession.expireTime, originalSession.expireTime)
+    XCTAssertEqual(originalSession.startTime, extendedSession.startTime)
+  }
+
+  func testGetSessionExpired() {
+    sessionManager = SessionManager(configuration: SessionConfig(sessionTimeout: 0))
+    let session1 = sessionManager.getSession()
+    Thread.sleep(forTimeInterval: 0.1)
+    let session2 = sessionManager.getSession()
+
+    XCTAssertNotEqual(session1.id, session2.id)
+    XCTAssertNotEqual(session1.startTime, session2.startTime)
+    XCTAssertGreaterThan(session2.startTime, session1.startTime)
+  }
+
+  func testGetSessionSavedToDisk() {
+    let session = sessionManager.getSession()
+    let savedId = UserDefaults.standard.object(forKey: SessionStore.idKey) as? String
+    let savedTimeout = UserDefaults.standard.object(forKey: SessionStore.sessionTimeoutKey) as? Int
+
+    XCTAssertEqual(session.id, savedId)
+    XCTAssertEqual(session.sessionTimeout, savedTimeout)
+  }
+
+  func testLoadSessionMissingExpiry() {
+    let id1 = "session-1"
+    UserDefaults.standard.set(id1, forKey: SessionStore.idKey)
+    XCTAssertNil(SessionStore.load())
+
+    let id2 = sessionManager.getSession().id
+    XCTAssertNotEqual(id1, id2)
+  }
+
+  func testLoadSessionMissingID() {
+    let expiry1 = Date()
+    UserDefaults.standard.set(expiry1, forKey: SessionStore.expireTimeKey)
+    XCTAssertNil(SessionStore.load())
+
+    let expiry2 = sessionManager.getSession().expireTime
+    XCTAssertNotEqual(expiry1, expiry2)
+  }
+
+  func testPeekSessionWithoutSession() {
+    XCTAssertNil(sessionManager.peekSession())
+  }
+
+  func testPeekSessionWithExistingSession() {
+    let session = sessionManager.getSession()
+    let peekedSession = sessionManager.peekSession()
+
+    XCTAssertNotNil(peekedSession)
+    XCTAssertEqual(peekedSession?.id, session.id)
+  }
+
+  func testPeekDoesNotExtendSession() {
+    let originalSession = sessionManager.getSession()
+    let peekedSession = sessionManager.peekSession()
+
+    XCTAssertEqual(peekedSession?.expireTime, originalSession.expireTime)
+  }
+
+  func testCustomSessionLength() {
+    let customLength = 60
+    sessionManager = SessionManager(configuration: SessionConfig(sessionTimeout: customLength))
+
+    let session1 = sessionManager.getSession()
+    let expectedExpiry = Date(timeIntervalSinceNow: Double(customLength))
+
+    XCTAssertEqual(session1.expireTime.timeIntervalSince1970, expectedExpiry.timeIntervalSince1970, accuracy: 1.0)
+    XCTAssertEqual(session1.sessionTimeout, customLength)
+  }
+
+  func testNewSessionHasNoPreviousId() {
+    let session = sessionManager.getSession()
+    XCTAssertNil(session.previousId)
+  }
+
+  func testExpiredSessionCreatesPreviousId() {
+    sessionManager = SessionManager(configuration: SessionConfig(sessionTimeout: 0))
+    let firstSession = sessionManager.getSession()
+    let secondSession = sessionManager.getSession()
+    let thirdSession = sessionManager.getSession()
+
+    XCTAssertNil(firstSession.previousId)
+    XCTAssertEqual(secondSession.previousId, firstSession.id)
+    XCTAssertEqual(thirdSession.previousId, secondSession.id)
+  }
+
+  func testStartSessionAddsToQueueWhenInstrumentationNotApplied() {
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = false
+
+    let session = sessionManager.getSession()
+
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 1)
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].id, session.id)
+  }
+
+  func testStartSessionTriggersNotificationWhenInstrumentationApplied() {
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = true
+
+    let expectation = XCTestExpectation(description: "Session notification posted")
+    var receivedSession: Session?
+
+    let observer = NotificationCenter.default.addObserver(
+      forName: SessionEventInstrumentation.sessionEventNotification,
+      object: nil,
+      queue: nil
+    ) { notification in
+      receivedSession = notification.object as? Session
+      expectation.fulfill()
+    }
+
+    let session = sessionManager.getSession()
+
+    wait(for: [expectation], timeout: 0.1)
+
+    XCTAssertNotNil(receivedSession)
+    XCTAssertEqual(receivedSession?.id, session.id)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 0)
+
+    NotificationCenter.default.removeObserver(observer)
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionSpanProcessorTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionSpanProcessorTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+import OpenTelemetryApi
+@testable import Sessions
+@testable import OpenTelemetrySdk
+
+final class SessionSpanProcessorTests: XCTestCase {
+  var mockSessionManager: MockSessionManager!
+  var spanProcessor: SessionSpanProcessor!
+  var mockSpan: MockReadableSpan!
+
+  override func setUp() {
+    super.setUp()
+    mockSessionManager = MockSessionManager()
+    spanProcessor = SessionSpanProcessor(sessionManager: mockSessionManager)
+    mockSpan = MockReadableSpan()
+  }
+
+  func testInitialization() {
+    XCTAssertTrue(spanProcessor.isStartRequired)
+    XCTAssertFalse(spanProcessor.isEndRequired)
+  }
+
+  func testOnStartAddsSessionId() {
+    let expectedSessionId = "test-session-123"
+    mockSessionManager.sessionId = expectedSessionId
+
+    spanProcessor.onStart(parentContext: nil, span: mockSpan)
+
+    if case let .string(sessionId) = mockSpan.capturedAttributes["session.id"] {
+      XCTAssertEqual(sessionId, expectedSessionId)
+    } else {
+      XCTFail("Expected session.id attribute to be a string value")
+    }
+  }
+
+  func testOnStartWithDifferentSessionIds() {
+    mockSessionManager.sessionId = "session-1"
+    spanProcessor.onStart(parentContext: nil, span: mockSpan)
+    if case let .string(sessionId) = mockSpan.capturedAttributes["session.id"] {
+      XCTAssertEqual(sessionId, "session-1")
+    } else {
+      XCTFail("Expected session.id attribute to be a string value")
+    }
+
+    let anotherSpan = MockReadableSpan()
+    mockSessionManager.sessionId = "session-2"
+    spanProcessor.onStart(parentContext: nil, span: anotherSpan)
+    if case let .string(sessionId) = anotherSpan.capturedAttributes["session.id"] {
+      XCTAssertEqual(sessionId, "session-2")
+    } else {
+      XCTFail("Expected session.id attribute to be a string value")
+    }
+  }
+
+  func testOnEndDoesNothing() {
+    spanProcessor.onEnd(span: mockSpan)
+    // No assertions needed - just verify it doesn't crash
+  }
+
+  func testShutdownDoesNothing() {
+    spanProcessor.shutdown(explicitTimeout: 5.0)
+    // No assertions needed - just verify it doesn't crash
+  }
+
+  func testForceFlushDoesNothing() {
+    spanProcessor.forceFlush(timeout: 5.0)
+    // No assertions needed - just verify it doesn't crash
+  }
+
+  func testOnStartAddsPreviousSessionId() {
+    let expectedSessionId = "current-session-123"
+    let expectedPreviousSessionId = "previous-session-456"
+    mockSessionManager.sessionId = expectedSessionId
+    mockSessionManager.previousSessionId = expectedPreviousSessionId
+
+    spanProcessor.onStart(parentContext: nil, span: mockSpan)
+
+    if case let .string(sessionId) = mockSpan.capturedAttributes["session.id"] {
+      XCTAssertEqual(sessionId, expectedSessionId)
+    } else {
+      XCTFail("Expected session.id attribute to be a string value")
+    }
+
+    if case let .string(previousSessionId) = mockSpan.capturedAttributes["session.previous_id"] {
+      XCTAssertEqual(previousSessionId, expectedPreviousSessionId)
+    } else {
+      XCTFail("Expected session.previous_id attribute to be a string value")
+    }
+  }
+
+  func testOnStartWithoutPreviousSessionId() {
+    let expectedSessionId = "current-session-123"
+    mockSessionManager.sessionId = expectedSessionId
+    mockSessionManager.previousSessionId = nil
+
+    spanProcessor.onStart(parentContext: nil, span: mockSpan)
+
+    if case let .string(sessionId) = mockSpan.capturedAttributes["session.id"] {
+      XCTAssertEqual(sessionId, expectedSessionId)
+    } else {
+      XCTFail("Expected session.id attribute to be a string value")
+    }
+
+    XCTAssertNil(mockSpan.capturedAttributes["session.previous_id"], "Previous session ID should not be set when nil")
+  }
+  
+  func testInitializationWithNilSessionManager() {
+    let processor = SessionSpanProcessor()
+    XCTAssertTrue(processor.isStartRequired)
+    XCTAssertFalse(processor.isEndRequired)
+  }
+}
+
+// MARK: - Mock Classes
+
+class MockSessionManager: SessionManager {
+  var sessionId: String = "default-session-id"
+  var previousSessionId: String?
+  var startTime: Date = .init()
+
+  override func getSession() -> Session {
+    return Session(
+      id: sessionId,
+      expireTime: Date(timeIntervalSinceNow: 1800),
+      previousId: previousSessionId,
+      startTime: startTime
+    )
+  }
+}
+
+class MockReadableSpan: ReadableSpan {
+  var capturedAttributes: [String: AttributeValue] = [:]
+
+  var hasEnded: Bool = false
+  var latency: TimeInterval = 0
+  var kind: SpanKind = .client
+  var instrumentationScopeInfo = InstrumentationScopeInfo()
+  var name: String = "MockSpan"
+  var context: SpanContext = .create(traceId: TraceId.random(), spanId: SpanId.random(), traceFlags: TraceFlags(), traceState: TraceState())
+  var isRecording: Bool = true
+  var status: Status = .unset
+  var description: String = "MockReadableSpan"
+  
+  func getAttributes() -> [String: AttributeValue] {
+    return capturedAttributes
+  }
+  
+  func setAttributes(_ attributes: [String: AttributeValue]) {
+    capturedAttributes.merge(attributes) { _, new in new }
+  }
+
+  func end() {}
+  func end(time: Date) {}
+
+  func toSpanData() -> SpanData {
+    return SpanData(traceId: context.traceId,
+                    spanId: context.spanId,
+                    traceFlags: context.traceFlags,
+                    traceState: TraceState(),
+                    resource: Resource(attributes: [String: AttributeValue]()),
+                    instrumentationScope: InstrumentationScopeInfo(),
+                    name: name,
+                    kind: kind,
+                    startTime: Date(),
+                    endTime: Date(),
+                    hasRemoteParent: false)
+  }
+
+  func updateName(name: String) {
+    self.name = name
+  }
+
+  func setAttribute(key: String, value: AttributeValue?) {
+    if let value = value {
+      capturedAttributes[key] = value
+    }
+  }
+
+  func addEvent(name: String) {}
+  func addEvent(name: String, attributes: [String: AttributeValue]) {}
+  func addEvent(name: String, timestamp: Date) {}
+  func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {}
+  func recordException(_ exception: SpanException) {}
+  func recordException(_ exception: any SpanException, timestamp: Date) {}
+  func recordException(_ exception: any SpanException, attributes: [String: AttributeValue]) {}
+  func recordException(_ exception: any SpanException, attributes: [String: AttributeValue], timestamp: Date) {}
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionStoreTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionStoreTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import Sessions
+
+final class SessionStoreTests: XCTestCase {
+  override func tearDown() {
+    SessionStore.teardown()
+    super.tearDown()
+  }
+
+  func testSaveAndLoadSession() {
+    let sessionId = "test-session-123"
+    let expireTime = Date(timeIntervalSinceNow: 1800)
+    let startTime = Date(timeIntervalSinceNow: -300)
+    let session = Session(id: sessionId, expireTime: expireTime, previousId: nil, startTime: startTime)
+
+    SessionStore.scheduleSave(session: session)
+    let loadedSession = SessionStore.load()
+
+    XCTAssertNotNil(loadedSession)
+    XCTAssertEqual(loadedSession?.id, sessionId)
+    XCTAssertEqual(loadedSession?.expireTime, expireTime)
+    XCTAssertEqual(loadedSession?.startTime, startTime)
+    XCTAssertNil(loadedSession?.previousId)
+  }
+
+  func testLoadSessionWhenNothingSaved() {
+    let loadedSession = SessionStore.load()
+    XCTAssertNil(loadedSession)
+  }
+
+  func testLoadSessionMissingId() {
+    UserDefaults.standard.set(Date(), forKey: SessionStore.expireTimeKey)
+    UserDefaults.standard.set(Date(), forKey: SessionStore.startTimeKey)
+    UserDefaults.standard.set(1800, forKey: SessionStore.sessionTimeoutKey)
+
+    let loadedSession = SessionStore.load()
+    XCTAssertNil(loadedSession)
+  }
+
+  func testLoadSessionMissingExpiry() {
+    UserDefaults.standard.set("test-id", forKey: SessionStore.idKey)
+    UserDefaults.standard.set(Date(), forKey: SessionStore.startTimeKey)
+    UserDefaults.standard.set(1800, forKey: SessionStore.sessionTimeoutKey)
+
+    let loadedSession = SessionStore.load()
+    XCTAssertNil(loadedSession)
+  }
+
+  func testLoadSessionMissingStartTime() {
+    UserDefaults.standard.set("test-id", forKey: SessionStore.idKey)
+    UserDefaults.standard.set(Date(), forKey: SessionStore.expireTimeKey)
+    UserDefaults.standard.set(1800, forKey: SessionStore.sessionTimeoutKey)
+
+    let loadedSession = SessionStore.load()
+    XCTAssertNil(loadedSession)
+  }
+
+  func testSaveOverwritesPreviousSession() {
+    let session1 = Session(id: "session-1", expireTime: Date(), previousId: nil, startTime: Date(), sessionTimeout: 1800)
+    let session2 = Session(id: "session-2", expireTime: Date(timeIntervalSinceNow: 1800), previousId: nil, startTime: Date(), sessionTimeout: 1800)
+
+    SessionStore.saveImmediately(session: session1)
+    let loaded1 = SessionStore.load()
+    XCTAssertEqual(loaded1?.id, "session-1")
+
+    SessionStore.saveImmediately(session: session2)
+    let loaded2 = SessionStore.load()
+    XCTAssertEqual(loaded2?.id, "session-2")
+  }
+
+  func testStoreKeys() {
+    XCTAssertEqual(SessionStore.idKey, "otel-session-id")
+    XCTAssertEqual(SessionStore.expireTimeKey, "otel-session-expire-time")
+    XCTAssertEqual(SessionStore.startTimeKey, "otel-session-start-time")
+    XCTAssertEqual(SessionStore.previousIdKey, "otel-session-previous-id")
+    XCTAssertEqual(SessionStore.sessionTimeoutKey, "otel-session-timeout")
+  }
+
+  func testLoadWithCorruptedData() {
+    UserDefaults.standard.set(123, forKey: SessionStore.idKey)
+    UserDefaults.standard.set("invalid-date", forKey: SessionStore.expireTimeKey)
+
+    let loadedSession = SessionStore.load()
+    XCTAssertNil(loadedSession)
+  }
+
+  func testSaveAndLoadSessionWithPreviousId() {
+    let sessionId = "current-session-123"
+    let previousId = "previous-session-456"
+    let expireTime = Date(timeIntervalSinceNow: 1800)
+    let session = Session(id: sessionId, expireTime: expireTime, previousId: previousId, startTime: Date(), sessionTimeout: 1800)
+
+    SessionStore.scheduleSave(session: session)
+    let loadedSession = SessionStore.load()
+
+    XCTAssertNotNil(loadedSession)
+    XCTAssertEqual(loadedSession?.id, sessionId)
+    XCTAssertEqual(loadedSession?.previousId, previousId)
+    XCTAssertEqual(loadedSession?.expireTime, expireTime)
+  }
+
+  func testScheduleSaveImmediatelySavesFirstSession() {
+    let session = Session(id: "test-session", expireTime: Date(timeIntervalSinceNow: 1800), previousId: nil, startTime: Date(), sessionTimeout: 1800)
+    SessionStore.scheduleSave(session: session)
+
+    let savedId = UserDefaults.standard.string(forKey: SessionStore.idKey)
+    XCTAssertEqual(savedId, session.id)
+  }
+
+  func testTeardownClearsUserDefaults() {
+    let session = Session(id: "test-session", expireTime: Date(timeIntervalSinceNow: 1800), previousId: nil, startTime: Date(), sessionTimeout: 1800)
+    SessionStore.saveImmediately(session: session)
+
+    XCTAssertNotNil(UserDefaults.standard.string(forKey: SessionStore.idKey))
+
+    SessionStore.teardown()
+
+    XCTAssertNil(UserDefaults.standard.string(forKey: SessionStore.idKey))
+    XCTAssertNil(UserDefaults.standard.object(forKey: SessionStore.expireTimeKey))
+    XCTAssertNil(UserDefaults.standard.object(forKey: SessionStore.startTimeKey))
+    XCTAssertNil(UserDefaults.standard.string(forKey: SessionStore.previousIdKey))
+    XCTAssertNil(UserDefaults.standard.object(forKey: SessionStore.sessionTimeoutKey))
+  }
+
+  func testTeardownInvalidatesTimer() {
+    let session = Session(id: "test-session", expireTime: Date(timeIntervalSinceNow: 1800), previousId: nil, startTime: Date(), sessionTimeout: 1800)
+    SessionStore.scheduleSave(session: session)
+
+    SessionStore.teardown()
+
+    let session2 = Session(id: "test-session-2", expireTime: Date(timeIntervalSinceNow: 1800), previousId: nil, startTime: Date())
+    SessionStore.scheduleSave(session: session2)
+
+    let savedId = UserDefaults.standard.string(forKey: SessionStore.idKey)
+    XCTAssertEqual(savedId, session2.id)
+  }
+  
+  func testLoadSessionMissingTimeout() {
+    UserDefaults.standard.set("test-id", forKey: SessionStore.idKey)
+    UserDefaults.standard.set(Date(), forKey: SessionStore.expireTimeKey)
+    UserDefaults.standard.set(Date(), forKey: SessionStore.startTimeKey)
+    
+    let loadedSession = SessionStore.load()
+    XCTAssertNil(loadedSession, "Session should be nil when timeout is missing")
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import Sessions
+@testable import OpenTelemetrySdk
+
+final class SessionTests: XCTestCase {
+  func testSessionInitialization() {
+    let id = "test-session-id"
+    let expireTime = Date(timeIntervalSinceNow: 1800) // 30 minutes from now
+
+    let session = Session(id: id, expireTime: expireTime)
+
+    XCTAssertEqual(session.id, id)
+    XCTAssertEqual(session.expireTime, expireTime)
+    XCTAssertNil(session.previousId, "Default initialization should have nil previousId")
+    XCTAssertLessThanOrEqual(Date().timeIntervalSince(session.startTime), 1.0, "Start time should be set to current time by default")
+  }
+
+  func testSessionEquality() {
+    let id = "test-session-id"
+    let expireTime = Date()
+    let startTime = Date()
+    let previousId = "prev-id"
+
+    let session1 = Session(id: id, expireTime: expireTime, previousId: previousId, startTime: startTime)
+    let session2 = Session(id: id, expireTime: expireTime, previousId: previousId, startTime: startTime)
+
+    XCTAssertEqual(session1, session2, "Sessions with same ID, expireTime, startTime, and previousId should be equal")
+  }
+
+  func testSessionInequality() {
+    let expireTime = Date()
+    let session1 = Session(id: "session-1", expireTime: expireTime)
+    let session2 = Session(id: "session-2", expireTime: expireTime)
+
+    XCTAssertNotEqual(session1, session2, "Sessions with different IDs should not be equal")
+  }
+
+  func testSessionNotExpired() {
+    let futureExpiry = Date(timeIntervalSinceNow: 1800) // 30 minutes from now
+    let session = Session(id: "test-id", expireTime: futureExpiry)
+
+    XCTAssertFalse(session.isExpired(), "Session with future expireTime should not be expired")
+  }
+
+  func testSessionExpired() {
+    let pastExpiry = Date(timeIntervalSinceNow: -1800) // 30 minutes ago
+    let session = Session(id: "test-id", expireTime: pastExpiry)
+
+    XCTAssertTrue(session.isExpired(), "Session with past expireTime should be expired")
+  }
+
+  func testSessionExpiryAtExactTime() {
+    let currentTime = Date()
+    let session = Session(id: "test-id", expireTime: currentTime)
+
+    // Sleep briefly to ensure current time is past expiry
+    Thread.sleep(forTimeInterval: 0.001)
+
+    XCTAssertTrue(session.isExpired(), "Session expiring at current time should be considered expired")
+  }
+
+  func testSessionWithPreviousId() {
+    let id = "current-session"
+    let previousId = "previous-session"
+    let expireTime = Date(timeIntervalSinceNow: 1800)
+
+    let session = Session(id: id, expireTime: expireTime, previousId: previousId)
+
+    XCTAssertEqual(session.id, id)
+    XCTAssertEqual(session.previousId, previousId)
+    XCTAssertEqual(session.expireTime, expireTime)
+  }
+  
+  func testEndTimeForActiveSession() {
+    let session = Session(id: "test-id", expireTime: Date(timeIntervalSinceNow: 1800))
+    XCTAssertNil(session.endTime, "Active session should have nil endTime")
+  }
+  
+  func testEndTimeForExpiredSession() {
+    let session = Session(id: "test-id", expireTime: Date(timeIntervalSinceNow: -1800), sessionTimeout: 1800)
+    XCTAssertNotNil(session.endTime, "Expired session should have endTime")
+  }
+  
+  func testDurationForActiveSession() {
+    let session = Session(id: "test-id", expireTime: Date(timeIntervalSinceNow: 1800))
+    XCTAssertNil(session.duration, "Active session should have nil duration")
+  }
+  
+  func testDurationForExpiredSession() {
+    let session = Session(id: "test-id", expireTime: Date(timeIntervalSinceNow: -1800), sessionTimeout: 1800)
+    XCTAssertNotNil(session.duration, "Expired session should have duration")
+  }
+  
+  func testSafeUnwrappingInComputedProperties() {
+    // Test that endTime and duration don't crash with force unwrapping
+    let expiredSession = Session(id: "test-id", expireTime: Date(timeIntervalSinceNow: -1800), sessionTimeout: 1800)
+    let activeSession = Session(id: "test-id", expireTime: Date(timeIntervalSinceNow: 1800))
+    
+    // These should not crash
+    _ = expiredSession.endTime
+    _ = expiredSession.duration
+    _ = activeSession.endTime
+    _ = activeSession.duration
+    
+    XCTAssertNotNil(expiredSession.endTime)
+    XCTAssertNotNil(expiredSession.duration)
+    XCTAssertNil(activeSession.endTime)
+    XCTAssertNil(activeSession.duration)
+  }
+}


### PR DESCRIPTION
## Summary

Hi team, I've added feature support for automatic session span management using "expiring user sessions", which expire after a period of inactivity (default 30 minutes). The three components that are exposed to users are:

1. Users can optionally customize a `SessionManager`, and globally register it to `SessionManagerProvider`. If no customization is provided, then a default SessionManager is provided. 
2. `SessionSpanProcessor` attaches `session.id` and `session.previous_id` to incoming spans as regular attributes. 
3. `SessionEventInstrumentation` creates `session.start` and `session.end` events as log records

## Basic usage

```swift
import Sessions
import OpenTelemetrySdk

// 1. [Optional] Customize session configuration
let sessionConfig = SessionConfigBuilder()
    .with(sessionTimeout: 45 * 60) // 45 minutes
    .build()
let sessionManager = SessionManager(configuration: sessionConfig)
SessionManagerProvider.register(sessionManager: sessionManager)

// 2. [Required] Setup session instrumentation
// emits `session.start` and `session.end` log records
let sessionInstrumentation = SessionEventInstrumentation()

// adds `session.id` and `session.previous_id` to incoming spans
let sessionSpanProcessor = SessionSpanProcessor()
let tracerProvider = TracerProviderBuilder()
    .add(spanProcessor: sessionSpanProcessor)
    .build()

// If step (1) is not done, then default a default SessionManager is supplied to `SessionSpanProcessor` and `SessionEventInstrumentation`
```

## Configuration

### SessionConfig

| Field | Type | Description | Default | Required |
|-------|------|-------------|---------|----------|
| `sessionTimeout` | `Int` | Duration in seconds after which a session expires if left inactive | `1800` (30 min) | No |

## Session Events

Emits OpenTelemetry log records following semantic conventions:

**session.start Event**:
```json
{
  "body": "session.start",
  "attributes": {
    "session.id": "550e8400-e29b-41d4-a716-446655440000",
    "session.start_time": 1692123456.789,
    "session.previous_id": "previous-session-id"
  }
}
```

**session.end Event**:
```json
{
  "body": "session.end",
  "attributes": {
    "session.id": "550e8400-e29b-41d4-a716-446655440000",
    "session.start_time": 1692123456.789,
    "session.end_time": 1692125256.789,
    "session.duration": 1800.0,
    "session.previous_id": "previous-session-id"
  }
}
```