### PR TITLE
Add configurable session lifecycle rules

### DIFF
--- a/Sources/Instrumentation/Sessions/README.md
+++ b/Sources/Instrumentation/Sessions/README.md
@@ -39,8 +39,10 @@ let builder = LoggerProviderBuilder()
 **Custom Configuration**:
 
 ```swift
-let sessionConfig = SessionConfigBuilder()
+let sessionConfig = SessionConfig.builder()
     .with(sessionTimeout: 45 * 60) // 45 minutes
+    .with(maxLifetime: 4 * 60 * 60)
+    .with(restorePersistedSession: false)
     .build()
 let sessionManager = SessionManager(configuration: sessionConfig)
 SessionManagerProvider.register(sessionManager: sessionManager)
@@ -129,13 +131,17 @@ print("Expired: \(session.isExpired())")
 
 ### SessionConfig
 
-| Field            | Type  | Description                                                        | Default         | Required |
-| ---------------- | ----- | ------------------------------------------------------------------ | --------------- | -------- |
-| `sessionTimeout` | `TimeInterval` | Duration in seconds after which a session expires if left inactive | `1800` (30 min) | No       |
+| Field                     | Type            | Description                                                                 | Default         | Required |
+| ------------------------- | --------------- | --------------------------------------------------------------------------- | --------------- | -------- |
+| `sessionTimeout`          | `TimeInterval`  | Duration in seconds after which a session expires if left inactive          | `1800` (30 min) | No       |
+| `maxLifetime`             | `TimeInterval?` | Maximum duration in seconds a session can remain active, regardless of activity | `nil` (disabled) | No       |
+| `restorePersistedSession` | `Bool`          | Whether to resume a saved session as current; when `false`, start a new session and link the saved one as `previous_id` | `true`          | No       |
 
 ```swift
-let config = SessionConfigBuilder()
+let config = SessionConfig.builder()
     .with(sessionTimeout: 30 * 60)
