### PR TITLE
Extract CocoaPods push into standalone reusable workflow

### DIFF
--- a/.github/workflows/Push-CocoaPods.yml
+++ b/.github/workflows/Push-CocoaPods.yml
@@ -1,0 +1,67 @@
+name: Push CocoaPods
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to push (e.g. 1.2.3)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  cocoapods:
+    name: Publish to CocoaPods
+    runs-on: macos-latest
+    env:
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Checkout at tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.version }}
+          fetch-depth: 0
+
+      - name: Publish to CocoaPods trunk
+        run: |
+          set -euo pipefail
+          failed_pods=()
+
+          pods=(
+            "OpenTelemetry-Swift-BaggagePropagationProcessor"
+            "OpenTelemetry-Swift-Instrumentation-NetworkStatus"
+            "OpenTelemetry-Swift-Instrumentation-URLSession"
+            "OpenTelemetry-Swift-SdkResourceExtension"
+            "OpenTelemetry-Swift-Protocol-Exporter-Common"
+            "OpenTelemetry-Swift-Protocol-Exporter-Http"
+            "OpenTelemetry-Swift-PersistenceExporter"
+          )
+
+          for pod_name in "${pods[@]}"; do
+            echo "Processing $pod_name..."
+            if pod trunk info "$pod_name" 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
+              echo "::warning::$pod_name '${VERSION}' already exists on CocoaPods. Skipping."
+            else
+              if ! pod trunk push "${pod_name}.podspec" --allow-warnings --synchronous; then
+                echo "::error::Failed to push $pod_name"
+                failed_pods+=("$pod_name")
+              else
+                echo "Successfully pushed $pod_name"
+              fi
+            fi
+          done
+
+          if [ ${#failed_pods[@]} -gt 0 ]; then
+            echo "::error::The following pods failed to publish: ${failed_pods[*]}"
+            exit 1
+          else
+            echo "All pods published successfully!"
+          fi

--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -56,49 +56,11 @@ jobs:
   
   cocoapods:
     name: Publish to CocoaPods
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
     needs: tag
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Publish to CocoaPods trunk
-        env: 
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: |
-          VERSION="${{ needs.tag.outputs.version }}"
-          failed_pods=()
-          
-          # Define all pods to publish
-          pods=(
-            "OpenTelemetry-Swift-BaggagePropagationProcessor"
-            "OpenTelemetry-Swift-Instrumentation-NetworkStatus"
-            "OpenTelemetry-Swift-Instrumentation-URLSession"
-            "OpenTelemetry-Swift-SdkResourceExtension"
-            "OpenTelemetry-Swift-Protocol-Exporter-Common"
-            "OpenTelemetry-Swift-Protocol-Exporter-Http"
-            "OpenTelemetry-Swift-PersistenceExporter"
-          )
-          
-          # Process each pod
-          for pod_name in "${pods[@]}"; do
-            echo "Processing $pod_name..."
-            
-            if pod trunk info "$pod_name" 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
-              echo "::warning::$pod_name '${VERSION}' already exists on CocoaPods. Skipping."
-            else
-              if ! pod trunk push "${pod_name}.podspec" --allow-warnings --synchronous; then
-                echo "::error::Failed to push $pod_name"
-                failed_pods+=("$pod_name")
-              else
-                echo "Successfully pushed $pod_name"
-              fi
-            fi
-          done
-          
-          # Report results
-          if [ ${#failed_pods[@]} -gt 0 ]; then
-            echo "::error::The following pods failed to publish: ${failed_pods[*]}"
-            exit 1
-          else
-            echo "All pods published successfully!"
-          fi
-        
+    uses: ./.github/workflows/Push-CocoaPods.yml
+    with:
+      version: ${{ needs.tag.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
# Overview
The cocoapods release step has been extracted into its own reusable workflow (Push-CocoaPods.yml) that can be triggered both automatically (called from `Tag-And-Release`) and manually via workflow_dispatch. This allows re-running just the cocoapods push after fixing a transient failure, without having to re-trigger the full release workflow or wait for a new PR merge.

> [!NOTE]
> This is a similar approach to [this other PR in Core](https://github.com/open-telemetry/opentelemetry-swift-core/pull/77); any changes there should be reflected here too.