### PR TITLE
fix: set SessionManager init as public

### DIFF
--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -15,7 +15,7 @@ public class SessionManager {
 
   /// Initializes the session manager and restores any previous session from disk
   /// - Parameter configuration: Session configuration settings
-  init(configuration: SessionConfig = .default) {
+  public init(configuration: SessionConfig = .default) {
     self.configuration = configuration
     restoreSessionFromDisk()
   }


### PR DESCRIPTION
Hi team 👋

This pull request addresses an error encountered when implementing a custom session configuration for the new sessions feature (#899).

While the [documentation](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/Instrumentation/Sessions/README.md#setup) provides a method for custom configurations, following it leads to an error triggered by an internal protection level.

```swift
let sessionConfig = SessionConfigBuilder()
    .with(sessionTimeout: 45 * 60) // 45 minutes
    .build()
let sessionManager = SessionManager(configuration: sessionConfig) // ❌ 'SessionManager' initializer is inaccessible due to 'internal' protection level
SessionManagerProvider.register(sessionManager: sessionManager)
``` 

This pull request corrects the necessary protection level, ensuring that custom session configurations function as intended and described in the documentation.

#### Regarding Testing
I was uncertain about the best approach to add tests for this specific fix. The current test suite imports the module using `@testable`, which bypasses the internal protection level this PR aims to correct.

Because the test target already has access to these symbols, the existing tests do not replicate the protection-level error that a consumer of the framework would encounter. I have manually verified the fix, but I am open to suggestions on how to best validate this change.