### PR TITLE
update MetricsAdapter to include exemplars for counters

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolCommon/metric/MetricsAdapter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/metric/MetricsAdapter.swift
@@ -228,6 +228,14 @@ public enum MetricsAdapter {
     pointData.exemplars.forEach {
       var protoExemplar = Opentelemetry_Proto_Metrics_V1_Exemplar()
       protoExemplar.timeUnixNano = $0.epochNanos
+		
+	  if let doubleExemplar = $0 as? DoubleExemplarData {
+		protoExemplar.value = .asDouble(doubleExemplar.value)
+	  }
+
+	  if let longExemplar = $0 as? LongExemplarData {
+		protoExemplar.value = .asInt(Int64(longExemplar.value))
+	  }
 
       $0.filteredAttributes.forEach {
         protoExemplar.filteredAttributes.append(CommonAdapter.toProtoAttribute(key: $0.key, attributeValue: $0.value))


### PR DESCRIPTION
Exemplar values are not being exported for counters.

Similar fix to https://github.com/open-telemetry/opentelemetry-swift/pull/748, except for counters.