+    .with(maxLifetime: 4 * 60 * 60)
+    .with(restorePersistedSession: false)
     .build()
 ```
 
@@ -143,6 +149,9 @@ let config = SessionConfigBuilder()
 
 - Sessions automatically expire after the configured timeout period of inactivity
 - Accessing a session via `getSession()` extends the expiration time
+- Sessions can also expire after `maxLifetime`, even if `getSession()` continues to extend inactivity
+- Set `restorePersistedSession` to `false` to start a new session on each clean application start while linking the persisted session as `previous_id`
+- When `restorePersistedSession` is `false`, the persisted session's `session.end` uses its last known activity time, capped at the new session start time
 - Expired sessions trigger `session.end` events and create new sessions with `previous_id` links
 
 ## Session Events
@@ -221,9 +230,10 @@ A `session.end` log record is created when a session expires.
 
 ## Persistence
 
-Sessions are automatically persisted to UserDefaults and restored on app restart:
+Sessions are automatically persisted to UserDefaults and can be resumed on app restart:
 
-- Active sessions continue from their previous state
+- By default, active persisted sessions continue from their previous state
+- Set `restorePersistedSession` to `false` to start a new session on clean start while linking and ending the persisted session
 - Expired sessions create new sessions with proper `previous_id` linking
 - Session data is saved periodically (every 30 seconds) to minimize disk I/O
 

--- a/Sources/Instrumentation/Sessions/Session.swift
+++ b/Sources/Instrumentation/Sessions/Session.swift
@@ -34,6 +34,8 @@ public struct Session: Equatable, Sendable {
   public let startTime: Date
   /// The duration in seconds after which this session expires if inactive
   public let sessionTimeout: TimeInterval
+  /// The maximum duration in seconds this session can remain active, regardless of activity
+  public let maxLifetime: TimeInterval?
 
   /// Creates a new session
   /// - Parameters:
@@ -42,16 +44,19 @@ public struct Session: Equatable, Sendable {
   ///   - previousId: Unique identifier of the user's previous session, if any
   ///   - startTime: Start time of the session, defaults to current time
   ///   - sessionTimeout: Duration in seconds after which the session expires if inactive
+  ///   - maxLifetime: Maximum duration in seconds the session can remain active, regardless of activity
   public init(id: String,
               expireTime: Date,
               previousId: String? = nil,
               startTime: Date = Date(),
-              sessionTimeout: TimeInterval = SessionConfig.default.sessionTimeout) {
+              sessionTimeout: TimeInterval = SessionConfig.default.sessionTimeout,
+              maxLifetime: TimeInterval? = SessionConfig.default.maxLifetime) {
     self.id = id
     self.expireTime = expireTime
     self.previousId = previousId
     self.startTime = startTime
     self.sessionTimeout = sessionTimeout
+    self.maxLifetime = maxLifetime
   }
 
   /// Two sessions are considered equal if they have the same ID, prevID, startTime, and expiry timestamp
@@ -60,13 +65,14 @@ public struct Session: Equatable, Sendable {
       lhs.id == rhs.id &&
       lhs.previousId == rhs.previousId &&
       lhs.startTime == rhs.startTime &&
-      lhs.sessionTimeout == rhs.sessionTimeout
+      lhs.sessionTimeout == rhs.sessionTimeout &&
+      lhs.maxLifetime == rhs.maxLifetime
   }
 
   /// Checks if the session has expired
-  /// - Returns: True if the current time is past the session's expireTime time
+  /// - Returns: True if the current time is past the session's inactivity expiry or maximum lifetime
   public func isExpired() -> Bool {
-    return expireTime <= Date()
+    return expirationTime <= Date()
   }
 
   /// The time when the session ended (only available for expired sessions).
@@ -76,6 +82,9 @@ public struct Session: Equatable, Sendable {
   /// - Returns: The session end time, or nil if the session is still active
   public var endTime: Date? {
     guard isExpired() else { return nil }
+    if let maxLifetimeExpirationTime, maxLifetimeExpirationTime <= expireTime {
+      return maxLifetimeExpirationTime
+    }
     return expireTime.addingTimeInterval(-Double(sessionTimeout))
   }
 
@@ -86,5 +95,19 @@ public struct Session: Equatable, Sendable {
   public var duration: TimeInterval? {
     guard let endTime else { return nil }
     return endTime.timeIntervalSince(startTime)
+  }
+
+  private var expirationTime: Date {
+    guard let maxLifetimeExpirationTime else {
+      return expireTime
+    }
+    return min(expireTime, maxLifetimeExpirationTime)
+  }
+
+  private var maxLifetimeExpirationTime: Date? {
+    guard let maxLifetime else {
+      return nil
+    }
+    return startTime.addingTimeInterval(maxLifetime)
   }
 }

--- a/Sources/Instrumentation/Sessions/SessionConfig.swift
+++ b/Sources/Instrumentation/Sessions/SessionConfig.swift
@@ -7,8 +7,9 @@ import Foundation
 
 /// Configuration object for session management settings.
 ///
-/// Controls session behavior including timeout duration and expiration handling.
-/// Sessions automatically expire after the specified timeout period of inactivity.
+/// Controls session behavior including timeout duration, maximum lifetime, and persistence.
+/// Sessions automatically expire after the specified timeout period of inactivity and can
+/// optionally expire after a maximum lifetime.
 ///
 /// Example:
 /// ```swift
@@ -18,6 +19,7 @@ import Foundation
 /// // Using builder pattern
 /// let config = SessionConfig.builder()
 ///   .with(sessionTimeout: 45 * 60)
+///   .with(maxLifetime: 4 * 60 * 60)
 ///   .build()
 /// 
 /// let manager = SessionManager(configuration: config)
