### PR TITLE
#636 Fix thread-safety crash in NetworkStatus.status()

### DIFF
--- a/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
+++ b/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
@@ -8,9 +8,38 @@
   import Foundation
   import Network
 
+  /// Provides network connection type and carrier information for span attributes.
+  ///
+  /// ## Thread safety
+  ///
+  /// `CTTelephonyNetworkInfo` is not thread-safe: its Objective-C properties
+  /// can be mutated internally by CoreTelephony on its own thread while being
+  /// read from a caller's thread, causing `EXC_BAD_ACCESS` when the returned
+  /// object is autoreleased after its backing memory has already been freed.
+  ///
+  /// To avoid this, we eagerly cache the telephony state and keep it up to date
+  /// through `CTTelephonyNetworkInfoDelegate` callbacks (via a proxy object),
+  /// which fire *after* the internal mutation has completed. Callers of
+  /// `status()` read only the cached Swift values, protected by an `NSLock`,
+  /// and never touch the underlying `CTTelephonyNetworkInfo` properties
+  /// directly.
   public class NetworkStatus {
     public private(set) var networkInfo: CTTelephonyNetworkInfo
     public private(set) var networkMonitor: NetworkMonitorProtocol
+
+    // MARK: - Cached telephony state
+
+    /// Guards all reads and writes to the `cached*` properties below.
+    private let lock = NSLock()
+
+    private var cachedServiceId: String?
+    private var cachedRadioTech: [String: String]?
+    private var cachedProviders: [String: CTCarrier]?
+
+    /// Delegate proxy that forwards `CTTelephonyNetworkInfoDelegate`
+    /// callbacks to `refreshCachedState()`. Stored to prevent deallocation.
+    private var delegateProxy: AnyObject?
+
     public convenience init() throws {
       try self.init(with: NetworkMonitor())
     }
@@ -18,6 +47,20 @@
     public init(with monitor: NetworkMonitorProtocol, info: CTTelephonyNetworkInfo = CTTelephonyNetworkInfo()) {
       networkMonitor = monitor
       networkInfo = info
+
+      refreshCachedState()
+
+      // Install a delegate so the cache stays current when the radio access
+      // technology or active data service changes. The delegate callbacks
+      // fire on CoreTelephony's internal serial queue *after* the property
+      // mutation has settled, so reading the properties there is safe.
+      if #available(iOS 13.0, *) {
+        let proxy = NetworkInfoDelegateProxy { [weak self] in
+          self?.refreshCachedState()
+        }
+        networkInfo.delegate = proxy
+        delegateProxy = proxy
+      }
     }
 
     public func status() -> (String, String?, CTCarrier?) {
@@ -26,8 +69,14 @@
         return ("wifi", nil, nil)
       case .cellular:
         if #available(iOS 13.0, *) {
-          if let serviceId = networkInfo.dataServiceIdentifier, let value = networkInfo.serviceCurrentRadioAccessTechnology?[serviceId] {
-            return ("cell", simpleConnectionName(connectionType: value), networkInfo.serviceSubscriberCellularProviders?[serviceId])
+          lock.lock()
+          let serviceId = cachedServiceId
+          let radioTech = cachedRadioTech
+          let providers = cachedProviders
+          lock.unlock()
+
+          if let serviceId, let value = radioTech?[serviceId] {
+            return ("cell", simpleConnectionName(connectionType: value), providers?[serviceId])
           }
         } else {
           if let radioType = networkInfo.currentRadioAccessTechnology {
@@ -38,6 +87,25 @@
       case .unavailable:
         return ("unavailable", nil, nil)
       }
+    }
+
+    // MARK: - Private
+
+    /// Snapshots the current `CTTelephonyNetworkInfo` state into Swift values.
+    ///
+    /// Safe to call from `init` (single-threaded) and from delegate callbacks
+    /// (which fire on CoreTelephony's serial queue after the internal mutation
+    /// has completed).
+    fileprivate func refreshCachedState() {
+      let serviceId = networkInfo.dataServiceIdentifier
+      let radioTech = networkInfo.serviceCurrentRadioAccessTechnology
+      let providers = networkInfo.serviceSubscriberCellularProviders
+
+      lock.lock()
+      cachedServiceId = serviceId
+      cachedRadioTech = radioTech
+      cachedProviders = providers
+      lock.unlock()
     }
 
     func simpleConnectionName(connectionType: String) -> String {
@@ -71,6 +139,30 @@
       default:
         return "unknown"
       }
+    }
+  }
+
+  // MARK: - NetworkInfoDelegateProxy
+
+  /// Lightweight `NSObject` subclass that bridges `CTTelephonyNetworkInfoDelegate`
+  /// callbacks to a closure, keeping `NetworkStatus` itself a plain Swift class
+  /// and preserving its existing public initializer signatures.
+  @available(iOS 13.0, *)
+  private class NetworkInfoDelegateProxy: NSObject, CTTelephonyNetworkInfoDelegate {
+    private let onUpdate: () -> Void
+
+    init(onUpdate: @escaping () -> Void) {
+      self.onUpdate = onUpdate
+    }
+
+    func dataServiceIdentifierDidChange(_ identifier: String) {
+      onUpdate()
+    }
+
+    func serviceCurrentRadioAccessTechnologyDidChange(
+      _ serviceCurrentRadioAccessTechnology: [String: String]
+    ) {
+      onUpdate()
     }
   }
 

