### PR TITLE
Update Xcode build destination for arm64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME="opentelemetry-swift-Package"
 
 XCODEBUILD_OPTIONS_IOS=\
 	-configuration Debug \
-	-destination 'platform=iOS Simulator,name=iPhone 16' \
+	-destination 'platform=iOS Simulator,name=iPhone 16,arch=arm64' \
 	-scheme $(PROJECT_NAME) \
 	-test-iterations 5 \
     -retry-tests-on-failure \


### PR DESCRIPTION
This should resolve test performance issues when the build system chooses an x86_64 simulator runs on arm64 macOS hardware due to : 
```
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:iOS Simulator, arch:arm64, id:19BF4941-E297-412C-9BEF-5DDEBF0097A6, OS:26.2, name:iPhone 16 }
{ platform:iOS Simulator, arch:x86_64, id:19BF4941-E297-412C-9BEF-5DDEBF0097A6, OS:26.2, name:iPhone 16 }

```