### PR TITLE
Bump swift-nio to resolve CVE‑2025‑8671

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
-        "version" : "2.83.0"
+        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
+        "version" : "2.86.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "1.0.0"),
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.86.0"),
     .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.26.1"),
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.30.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),


### PR DESCRIPTION
Supersedes https://github.com/open-telemetry/opentelemetry-swift/pull/854 since that PR doesn't include Package.resolved changes. Resolves https://github.com/open-telemetry/opentelemetry-swift/issues/902