--- a/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
+++ b/Sources/Instrumentation/NetworkStatus/NetworkStatus.swift
@@ -8,36 +8,14 @@
   import Foundation
   import Network
 
-  /// Provides network connection type and carrier information for span attributes.
-  ///
-  /// ## Thread safety
-  ///
-  /// `CTTelephonyNetworkInfo` is not thread-safe: its Objective-C properties
-  /// can be mutated internally by CoreTelephony on its own thread while being
-  /// read from a caller's thread, causing `EXC_BAD_ACCESS` when the returned
-  /// object is autoreleased after its backing memory has already been freed.
-  ///
-  /// To avoid this, we eagerly cache the telephony state and keep it up to date
-  /// through `CTTelephonyNetworkInfoDelegate` callbacks (via a proxy object),
-  /// which fire *after* the internal mutation has completed. Callers of
-  /// `status()` read only the cached Swift values, protected by an `NSLock`,
-  /// and never touch the underlying `CTTelephonyNetworkInfo` properties
-  /// directly.
   public class NetworkStatus {
     public private(set) var networkInfo: CTTelephonyNetworkInfo
     public private(set) var networkMonitor: NetworkMonitorProtocol
 
-    // MARK: - Cached telephony state
-
-    /// Guards all reads and writes to the `cached*` properties below.
     private let lock = NSLock()
-
     private var cachedServiceId: String?
     private var cachedRadioTech: [String: String]?
     private var cachedProviders: [String: CTCarrier]?
-
-    /// Delegate proxy that forwards `CTTelephonyNetworkInfoDelegate`
-    /// callbacks to `refreshCachedState()`. Stored to prevent deallocation.
     private var delegateProxy: AnyObject?
 
     public convenience init() throws {
@@ -50,10 +28,6 @@
 
       refreshCachedState()
 
-      // Install a delegate so the cache stays current when the radio access
-      // technology or active data service changes. The delegate callbacks
-      // fire on CoreTelephony's internal serial queue *after* the property
-      // mutation has settled, so reading the properties there is safe.
       if #available(iOS 13.0, *) {
         let proxy = NetworkInfoDelegateProxy { [weak self] in
           self?.refreshCachedState()
@@ -89,13 +63,7 @@
       }
     }
 
-    // MARK: - Private
-
-    /// Snapshots the current `CTTelephonyNetworkInfo` state into Swift values.
-    ///
-    /// Safe to call from `init` (single-threaded) and from delegate callbacks
-    /// (which fire on CoreTelephony's serial queue after the internal mutation
-    /// has completed).
+    /// Snapshots the current `CTTelephonyNetworkInfo` state into the cached properties.
     fileprivate func refreshCachedState() {
       let serviceId = networkInfo.dataServiceIdentifier
       let radioTech = networkInfo.serviceCurrentRadioAccessTechnology
@@ -142,11 +110,7 @@
     }
   }
 
-  // MARK: - NetworkInfoDelegateProxy
-
-  /// Lightweight `NSObject` subclass that bridges `CTTelephonyNetworkInfoDelegate`
-  /// callbacks to a closure, keeping `NetworkStatus` itself a plain Swift class
-  /// and preserving its existing public initializer signatures.
+  /// Forwards `CTTelephonyNetworkInfoDelegate` callbacks to a closure.
   @available(iOS 13.0, *)
   private class NetworkInfoDelegateProxy: NSObject, CTTelephonyNetworkInfoDelegate {
     private let onUpdate: () -> Void

--- a/Tests/InstrumentationTests/NetworkStatusTests/NetworkStatusTests.swift
+++ b/Tests/InstrumentationTests/NetworkStatusTests/NetworkStatusTests.swift
@@ -139,6 +139,32 @@
       XCTAssertNil(info)
       XCTAssertEqual("unavailable", type)
     }
+
+    /// Verify that `status()` can be called safely from many threads at once.
+    /// Before the thread-safety fix, concurrent reads of `CTTelephonyNetworkInfo`
+    /// properties could trigger `EXC_BAD_ACCESS` during `objc_autorelease`.
+    func testConcurrentStatusAccess() {
+      let netStatus = NetworkStatus(
+        with: MockNetworkMonitor(connection: .cellular),
+        info: MockCTTelephonyNetworkInfo(
+          dataServiceIndentifier: "service1",
+          currentRadioAccessTechnology: "CTRadioAccessTechnologyLTE",
+          carrier: MockCTCarrier(
+            carrierName: "TestCarrier",
+            isoCountryCode: "US",
+            mobileCountryCode: "310",
+            mobileNetworkCode: "410"
+          )
+        )
+      )
+
+      DispatchQueue.concurrentPerform(iterations: 10_000) { _ in
+        let (type, subtype, carrier) = netStatus.status()
+        XCTAssertEqual("cell", type)
+        XCTAssertEqual("LTE", subtype)
+        XCTAssertEqual("TestCarrier", carrier?.carrierName)
+      }
+    }
   }
 
 #endif // os(iOS) && !targetEnvironment(macCatalyst)

