### PR TITLE
feat: support log events

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift-core.git",
       "state" : {
-        "revision" : "6aebc7734e154cd221ea9fb76bd4f611262be962",
-        "version" : "2.1.1"
+        "revision" : "fd787757decabfa93319cc3c04f03a49e0cf40b6",
+        "version" : "2.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     .executable(name: "StableMetricSample", targets: ["StableMetricSample"])
   ],
   dependencies: [
-    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.1.1"),
+    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.2.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.86.0"),
     .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.26.1"),
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.30.0"),

--- a/Sources/Exporters/OpenTelemetryProtocolCommon/logs/LogRecordAdapter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/logs/LogRecordAdapter.swift
@@ -46,6 +46,10 @@ public class LogRecordAdapter {
 
     protoLogRecord.timeUnixNano = logRecord.timestamp.timeIntervalSince1970.toNanoseconds
 
+    if let eventName = logRecord.eventName {
+      protoLogRecord.eventName = eventName
+    }
+
     if let body = logRecord.body {
       protoLogRecord.body = CommonAdapter.toProtoAnyValue(attributeValue: body)
     }

--- a/Sources/Instrumentation/Sessions/SessionEventInstrumentation.swift
+++ b/Sources/Instrumentation/Sessions/SessionEventInstrumentation.swift
@@ -125,7 +125,6 @@ public class SessionEventInstrumentation {
     /// https://opentelemetry.io/docs/specs/semconv/general/session/
     logger.logRecordBuilder()
       .setBody(AttributeValue.string(SessionConstants.sessionStartEvent))
-      .setEventName(SessionConstants.sessionStartEvent)
       .setAttributes(attributes)
       .emit()
   }
@@ -156,7 +155,6 @@ public class SessionEventInstrumentation {
     /// https://opentelemetry.io/docs/specs/semconv/general/session/
     logger.logRecordBuilder()
       .setBody(AttributeValue.string(SessionConstants.sessionEndEvent))
-      .setEventName(SessionConstants.sessionEndEvent)
       .setAttributes(attributes)
       .emit()
   }

--- a/Sources/Instrumentation/Sessions/SessionEventInstrumentation.swift
+++ b/Sources/Instrumentation/Sessions/SessionEventInstrumentation.swift
@@ -52,7 +52,7 @@ public class SessionEventInstrumentation {
   static var isApplied = false
 
   public init() {
-    logger = OpenTelemetry.instance.loggerProvider.get(instrumentationScopeName: SessionEventInstrumentation.instrumentationKey)
+    logger = OpenTelemetry.instance.loggerProvider.loggerBuilder(instrumentationScopeName: SessionEventInstrumentation.instrumentationKey).build()
     guard !SessionEventInstrumentation.isApplied else {
       return
     }
@@ -125,6 +125,7 @@ public class SessionEventInstrumentation {
     /// https://opentelemetry.io/docs/specs/semconv/general/session/
     logger.logRecordBuilder()
       .setBody(AttributeValue.string(SessionConstants.sessionStartEvent))
+      .setEventName(SessionConstants.sessionStartEvent)
       .setAttributes(attributes)
       .emit()
   }
@@ -155,6 +156,7 @@ public class SessionEventInstrumentation {
     /// https://opentelemetry.io/docs/specs/semconv/general/session/
     logger.logRecordBuilder()
       .setBody(AttributeValue.string(SessionConstants.sessionEndEvent))
+      .setEventName(SessionConstants.sessionEndEvent)
       .setAttributes(attributes)
       .emit()
   }

--- a/Sources/Instrumentation/Sessions/SessionEventInstrumentation.swift
+++ b/Sources/Instrumentation/Sessions/SessionEventInstrumentation.swift
@@ -52,7 +52,7 @@ public class SessionEventInstrumentation {
   static var isApplied = false
 
   public init() {
-    logger = OpenTelemetry.instance.loggerProvider.loggerBuilder(instrumentationScopeName: SessionEventInstrumentation.instrumentationKey).build()
+    logger = OpenTelemetry.instance.loggerProvider.get(instrumentationScopeName: SessionEventInstrumentation.instrumentationKey)
     guard !SessionEventInstrumentation.isApplied else {
       return
     }

--- a/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift
+++ b/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift
@@ -22,7 +22,7 @@ public class SessionLogRecordProcessor: LogRecordProcessor {
 
   /// Called when a log record is emitted - adds session attributes and forwards to next processor
   public func onEmit(logRecord: ReadableLogRecord) {
-    var newAttributes = logRecord.attributes
+    var enhancedRecord = logRecord
 
     // For session.start and session.end events, preserve existing session attributes
     if let body = logRecord.body,
@@ -33,22 +33,11 @@ public class SessionLogRecordProcessor: LogRecordProcessor {
     } else {
       // For other log records, add current session attributes
       let session = sessionManager.getSession()
-      newAttributes[SessionConstants.id] = AttributeValue.string(session.id)
+      enhancedRecord.setAttribute(key: SessionConstants.id, value: AttributeValue.string(session.id))
       if let previousId = session.previousId {
-        newAttributes[SessionConstants.previousId] = AttributeValue.string(previousId)
+        enhancedRecord.setAttribute(key: SessionConstants.previousId, value: AttributeValue.string(previousId))
       }
     }
-
-    let enhancedRecord = ReadableLogRecord(
-      resource: logRecord.resource,
-      instrumentationScopeInfo: logRecord.instrumentationScopeInfo,
-      timestamp: logRecord.timestamp,
-      observedTimestamp: logRecord.observedTimestamp,
-      spanContext: logRecord.spanContext,
-      severity: logRecord.severity,
-      body: logRecord.body,
-      attributes: newAttributes
-    )
 
     nextProcessor.onEmit(logRecord: enhancedRecord)
   }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/LogRecordAdapterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/LogRecordAdapterTests.swift
@@ -42,7 +42,8 @@ class LogRecordAdapterTests: XCTestCase {
                                       spanContext: spanContext,
                                       severity: .fatal,
                                       body: AttributeValue.string("Hello, world"),
-                                      attributes: ["event.name": AttributeValue.string("name"), "event.domain": AttributeValue.string("domain")])
+                                      attributes: ["event.name": AttributeValue.string("name"), "event.domain": AttributeValue.string("domain")],
+                                      eventName: "session.start")
 
     let protoLog = LogRecordAdapter.toProtoLogRecord(logRecord: logRecord)
 
@@ -55,5 +56,6 @@ class LogRecordAdapterTests: XCTestCase {
     XCTAssertEqual(protoLog.traceID, Data(bytes: traceIdBytes, count: 16))
     XCTAssertEqual(protoLog.timeUnixNano, timestamp.timeIntervalSince1970.toNanoseconds)
     XCTAssertEqual(protoLog.attributes.count, 2)
+    XCTAssertEqual(protoLog.eventName, "session.start")
   }
 }


### PR DESCRIPTION
## Warning

~~⚠️ Warning~~ ✅ Deployed - This PR has a hard dependency on first deploying https://github.com/open-telemetry/opentelemetry-swift-core/pull/15 

## Summary

I want to support log events, which just needs eventName to be added. 

## Implementation

This PR just adds the field name to the logsproto from ReadableLogRecord included in telemetry/opentelemetry-swift-core/pull/15 

## Test

Tested this end to end along with https://github.com/open-telemetry/opentelemetry-swift-core/pull/15

```json
"scopeLogs": [
        {
          "scope": { "name": "io.opentelemetry.sessions" },
          "logRecords": [
            {
              "timeUnixNano": "1758599294896214016",
              "observedTimeUnixNano": "1758599294896211200",
              "body": { "stringValue": "session.end" },
              "attributes": [
                {
                  "key": "session.previous_id",
                  "value": { "stringValue": "48D2D24F-8229-48A3-A76C-556020ADD63E" }
                },
                { "key": "session.end_time", "value": { "doubleValue": 1758598647233387000 } },
                { "key": "session.start_time", "value": { "doubleValue": 1758598647233387000 } },
                { "key": "event.name", "value": { "stringValue": "session.end" } },
                { "key": "session.duration", "value": { "doubleValue": 0 } },
                {
                  "key": "user.id",
                  "value": { "stringValue": "1CBF1932-6111-4C87-89A3-8CD7B971187B" }
                },
                {
                  "key": "session.id",
                  "value": { "stringValue": "14F51F53-BE28-4FF6-9F68-CD9863F8986E" }
                }
              ],
              "traceId": "",
              "spanId": ""
            },
            {
              "timeUnixNano": "1758599294896258816",
              "observedTimeUnixNano": "1758599294896257792",
              "body": { "stringValue": "session.start" },
              "attributes": [
                { "key": "event.name", "value": { "stringValue": "session.start" } },
                {
                  "key": "session.id",
                  "value": { "stringValue": "CAE1FE4A-D24B-4181-A91F-6DACBBCBC0D2" }
                },
                { "key": "session.start_time", "value": { "doubleValue": 1758599294895009000 } },
                {
                  "key": "session.previous_id",
                  "value": { "stringValue": "14F51F53-BE28-4FF6-9F68-CD9863F8986E" }
                },
                {
                  "key": "user.id",
                  "value": { "stringValue": "1CBF1932-6111-4C87-89A3-8CD7B971187B" }
                }
              ],
              "traceId": "",
              "spanId": ""
            }
          ]
        }
      ]
```