@@ -25,13 +27,27 @@ import Foundation
 public struct SessionConfig: Sendable {
   /// Duration in seconds after which a session expires if left inactive
   public let sessionTimeout: TimeInterval
-  
+
+  /// Maximum duration in seconds a session can remain active, regardless of activity
+  public let maxLifetime: TimeInterval?
+
+  /// Whether a previously saved session should be resumed as the current session
+  public let restorePersistedSession: Bool
+
   /// Creates a new session configuration
-  /// - Parameter sessionTimeout: Duration in seconds after which a session expires if left inactive (default 30 minutes)
-  public init(sessionTimeout: TimeInterval = 30 * 60) {
+  /// - Parameters:
+  ///   - sessionTimeout: Duration in seconds after which a session expires if left inactive (default 30 minutes)
+  ///   - maxLifetime: Maximum duration in seconds a session can remain active, regardless of activity (default disabled)
+  ///   - restorePersistedSession: Whether a previously saved session should be resumed as current (default true).
+  ///     When false, a new session starts and the saved session is linked as previous.
+  public init(sessionTimeout: TimeInterval = 30 * 60,
+              maxLifetime: TimeInterval? = nil,
+              restorePersistedSession: Bool = true) {
     self.sessionTimeout = sessionTimeout
+    self.maxLifetime = maxLifetime
+    self.restorePersistedSession = restorePersistedSession
   }
-  
+
   /// Default configuration with 30-minute session timeout
   public static let `default` = SessionConfig()
 }
@@ -48,7 +64,9 @@ public struct SessionConfig: Sendable {
 /// ```
 public class SessionConfigBuilder {
   public private(set) var sessionTimeout: TimeInterval = 30 * 60
-  
+  public private(set) var maxLifetime: TimeInterval?
+  public private(set) var restorePersistedSession = true
+
   /// Sets the session timeout duration
   /// - Parameter sessionTimeout: Duration in seconds after which a session expires if left inactive
   /// - Returns: The builder instance for method chaining
@@ -56,11 +74,32 @@ public class SessionConfigBuilder {
     self.sessionTimeout = sessionTimeout
     return self
   }
-  
+
+  /// Sets the maximum duration a session can remain active
+  /// - Parameter maxLifetime: Maximum duration in seconds a session can remain active, regardless of activity
+  /// - Returns: The builder instance for method chaining
+  public func with(maxLifetime: TimeInterval?) -> Self {
+    self.maxLifetime = maxLifetime
+    return self
+  }
+
+  /// Sets whether a previously saved session should be resumed as the current session
+  /// - Parameter restorePersistedSession: Whether persisted sessions should be resumed as current.
+  ///   When false, a new session starts and the saved session is linked as previous.
+  /// - Returns: The builder instance for method chaining
+  public func with(restorePersistedSession: Bool) -> Self {
+    self.restorePersistedSession = restorePersistedSession
+    return self
+  }
+
   /// Builds the SessionConfig with the configured settings
   /// - Returns: A new SessionConfig instance
   public func build() -> SessionConfig {
-    return SessionConfig(sessionTimeout: sessionTimeout)
+    return SessionConfig(
+      sessionTimeout: sessionTimeout,
+      maxLifetime: maxLifetime,
+      restorePersistedSession: restorePersistedSession
+    )
   }
 }
 

--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -11,13 +11,14 @@ import Foundation
 public class SessionManager: @unchecked Sendable {
   private var configuration: SessionConfig
   private var session: Session?
+  private var persistedPreviousSession: Session?
   private let lock = NSLock()
 
   /// Initializes the session manager and restores any previous session from disk
   /// - Parameter configuration: Session configuration settings
   public init(configuration: SessionConfig = .default) {
     self.configuration = configuration
-    restoreSessionFromDisk()
+    loadPersistedSessionFromDisk()
   }
 
   /// Gets the current session, creating or extending it as needed
@@ -26,7 +27,7 @@ public class SessionManager: @unchecked Sendable {
   @discardableResult
   public func getSession() -> Session {
     let (currentSession,
-         previousSession,
+         previousSessionToEnd,
          sessionDidExpire) = lock.withLock {
       if let session,
          !session.isExpired() {
@@ -36,17 +37,18 @@ public class SessionManager: @unchecked Sendable {
         return (extendedSession, nil as Session?, false)
       } else {
         // start new session
-        let prev = session
+        let prev = session ?? persistedPreviousSession
         let nextSession = locked_startSession()
         self.session = nextSession
+        self.persistedPreviousSession = nil
         return (nextSession, prev, true)
       }
     }
 
     // Call external code outside the lock only if new session was created
     if sessionDidExpire {
-      if let previousSession {
-        SessionEventInstrumentation.addSession(session: previousSession, eventType: .end)
+      if let previousSessionToEnd {
+        SessionEventInstrumentation.addSession(session: previousSessionToEnd, eventType: .end)
       }
       SessionEventInstrumentation.addSession(session: currentSession, eventType: .start)
       NotificationCenter.default.post(name: SessionEventNotification, object: currentSession)
@@ -70,9 +72,35 @@ public class SessionManager: @unchecked Sendable {
     return Session(
       id: UUID().uuidString,
       expireTime: now.addingTimeInterval(Double(configuration.sessionTimeout)),
-      previousId: session?.id,
+      previousId: session?.id ?? persistedPreviousSession?.id,
       startTime: now,
-      sessionTimeout: configuration.sessionTimeout
+      sessionTimeout: configuration.sessionTimeout,
+      maxLifetime: configuration.maxLifetime
+    )
+  }
+
+  /// Ends a restored historical session at its last known activity, capped at restore time
+  private func endPersistedPreviousSession(_ session: Session) -> Session {
+    guard !session.isExpired() else {
+      return session
+    }
+
+    let now = Date()
+    var inferredEndTime = session.expireTime.addingTimeInterval(-session.sessionTimeout)
+    if inferredEndTime < session.startTime {
+      inferredEndTime = session.startTime
+    }
+    if inferredEndTime > now {
+      inferredEndTime = now
+    }
+    return Session(
+      id: session.id,
+      expireTime: inferredEndTime,
+      previousId: session.previousId,
+      startTime: session.startTime,
+      // Pin `endTime` to `inferredEndTime`; `Session.endTime` subtracts `sessionTimeout`.
+      sessionTimeout: 0,
+      maxLifetime: nil
     )
   }
 
@@ -84,15 +112,20 @@ public class SessionManager: @unchecked Sendable {
       expireTime: Date(timeIntervalSinceNow: Double(configuration.sessionTimeout)),
       previousId: session.previousId,
       startTime: session.startTime,
-      sessionTimeout: configuration.sessionTimeout
+      sessionTimeout: configuration.sessionTimeout,
+      maxLifetime: session.maxLifetime
     )
   }
 
-  /// Restores a previously saved session from UserDefaults
-  private func restoreSessionFromDisk() {
+  /// Loads a saved session from UserDefaults according to the configured restore behavior
+  private func loadPersistedSessionFromDisk() {
     let loadedSession = SessionStore.load()
     lock.withLock {
-      session = loadedSession
+      if configuration.restorePersistedSession {
+        session = loadedSession
+      } else {
+        persistedPreviousSession = loadedSession.map { endPersistedPreviousSession($0) }
+      }
     }
   }
 }

--- a/Sources/Instrumentation/Sessions/SessionStore.swift
+++ b/Sources/Instrumentation/Sessions/SessionStore.swift
@@ -18,6 +18,8 @@ internal final class SessionStore {
   static let startTimeKey = "otel-session-start-time"
   /// UserDefaults key for storing session timeout
   static let sessionTimeoutKey = "otel-session-timeout"
+  /// UserDefaults key for storing session maximum lifetime
+  static let maxLifetimeKey = "otel-session-max-lifetime"
 
   /// To avoid writing to disk too often, SessionStore only keeps the current session
   /// in memory and saves to disk on an interval (every 30 seconds).
@@ -81,6 +83,11 @@ internal final class SessionStore {
     UserDefaults.standard.set(session.startTime, forKey: startTimeKey)
     UserDefaults.standard.set(session.previousId, forKey: previousIdKey)
     UserDefaults.standard.set(session.sessionTimeout, forKey: sessionTimeoutKey)
+    if let maxLifetime = session.maxLifetime {
+      UserDefaults.standard.set(maxLifetime, forKey: maxLifetimeKey)
+    } else {
+      UserDefaults.standard.removeObject(forKey: maxLifetimeKey)
+    }
 
     lock.withLock {
       // update prev session
@@ -102,13 +109,15 @@ internal final class SessionStore {
     }
 
     let previousId = UserDefaults.standard.string(forKey: previousIdKey)
+    let maxLifetime = UserDefaults.standard.object(forKey: maxLifetimeKey) as? TimeInterval
 
     let session = Session(
       id: id,
       expireTime: expireTime,
       previousId: previousId,
       startTime: startTime,
-      sessionTimeout: sessionTimeout
+      sessionTimeout: sessionTimeout,
+      maxLifetime: maxLifetime
     )
     lock.withLock {
       // reset sessions so it does not get overridden in the next scheduled save
@@ -133,5 +142,6 @@ internal final class SessionStore {
     UserDefaults.standard.removeObject(forKey: expireTimeKey)
     UserDefaults.standard.removeObject(forKey: previousIdKey)
     UserDefaults.standard.removeObject(forKey: sessionTimeoutKey)
+    UserDefaults.standard.removeObject(forKey: maxLifetimeKey)
   }
 }

--- a/Tests/InstrumentationTests/SessionTests/SessionConfigTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionConfigTests.swift
@@ -6,38 +6,54 @@ final class SessionConfigurationTests: XCTestCase {
   func testDefaultConfiguration() {
     let config = SessionConfig.default
     XCTAssertEqual(config.sessionTimeout, 30 * 60) // should be 30 minutes
+    XCTAssertNil(config.maxLifetime)
+    XCTAssertTrue(config.restorePersistedSession)
   }
   
   func testCustomConfiguration() {
-    let config = SessionConfig(sessionTimeout: 3600)
+    let config = SessionConfig(sessionTimeout: 3600, maxLifetime: 4 * 60 * 60, restorePersistedSession: false)
     XCTAssertEqual(config.sessionTimeout, 3600)
+    XCTAssertEqual(config.maxLifetime, 4 * 60 * 60)
+    XCTAssertFalse(config.restorePersistedSession)
   }
   
   func testBuilderPattern() {
     let config = SessionConfig.builder()
       .with(sessionTimeout: 45 * 60)
+      .with(maxLifetime: 4 * 60 * 60)
+      .with(restorePersistedSession: false)
       .build()
     
     XCTAssertEqual(config.sessionTimeout, 45 * 60)
+    XCTAssertEqual(config.maxLifetime, 4 * 60 * 60)
+    XCTAssertFalse(config.restorePersistedSession)
   }
   
   func testBuilderDefaultValues() {
     let config = SessionConfig.builder().build()
     XCTAssertEqual(config.sessionTimeout, 30 * 60) // should be 30 minutes
+    XCTAssertNil(config.maxLifetime)
+    XCTAssertTrue(config.restorePersistedSession)
   }
   
   func testBuilderMethodChaining() {
     let builder = SessionConfig.builder()
     let sameBuilder = builder.with(sessionTimeout: 60 * 60)
     XCTAssertTrue(builder === sameBuilder)
+    XCTAssertTrue(builder === builder.with(maxLifetime: 4 * 60 * 60))
+    XCTAssertTrue(builder === builder.with(restorePersistedSession: false))
   }
   
   func testBuilderEqualsNormalConfig() {
-    let normalConfig = SessionConfig(sessionTimeout: 45 * 60)
+    let normalConfig = SessionConfig(sessionTimeout: 45 * 60, maxLifetime: 4 * 60 * 60, restorePersistedSession: false)
     let builderConfig = SessionConfig.builder()
       .with(sessionTimeout: 45 * 60)
+      .with(maxLifetime: 4 * 60 * 60)
+      .with(restorePersistedSession: false)
       .build()
     
     XCTAssertEqual(normalConfig.sessionTimeout, builderConfig.sessionTimeout)
+    XCTAssertEqual(normalConfig.maxLifetime, builderConfig.maxLifetime)
+    XCTAssertEqual(normalConfig.restorePersistedSession, builderConfig.restorePersistedSession)
   }
 }

--- a/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
@@ -57,6 +57,16 @@ final class SessionManagerTests: XCTestCase {
     XCTAssertGreaterThan(session2.startTime, session1.startTime)
   }
 
+  func testGetSessionExpiredByMaxLifetime() {
+    sessionManager = SessionManager(configuration: SessionConfig(sessionTimeout: 60 * 60, maxLifetime: 0))
+    let session1 = sessionManager.getSession()
+    let session2 = sessionManager.getSession()
+
+    XCTAssertNotEqual(session1.id, session2.id)
+    XCTAssertEqual(session2.previousId, session1.id)
+    XCTAssertGreaterThan(session1.expireTime, Date())
+  }
+
   func testGetSessionSavedToDisk() {
     let session = sessionManager.getSession()
     let savedId = UserDefaults.standard.object(forKey: SessionStore.idKey) as? String
@@ -64,6 +74,68 @@ final class SessionManagerTests: XCTestCase {
 
     XCTAssertEqual(session.id, savedId)
     XCTAssertEqual(session.sessionTimeout, TimeInterval(savedTimeout ?? -1))
+  }
+
+  func testRestorePersistedSessionFalseUsesPersistedSessionAsPreviousSession() {
+    let persistedSession = Session(
+      id: "persisted-session",
+      expireTime: Date(timeIntervalSinceNow: 60 * 60),
+      startTime: Date(),
+      sessionTimeout: 60 * 60
+    )
+    SessionStore.saveImmediately(session: persistedSession)
+
+    sessionManager = SessionManager(
+      configuration: SessionConfig(sessionTimeout: 60 * 60, restorePersistedSession: false)
+    )
+
+    XCTAssertNil(sessionManager.peekSession())
+
+    let newSession = sessionManager.getSession()
+    XCTAssertNotEqual(newSession.id, persistedSession.id)
+    XCTAssertEqual(newSession.previousId, persistedSession.id)
+  }
+
+  func testRestorePersistedSessionFalseEndsPersistedSessionAtLastActivity() {
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = false
+    defer {
+      SessionEventInstrumentation.queue = []
+      SessionEventInstrumentation.isApplied = false
+    }
+    let sessionTimeout: TimeInterval = 60 * 60
+    let lastActivity = Date(timeIntervalSinceNow: -5 * 60)
+    let persistedSession = Session(
+      id: "persisted-session",
+      expireTime: lastActivity.addingTimeInterval(sessionTimeout),
+      startTime: Date(timeIntervalSinceNow: -2 * 60 * 60),
+      sessionTimeout: sessionTimeout
+    )
+    SessionStore.saveImmediately(session: persistedSession)
+
+    sessionManager = SessionManager(
+      configuration: SessionConfig(sessionTimeout: sessionTimeout, restorePersistedSession: false)
+    )
+
+    let newSession = sessionManager.getSession()
+
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 2)
+    guard SessionEventInstrumentation.queue.count >= 2 else {
+      return
+    }
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].session.id, persistedSession.id)
+    if case .end = SessionEventInstrumentation.queue[0].eventType {
+      XCTAssertEqual(SessionEventInstrumentation.queue[0].session.endTime?.timeIntervalSince1970 ?? 0, lastActivity.timeIntervalSince1970, accuracy: 1.0)
+    } else {
+      XCTFail("Expected a session.end event for the persisted session")
+    }
+    XCTAssertLessThanOrEqual(SessionEventInstrumentation.queue[0].session.endTime ?? .distantFuture, newSession.startTime)
+
+    XCTAssertEqual(SessionEventInstrumentation.queue[1].session.id, newSession.id)
+    if case .start = SessionEventInstrumentation.queue[1].eventType {
+      return
+    }
+    XCTFail("Expected a session.start event for the new session")
   }
 
   func testLoadSessionMissingExpiry() {

--- a/Tests/InstrumentationTests/SessionTests/SessionStoreTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionStoreTests.swift
@@ -11,7 +11,7 @@ final class SessionStoreTests: XCTestCase {
     let sessionId = "test-session-123"
     let expireTime = Date(timeIntervalSinceNow: 1800)
     let startTime = Date(timeIntervalSinceNow: -300)
-    let session = Session(id: sessionId, expireTime: expireTime, previousId: nil, startTime: startTime)
+    let session = Session(id: sessionId, expireTime: expireTime, previousId: nil, startTime: startTime, maxLifetime: 4 * 60 * 60)
 
     SessionStore.scheduleSave(session: session)
     let loadedSession = SessionStore.load()
@@ -21,6 +21,7 @@ final class SessionStoreTests: XCTestCase {
     XCTAssertEqual(loadedSession?.expireTime, expireTime)
     XCTAssertEqual(loadedSession?.startTime, startTime)
     XCTAssertNil(loadedSession?.previousId)
+    XCTAssertEqual(loadedSession?.maxLifetime, 4 * 60 * 60)
   }
 
   func testLoadSessionWhenNothingSaved() {
@@ -68,12 +69,38 @@ final class SessionStoreTests: XCTestCase {
     XCTAssertEqual(loaded2?.id, "session-2")
   }
 
+  func testSaveWithoutMaxLifetimeClearsPreviousMaxLifetime() {
+    let cappedSession = Session(
+      id: "session-1",
+      expireTime: Date(timeIntervalSinceNow: 1800),
+      startTime: Date(),
+      sessionTimeout: 1800,
+      maxLifetime: 4 * 60 * 60
+    )
+    let uncappedSession = Session(
+      id: "session-2",
+      expireTime: Date(timeIntervalSinceNow: 1800),
+      startTime: Date(),
+      sessionTimeout: 1800
+    )
+
+    SessionStore.saveImmediately(session: cappedSession)
+    XCTAssertNotNil(UserDefaults.standard.object(forKey: SessionStore.maxLifetimeKey))
+
+    SessionStore.saveImmediately(session: uncappedSession)
+    let loadedSession = SessionStore.load()
+
+    XCTAssertNil(UserDefaults.standard.object(forKey: SessionStore.maxLifetimeKey))
+    XCTAssertNil(loadedSession?.maxLifetime)
+  }
+
   func testStoreKeys() {
     XCTAssertEqual(SessionStore.idKey, "otel-session-id")
     XCTAssertEqual(SessionStore.expireTimeKey, "otel-session-expire-time")
     XCTAssertEqual(SessionStore.startTimeKey, "otel-session-start-time")
     XCTAssertEqual(SessionStore.previousIdKey, "otel-session-previous-id")
     XCTAssertEqual(SessionStore.sessionTimeoutKey, "otel-session-timeout")
+    XCTAssertEqual(SessionStore.maxLifetimeKey, "otel-session-max-lifetime")
   }
 
 
@@ -102,10 +129,11 @@ final class SessionStoreTests: XCTestCase {
   }
 
   func testTeardownClearsUserDefaults() {
-    let session = Session(id: "test-session", expireTime: Date(timeIntervalSinceNow: 1800), previousId: nil, startTime: Date(), sessionTimeout: 1800)
+    let session = Session(id: "test-session", expireTime: Date(timeIntervalSinceNow: 1800), previousId: nil, startTime: Date(), sessionTimeout: 1800, maxLifetime: 4 * 60 * 60)
     SessionStore.saveImmediately(session: session)
 
     XCTAssertNotNil(UserDefaults.standard.string(forKey: SessionStore.idKey))
+    XCTAssertNotNil(UserDefaults.standard.object(forKey: SessionStore.maxLifetimeKey))
 
     SessionStore.teardown()
 
@@ -114,6 +142,7 @@ final class SessionStoreTests: XCTestCase {
     XCTAssertNil(UserDefaults.standard.object(forKey: SessionStore.startTimeKey))
     XCTAssertNil(UserDefaults.standard.string(forKey: SessionStore.previousIdKey))
     XCTAssertNil(UserDefaults.standard.object(forKey: SessionStore.sessionTimeoutKey))
+    XCTAssertNil(UserDefaults.standard.object(forKey: SessionStore.maxLifetimeKey))
   }
 
   func testTeardownInvalidatesTimer() {

--- a/Tests/InstrumentationTests/SessionTests/SessionTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionTests.swift
@@ -49,6 +49,43 @@ final class SessionTests: XCTestCase {
     XCTAssertTrue(session.isExpired(), "Session with past expireTime should be expired")
   }
 
+  func testSessionExpiredByMaxLifetime() {
+    let startTime = Date(timeIntervalSinceNow: -4 * 60 * 60)
+    let inactivityExpiry = Date(timeIntervalSinceNow: 60 * 60)
+    let session = Session(
+      id: "test-id",
+      expireTime: inactivityExpiry,
+      startTime: startTime,
+      sessionTimeout: 60 * 60,
+      maxLifetime: 4 * 60 * 60
+    )
+
+    XCTAssertTrue(session.isExpired(), "Session should expire when maxLifetime is reached")
+    XCTAssertNotNil(session.endTime)
+    XCTAssertNotNil(session.duration)
+    XCTAssertEqual(session.endTime?.timeIntervalSince1970 ?? 0, startTime.addingTimeInterval(4 * 60 * 60).timeIntervalSince1970, accuracy: 1.0)
+    XCTAssertEqual(session.duration ?? 0, 4 * 60 * 60, accuracy: 1.0)
+  }
+
+  func testSessionExpiredByInactivityBeforeMaxLifetime() {
+    let startTime = Date(timeIntervalSinceNow: -2 * 60 * 60)
+    let sessionTimeout: TimeInterval = 60 * 60
+    let expectedEndTime = Date(timeIntervalSinceNow: -90 * 60)
+    let session = Session(
+      id: "test-id",
+      expireTime: expectedEndTime.addingTimeInterval(sessionTimeout),
+      startTime: startTime,
+      sessionTimeout: sessionTimeout,
+      maxLifetime: 4 * 60 * 60
+    )
+
+    XCTAssertTrue(session.isExpired(), "Session should expire when inactivity timeout is reached before maxLifetime")
+    XCTAssertNotNil(session.endTime)
+    XCTAssertNotNil(session.duration)
+    XCTAssertEqual(session.endTime?.timeIntervalSince1970 ?? 0, expectedEndTime.timeIntervalSince1970, accuracy: 1.0)
+    XCTAssertEqual(session.duration ?? 0, expectedEndTime.timeIntervalSince(startTime), accuracy: 1.0)
+  }
+
   func testSessionExpiryAtExactTime() {
     let currentTime = Date()
     let session = Session(id: "test-id", expireTime: currentTime)


### PR DESCRIPTION
## Summary

I think there might be use cases when you want to control the session lifecycle a bit more, and for example be able to tell it to always create a new session on clean app start.

I am not sure if this is the right approach to just open a PR, or if you would like to have an issue for this first.
Maybe you already discussed this topic and decided against it. 

Anyhow, it was not so much work to add this support, so I thought I would just open up a PR directly.

This PR does:

- Add `maxLifetime` and `restorePersistedSession` to `SessionConfig` and `SessionConfigBuilder` while preserving existing defaults.
- Expire sessions by either inactivity timeout or optional maximum lifetime.
- Support clean-start session behavior with `restorePersistedSession: false`, while still linking the persisted session as `session.previous_id` and emitting an inferred `session.end` before the new `session.start`.
- Persist `maxLifetime`, handle old persisted sessions where it is absent, and update Sessions README docs.

## Context

The OpenTelemetry session semantic convention defines the session attributes and lifecycle events, but leaves lifecycle policy to instrumentation. It says sessions may end due to inactivity or timeout, and allows a new `session.start` to include `session.previous_id` when continuing from a prior session: https://opentelemetry.io/docs/specs/semconv/general/session/

The Android OpenTelemetry instrumentation exposes a session lifecycle configuration for inactivity timeout and maximum lifetime (`backgroundInactivityTimeout`, `maxLifetime`): https://opentelemetry.io/docs/platforms/client-apps/android/
This change brings Swift closer to that configurable session-SDK behavior without changing default behavior for existing users.

## Compatibility

Defaults preserve current behavior:

- `sessionTimeout` remains 30 minutes.
- `maxLifetime` defaults to `nil`, so no absolute lifetime cap is applied unless configured.
- `restorePersistedSession` defaults to `true`, so persisted sessions are resumed as current by default.

Persisted sessions created by older versions do not contain `maxLifetime`; those load as `nil`.

## Validation

- `swift build --build-tests`
- `swift test --filter SessionTests`