--- a/Tests/InstrumentationTests/NetworkStatusTests/NetworkStatusTests.swift
+++ b/Tests/InstrumentationTests/NetworkStatusTests/NetworkStatusTests.swift
@@ -140,9 +140,6 @@
       XCTAssertEqual("unavailable", type)
     }
 
-    /// Verify that `status()` can be called safely from many threads at once.
-    /// Before the thread-safety fix, concurrent reads of `CTTelephonyNetworkInfo`
-    /// properties could trigger `EXC_BAD_ACCESS` during `objc_autorelease`.
     func testConcurrentStatusAccess() {
       let netStatus = NetworkStatus(
         with: MockNetworkMonitor(connection: .cellular),


### PR DESCRIPTION
## Summary

`NetworkStatus.status()` reads `CTTelephonyNetworkInfo` properties directly on the caller's thread, which causes `EXC_BAD_ACCESS` crashes when CoreTelephony's internal state is mutated concurrently. This change caches the telephony state behind an `NSLock` and keeps it up to date via `CTTelephonyNetworkInfoDelegate`, so callers of `status()` never touch the thread-unsafe ObjC properties directly.

## Problem

`CTTelephonyNetworkInfo` is not thread-safe. Its Objective-C properties (`dataServiceIdentifier`, `serviceCurrentRadioAccessTechnology`, `serviceSubscriberCellularProviders`) can be freed internally by CoreTelephony on its own thread while being read from another thread. When the returned ObjC object is autoreleased after its backing memory has already been freed, the app crashes with `EXC_BAD_ACCESS` in `objc_autorelease`.

This is triggered in production because `URLSessionLogger.processAndLogRequest` calls `netstatInjector.inject(span:)` -- and therefore `NetworkStatus.status()` -- from arbitrary background threads (GCD worker threads via `NSOperationQueue`).

Example crash stack trace:

```
Thread Name: EXC_BAD_ACCESS
  libobjc.A.dylib        objc_autorelease
  CoreTelephony           -[CTTelephonyNetworkInfo dataServiceIdentifier]
  App                     NetworkStatus.status()            (NetworkStatus.swift:29)
  App                     NetworkStatusInjector.inject(span:) (NetworkStatusInjector.swift:21)
  App                     URLSessionLogger.processAndLogRequest(...)  (URLSessionLogger.swift:92)
```

Previously reported as #636 (closed without a fix).

## Solution

Instead of reading `CTTelephonyNetworkInfo` properties on demand from arbitrary threads, we:

1. **Cache the telephony state** (`dataServiceIdentifier`, `serviceCurrentRadioAccessTechnology`, `serviceSubscriberCellularProviders`) as plain Swift values at init time.

2. **Keep the cache up to date** by installing a `CTTelephonyNetworkInfoDelegate` (via a lightweight `NetworkInfoDelegateProxy`). The delegate callbacks fire on CoreTelephony's internal serial queue *after* the property mutation has completed, so reading the properties in the callback is safe.

3. **Serve only cached values** from `status()`, protected by an `NSLock`. Callers never touch the underlying `CTTelephonyNetworkInfo` properties directly, eliminating the race condition entirely.

This follows the same `NSLock`-based thread-safety pattern already used by `NetworkMonitor` in this codebase.

### Why a delegate proxy?

`CTTelephonyNetworkInfoDelegate` requires `NSObject` conformance. Making `NetworkStatus` inherit from `NSObject` would break its existing `convenience init() throws` (Swift does not allow overriding a non-throwing superclass init with a throwing one). The `NetworkInfoDelegateProxy` is a small private `NSObject` subclass that bridges the delegate callbacks to a closure, keeping `NetworkStatus` as a plain Swift class with its original public API intact.

## Changes

- **`NetworkStatus.swift`**: Add `NSLock`, cached properties, `refreshCachedState()`, `NetworkInfoDelegateProxy`. `status()` reads from cache instead of `CTTelephonyNetworkInfo` directly.
- **`NetworkStatusTests.swift`**: Add `testConcurrentStatusAccess` -- calls `status()` from 10,000 concurrent threads to verify no crashes or data races.

## Backward compatibility

- No changes to public API signatures.
- No changes to `URLSessionLogger.swift` or `NetworkStatusInjector.swift` (fix is entirely within `NetworkStatus`).
- The pre-iOS 13 fallback path in `status()` is preserved.
