### PR TITLE
fix(URLSessionInstrumentation): dedupe spans on watchOS data(for:) path

### DIFF
--- a/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
+++ b/Sources/Instrumentation/URLSession/InstrumentationUtils.swift
@@ -8,7 +8,7 @@ import Foundation
   import os.log
 #endif
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS) 
 import UIKit
 #elseif os(watchOS)
 import WatchKit

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -753,16 +753,21 @@ public class URLSessionInstrumentation {
         requestMap[taskId]?.setRequest(request)
       }
 
-      // A span may have already been started for this task — either by a factory
-      // swizzle (e.g. dataTask(with:completionHandler:)) or by a previous resume
-      // (NSURLSession super-class chaining and redirect handling can both cause
-      // resume to fire more than once per logical request, most visibly on watchOS).
-      // Starting another one here would orphan the existing span: processAndLogRequest
-      // would overwrite runningSpans[taskId] and the first span would never be ended.
+      #if os(watchOS)
+      // watchOS-only defensive guard: a span may have already been started for this
+      // task by a factory swizzle (e.g. dataTask(with:completionHandler:)) re-entered
+      // from data(for:), or by a previous resume (NSURLSession super-class chaining
+      // and redirect handling can both cause resume to fire more than once per logical
+      // request). Starting another one here would orphan the existing span:
+      // processAndLogRequest would overwrite runningSpans[taskId] and the first span
+      // would never be ended. Other platforms don't exhibit these re-entries in
+      // practice (verified via URLSessionInstrumentationTests), so this lookup is
+      // gated to watchOS to avoid the per-resume queue sync.
       let alreadyTracked = URLSessionLogger.runningSpansQueue.sync {
         URLSessionLogger.runningSpans[taskId] != nil
       }
       if alreadyTracked { return }
