### PR TITLE
Removed `StdoutExporter` podpsec

### DIFF
--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -77,7 +77,6 @@ jobs:
             "OpenTelemetry-Swift-Protocol-Exporter-Common"
             "OpenTelemetry-Swift-Protocol-Exporter-Http"
             "OpenTelemetry-Swift-PersistenceExporter"
-            "OpenTelemetry-Swift-StdoutExporter"
           )
           
           # Process each pod


### PR DESCRIPTION
# Overview
Removed the `StdoutExporter` podspec, as it's now part of the [OpenTelemetry-Swift-Core repository](https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/OpenTelemetry-Swift-StdoutExporter.podspec).

This was causing the `Tag and Release` workflow to fail (no other side effects, since it's the last `.podspec` the job tries to push).