+      #endif
 
       // For iOS 15+/macOS 12+, handle async/await methods differently
       if #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) {

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -743,7 +743,7 @@ public class URLSessionInstrumentation {
     guard !task.isBackground else {
       return
     }
-    
+
     let taskId = idKeyForTask(task)
     if let request = task.currentRequest {
       queue.sync {
@@ -752,6 +752,17 @@ public class URLSessionInstrumentation {
         }
         requestMap[taskId]?.setRequest(request)
       }
+
+      // A span may have already been started for this task — either by a factory
+      // swizzle (e.g. dataTask(with:completionHandler:)) or by a previous resume
+      // (NSURLSession super-class chaining and redirect handling can both cause
+      // resume to fire more than once per logical request, most visibly on watchOS).
+      // Starting another one here would orphan the existing span: processAndLogRequest
+      // would overwrite runningSpans[taskId] and the first span would never be ended.
+      let alreadyTracked = URLSessionLogger.runningSpansQueue.sync {
+        URLSessionLogger.runningSpans[taskId] != nil
+      }
+      if alreadyTracked { return }
 
       // For iOS 15+/macOS 12+, handle async/await methods differently
       if #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) {

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -34,16 +34,19 @@ class URLSessionLogger {
 
   /// This methods creates a Span for a request, and optionally injects tracing headers, returns a  new request if it was needed to create a new one to add the tracing headers
   @discardableResult static func processAndLogRequest(_ request: URLRequest, sessionTaskId: String, instrumentation: URLSessionInstrumentation, shouldInjectHeaders: Bool) -> URLRequest? {
-    // Some platforms (most visibly watchOS) re-route a single user-level URLSession
-    // call through two distinct URLSessionTask objects: an outer task whose `resume()`
-    // is intercepted by our swizzle, and an inner task that Foundation creates by
-    // re-entering the public `session.dataTask(with: URLRequest)` we also swizzle.
-    // The inner factory swizzle would then start a second span and orphan the first.
-    // Detect that case by recognising the `traceparent` header we just injected on
-    // the outer pass, and return without creating a duplicate.
+    #if os(watchOS)
+    // watchOS routes a single user-level URLSession call (e.g. `data(for:)`) through
+    // two distinct URLSessionTask objects: an outer task whose `resume()` is intercepted
+    // by our swizzle, and an inner task that Foundation creates by re-entering the public
+    // `session.dataTask(with: URLRequest)` we also swizzle. The inner factory swizzle
+    // would then start a second span and orphan the first. Detect that case by recognising
+    // the `traceparent` header we just injected on the outer pass, and return without
+    // creating a duplicate. Other platforms implement `data(for:)` without re-entering
+    // the public factory, so this lookup is unnecessary overhead there.
     if hasAlreadyInstrumentedSpan(for: request) {
       return nil
     }
+    #endif
     guard instrumentation.configuration.shouldInstrument?(request) ?? true else {
       return nil
     }
@@ -202,12 +205,12 @@ class URLSessionLogger {
     span.end()
   }
 
+  #if os(watchOS)
   /// Returns true when the request already carries a `traceparent` whose trace id
-  /// matches a currently running span. This is used to suppress duplicate spans on
-  /// paths where Foundation re-injects the already-instrumented request into one of
-  /// the swizzled task-creation factories (notably watchOS, where the outer
-  /// async-await task spawns an inner data task via the public dataTask(with:) API
-  /// after we have already injected headers on the outer task's currentRequest).
+  /// matches a currently running span. Used on watchOS to suppress duplicate spans
+  /// when Foundation re-injects an already-instrumented request into the swizzled
+  /// `dataTask(with:)` factory after the outer task's resume swizzle has already
+  /// started a span.
   private static func hasAlreadyInstrumentedSpan(for request: URLRequest) -> Bool {
     guard let traceparent = request.value(forHTTPHeaderField: "traceparent") else {
       return false
@@ -219,6 +222,7 @@ class URLSessionLogger {
       runningSpans.values.contains { $0.context.traceId.hexString.lowercased() == incomingTraceId }
     }
   }
+  #endif
 
   private static func statusForStatusCode(code: Int) -> Status {
     switch code {

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -34,6 +34,16 @@ class URLSessionLogger {
 
   /// This methods creates a Span for a request, and optionally injects tracing headers, returns a  new request if it was needed to create a new one to add the tracing headers
   @discardableResult static func processAndLogRequest(_ request: URLRequest, sessionTaskId: String, instrumentation: URLSessionInstrumentation, shouldInjectHeaders: Bool) -> URLRequest? {
+    // Some platforms (most visibly watchOS) re-route a single user-level URLSession
+    // call through two distinct URLSessionTask objects: an outer task whose `resume()`
+    // is intercepted by our swizzle, and an inner task that Foundation creates by
+    // re-entering the public `session.dataTask(with: URLRequest)` we also swizzle.
+    // The inner factory swizzle would then start a second span and orphan the first.
+    // Detect that case by recognising the `traceparent` header we just injected on
+    // the outer pass, and return without creating a duplicate.
+    if hasAlreadyInstrumentedSpan(for: request) {
+      return nil
+    }
     guard instrumentation.configuration.shouldInstrument?(request) ?? true else {
       return nil
     }
@@ -190,6 +200,24 @@ class URLSessionLogger {
     instrumentation.configuration.receivedError?(error, dataOrFile, statusCode, span)
 
     span.end()
+  }
+
+  /// Returns true when the request already carries a `traceparent` whose trace id
+  /// matches a currently running span. This is used to suppress duplicate spans on
+  /// paths where Foundation re-injects the already-instrumented request into one of
+  /// the swizzled task-creation factories (notably watchOS, where the outer
+  /// async-await task spawns an inner data task via the public dataTask(with:) API
+  /// after we have already injected headers on the outer task's currentRequest).
+  private static func hasAlreadyInstrumentedSpan(for request: URLRequest) -> Bool {
+    guard let traceparent = request.value(forHTTPHeaderField: "traceparent") else {
+      return false
+    }
+    let parts = traceparent.split(separator: "-")
+    guard parts.count >= 2 else { return false }
+    let incomingTraceId = parts[1].lowercased()
+    return runningSpansQueue.sync {
+      runningSpans.values.contains { $0.context.traceId.hexString.lowercased() == incomingTraceId }
+    }
   }
 
   private static func statusForStatusCode(code: Int) -> Status {

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -383,12 +383,7 @@ class URLSessionInstrumentationTests: XCTestCase {
     task.resume()
     URLSessionInstrumentationTests.semaphore.wait()
 
-
-#if os(watchOS)
-    XCTAssertEqual(1, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
-#else
     XCTAssertEqual(0, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
-#endif
     XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled)
     XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
   }
@@ -657,11 +652,7 @@ class URLSessionInstrumentationTests: XCTestCase {
 
     _ = try await URLSession.shared.data(for: request)
 
-#if os(watchOS)
-    XCTAssertEqual(1, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
-#else
     XCTAssertEqual(0, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
-#endif
     XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled)
     XCTAssertNotNil(URLSessionInstrumentationTests.requestCopy?.allHTTPHeaderFields?[W3CTraceContextPropagator.traceparent])
   }


### PR DESCRIPTION
URLSession instrumentation creates more than one span per request on watchOS.  URLSession on watchOS does public API calls instead of internal ones, so current instrumentation called multiple times for the same request and creates orphaned(normal requests) and finished(requests with redirects) spans.

`URLSession.data(for:)` on watchOS spawns an inner `__NSCFLocalDataTask` via the public `session.dataTask(with:URLRequest)` factory after our resume swizzle has already injected a `traceparent` on the outer task's `currentRequest`. That re-entry would start a second span and orphan the first (started but never .end()'d).

Added check to skip the duplicate by matching the request's traceparent against the running-spans map.

Also added a defensive early-return in `urlSessionTaskWillResume` when a span for the task id already exists — this also covers the `URLSessionTask.resume` / `__NSCFURLSessionTask.resume` super-class chain and redirect-triggered re-resumes.

Tested fix on all supported platforms. All `URLSessionInstrumentationTests` pass.