### PR TITLE
URLSessionInstrumentation - swizzle to always add URLSessionDataDelegate hooks

### DIFF
--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -492,6 +492,13 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
     let selector = #selector(
       URLSessionDataDelegate.urlSession(_:dataTask:didReceive:))
     guard let original = class_getInstanceMethod(cls, selector) else {
+      let block:
+        @convention(block) (Any, URLSession, URLSessionDataTask, Data) -> Void = { _, session, dataTask, data in
+          self.urlSession(session, dataTask: dataTask, didReceive: data)
+        }
+      let imp = imp_implementationWithBlock(
+        unsafeBitCast(block, to: AnyObject.self))
+      class_addMethod(cls, selector, imp, "v@:@@@")
       return
     }
     var originalIMP: IMP?
@@ -517,6 +524,16 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
       URLSessionDataDelegate.urlSession(
         _:dataTask:didReceive:completionHandler:))
     guard let original = class_getInstanceMethod(cls, selector) else {
+      let block:
+        @convention(block) (Any, URLSession, URLSessionDataTask, URLResponse,
+                            @escaping (URLSession.ResponseDisposition) -> Void) -> Void = { _, session, dataTask, response, completion in
+          self.urlSession(session, dataTask: dataTask, didReceive: response,
+                          completionHandler: completion)
+          completion(.allow)
+        }
+      let imp = imp_implementationWithBlock(
+        unsafeBitCast(block, to: AnyObject.self))
+      class_addMethod(cls, selector, imp, "v@:@@@@")
       return
     }
     var originalIMP: IMP?
@@ -544,6 +561,13 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
     let selector = #selector(
       URLSessionDataDelegate.urlSession(_:task:didCompleteWithError:))
     guard let original = class_getInstanceMethod(cls, selector) else {
+      let block:
+        @convention(block) (Any, URLSession, URLSessionTask, Error?) -> Void = { _, session, task, error in
+          self.urlSession(session, task: task, didCompleteWithError: error)
+        }
+      let imp = imp_implementationWithBlock(
+        unsafeBitCast(block, to: AnyObject.self))
+      class_addMethod(cls, selector, imp, "v@:@@@")
       return
     }
     var originalIMP: IMP?
@@ -576,7 +600,7 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
         }
       let imp = imp_implementationWithBlock(
         unsafeBitCast(block, to: AnyObject.self))
-      class_addMethod(cls, selector, imp, "@@@")
+      class_addMethod(cls, selector, imp, "v@:@@@")
       return
     }
     var originalIMP: IMP?
@@ -629,6 +653,13 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
           (URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void
         )?)
     guard let original = class_getInstanceMethod(cls, selector) else {
+      let block:
+        @convention(block) (Any, URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void = { _, session, dataTask, downloadTask in
+          self.urlSession(session, dataTask: dataTask, didBecome: downloadTask)
+        }
+      let imp = imp_implementationWithBlock(
+        unsafeBitCast(block, to: AnyObject.self))
+      class_addMethod(cls, selector, imp, "v@:@@@")
       return
     }
     var originalIMP: IMP?

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -71,19 +71,14 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
   }
 
   private func injectInNSURLClasses() {
-    let classes =
-      configuration.delegateClassesToInstrument
-        ?? InstrumentationUtils.objc_getClassList()
-    DispatchQueue.concurrentPerform(iterations: classes.count) { iteration in
-      let theClass: AnyClass = classes[iteration]
-      guard theClass != Self.self,
-            !Self.excludeList.contains(NSStringFromClass(theClass)),
-            Self.conformsToURLSessionTaskDelegate(theClass)
-      else {
-        return
+    if let delegateClassesToInstrument = configuration.delegateClassesToInstrument {
+      DispatchQueue.concurrentPerform(iterations: delegateClassesToInstrument.count) { iteration in
+        let theClass: AnyClass = delegateClassesToInstrument[iteration]
+        guard theClass != Self.self else { return }
+        injectIntoDelegateClass(cls: theClass)
       }
-
-      injectIntoDelegateClass(cls: theClass)
+    } else {
+      injectIntoDiscoveredDelegateClasses()
     }
 
     if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
@@ -95,15 +90,59 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
     injectIntoNSURLSessionTaskResume()
   }
 
-  private static func conformsToURLSessionTaskDelegate(_ cls: AnyClass) -> Bool {
-    var currentClass: AnyClass? = cls
-    while let candidate = currentClass {
-      if class_conformsToProtocol(candidate, URLSessionTaskDelegate.self) {
-        return true
+  private func injectIntoDiscoveredDelegateClasses() {
+    let selectors = [
+      #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:)),
+      #selector(
+        URLSessionDataDelegate.urlSession(
+          _:dataTask:didReceive:completionHandler:)),
+      #selector(
+        URLSessionDataDelegate.urlSession(_:task:didCompleteWithError:)),
+      #selector(
+        URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)
+          as (URLSessionDataDelegate) -> (
+            (URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void
+          )?),
+      #selector(
+        URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)
+          as (URLSessionDataDelegate) -> (
+            (URLSession, URLSessionDataTask, URLSessionStreamTask) -> Void
+          )?),
+      #selector(
+        URLSessionTaskDelegate.urlSession(_:task:didFinishCollecting:))
+    ]
+    let classes = InstrumentationUtils.objc_getClassList()
+    let selectorsCount = selectors.count
+    DispatchQueue.concurrentPerform(iterations: classes.count) { iteration in
+      let theClass: AnyClass = classes[iteration]
+      guard theClass != Self.self else { return }
+      var selectorFound = false
+      var methodCount: UInt32 = 0
+      guard let methodList = class_copyMethodList(theClass, &methodCount) else {
+        return
       }
-      currentClass = class_getSuperclass(candidate)
+      defer { free(methodList) }
+
+      var foundClasses: [AnyClass] = []
+      for j in 0 ..< selectorsCount {
+        for i in 0 ..< Int(methodCount)
+          where method_getName(methodList[i]) == selectors[j] {
+          selectorFound = true
+          foundClasses.append(theClass)
+        }
+        if selectorFound {
+          break
+        }
+      }
+
+      foundClasses.removeAll { cls in
+        Self.excludeList.contains(NSStringFromClass(cls))
+      }
+
+      foundClasses.forEach { cls in
+        injectIntoDelegateClass(cls: cls)
+      }
     }
-    return false
   }
 
   private func injectIntoDelegateClass(cls: AnyClass) {

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -71,59 +71,19 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
   }
 
   private func injectInNSURLClasses() {
-    let selectors = [
-      #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:)),
-      #selector(
-        URLSessionDataDelegate.urlSession(
-          _:dataTask:didReceive:completionHandler:)),
-      #selector(
-        URLSessionDataDelegate.urlSession(_:task:didCompleteWithError:)),
-      #selector(
-        URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)
-          as (URLSessionDataDelegate) -> (
-            (URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void
-          )?),
-      #selector(
-        URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)
-          as (URLSessionDataDelegate) -> (
-            (URLSession, URLSessionDataTask, URLSessionStreamTask) -> Void
-          )?),
-      #selector(
-        URLSessionTaskDelegate.urlSession(_:task:didFinishCollecting:))
-    ]
     let classes =
       configuration.delegateClassesToInstrument
         ?? InstrumentationUtils.objc_getClassList()
-    let selectorsCount = selectors.count
     DispatchQueue.concurrentPerform(iterations: classes.count) { iteration in
       let theClass: AnyClass = classes[iteration]
-      guard theClass != Self.self else { return }
-      var selectorFound = false
-      var methodCount: UInt32 = 0
-      guard let methodList = class_copyMethodList(theClass, &methodCount) else {
+      guard theClass != Self.self,
+            !Self.excludeList.contains(NSStringFromClass(theClass)),
+            Self.conformsToURLSessionTaskDelegate(theClass)
+      else {
         return
       }
-      defer { free(methodList) }
 
-      var foundClasses: [AnyClass] = []
-      for j in 0 ..< selectorsCount {
-        for i in 0 ..< Int(methodCount)
-          where method_getName(methodList[i]) == selectors[j] {
-          selectorFound = true
-          foundClasses.append(theClass)
-        }
-        if selectorFound {
-          break
-        }
-      }
-
-      foundClasses.removeAll { cls in
-        Self.excludeList.contains(NSStringFromClass(cls))
-      }
-
-      foundClasses.forEach { cls in
-        injectIntoDelegateClass(cls: cls)
-      }
+      injectIntoDelegateClass(cls: theClass)
     }
 
     if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
@@ -133,6 +93,17 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
     injectIntoNSURLSessionAsyncDataAndDownloadTaskMethods()
     injectIntoNSURLSessionAsyncUploadTaskMethods()
     injectIntoNSURLSessionTaskResume()
+  }
+
+  private static func conformsToURLSessionTaskDelegate(_ cls: AnyClass) -> Bool {
+    var currentClass: AnyClass? = cls
+    while let candidate = currentClass {
+      if class_conformsToProtocol(candidate, URLSessionTaskDelegate.self) {
+        return true
+      }
+      currentClass = class_getSuperclass(candidate)
+    }
+    return false
   }
 
   private func injectIntoDelegateClass(cls: AnyClass) {

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -1043,21 +1043,41 @@ class URLSessionInstrumentationTests: XCTestCase {
     XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled, "Instrumentation should capture the response")
   }
 
-  public func testDelegateDiscoveryRequiresURLSessionTaskDelegateConformance() {
+  public func testDelegateDiscoveryUsesURLSessionSelectors() {
     let inheritedDelegate = InheritedEmptyTaskDelegate()
     let nonDelegate = NotURLSessionDelegate()
 
-    XCTAssertTrue(
+    XCTAssertFalse(
       inheritedDelegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
-      "Instrumentation should add missing methods to URLSessionTaskDelegate subtypes"
+      "Selector-based discovery should not instrument classes without a matching selector"
     )
     XCTAssertTrue(
       nonDelegate.responds(to: #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:completionHandler:))),
       "NotURLSessionDelegate responds to selector"
     )
-    XCTAssertFalse(
+    XCTAssertTrue(
       nonDelegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
-      "Instrumentation should ignore classes that are not URLSessionTaskDelegate types"
+      "Selector-based discovery should add missing methods to classes with matching selectors"
+    )
+  }
+
+  public func testExplicitDelegateClassesBypassSelectorDiscovery() {
+    let inheritedDelegateBeforeInstrumentation = InheritedEmptyTaskDelegate()
+    XCTAssertFalse(
+      inheritedDelegateBeforeInstrumentation.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
+      "Auto-discovery should not instrument classes without a matching selector"
+    )
+
+    _ = URLSessionInstrumentation(
+      configuration: URLSessionInstrumentationConfiguration(
+        delegateClassesToInstrument: [InheritedEmptyTaskDelegate.self]
+      )
+    )
+
+    let inheritedDelegateAfterInstrumentation = InheritedEmptyTaskDelegate()
+    XCTAssertTrue(
+      inheritedDelegateAfterInstrumentation.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
+      "Explicit delegate classes should be instrumented without selector discovery"
     )
   }
 

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -84,9 +84,9 @@ class URLSessionInstrumentationTests: XCTestCase {
 
   final class NotURLSessionDelegate: NSObject, @unchecked Sendable {
     @objc
-    func urlSession(_ session: URLSession,
+    func URLSession(_ session: URLSession,
                     dataTask: URLSessionDataTask,
-                    didReceive response: URLResponse,
+                    didReceiveResponse response: URLResponse,
                     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
       completionHandler(.allow)
     }
@@ -1031,7 +1031,10 @@ class URLSessionInstrumentationTests: XCTestCase {
       delegate.didReceiveResponseCalled
     }
     wait(timeout: 5) {
-      URLSessionInstrumentationTests.instrumentation.startedRequestSpans.isEmpty
+      URLSessionInstrumentationTests.checker.receivedResponseCalled
+    }
+    wait(timeout: 5) {
+      task.state == .completed
     }
 
     XCTAssertEqual(delegate.statusCode, 200, "Request should succeed")
@@ -1058,26 +1061,6 @@ class URLSessionInstrumentationTests: XCTestCase {
     XCTAssertTrue(
       nonDelegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
       "Selector-based discovery should add missing methods to classes with matching selectors"
-    )
-  }
-
-  public func testExplicitDelegateClassesBypassSelectorDiscovery() {
-    let inheritedDelegateBeforeInstrumentation = InheritedEmptyTaskDelegate()
-    XCTAssertFalse(
-      inheritedDelegateBeforeInstrumentation.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
-      "Auto-discovery should not instrument classes without a matching selector"
-    )
-
-    _ = URLSessionInstrumentation(
-      configuration: URLSessionInstrumentationConfiguration(
-        delegateClassesToInstrument: [InheritedEmptyTaskDelegate.self]
-      )
-    )
-
-    let inheritedDelegateAfterInstrumentation = InheritedEmptyTaskDelegate()
-    XCTAssertTrue(
-      inheritedDelegateAfterInstrumentation.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
-      "Explicit delegate classes should be instrumented without selector discovery"
     )
   }
 

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -64,6 +64,20 @@ class URLSessionInstrumentationTests: XCTestCase {
     }
   }
 
+  final class ResponseOnlyDataDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    var didReceiveResponseCalled = false
+    var statusCode: Int?
+
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+      didReceiveResponseCalled = true
+      statusCode = (response as? HTTPURLResponse)?.statusCode
+      completionHandler(.allow)
+    }
+  }
+
   nonisolated(unsafe) static var requestCopy: URLRequest!
   nonisolated(unsafe) static var responseCopy: HTTPURLResponse!
 
@@ -987,6 +1001,31 @@ class URLSessionInstrumentationTests: XCTestCase {
 
     // Verify instrumentation worked (span was created and completed)
     XCTAssertTrue(URLSessionInstrumentationTests.checker.createdRequestCalled, "Instrumentation should capture the request")
+    XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled, "Instrumentation should capture the response")
+  }
+
+  public func testDelegateMissingCompletionCallbackReceivesInjectedImplementation() {
+    let request = URLRequest(url: URL(string: "http://localhost:33333/success")!)
+
+    let delegate = ResponseOnlyDataDelegate()
+    let session = URLSession(configuration: URLSessionConfiguration.default, delegate: delegate, delegateQueue: nil)
+
+    let task = session.dataTask(with: request)
+    task.resume()
+
+    wait(timeout: 5) {
+      delegate.didReceiveResponseCalled
+    }
+    wait(timeout: 5) {
+      URLSessionInstrumentationTests.instrumentation.startedRequestSpans.isEmpty
+    }
+
+    XCTAssertEqual(delegate.statusCode, 200, "Request should succeed")
+    XCTAssertTrue(delegate.didReceiveResponseCalled, "Delegate should receive response callback")
+    XCTAssertTrue(
+      delegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
+      "Instrumentation should add missing completion callback implementation"
+    )
     XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled, "Instrumentation should capture the response")
   }
 

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -78,6 +78,20 @@ class URLSessionInstrumentationTests: XCTestCase {
     }
   }
 
+  class EmptyTaskDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {}
+
+  final class InheritedEmptyTaskDelegate: EmptyTaskDelegate, @unchecked Sendable {}
+
+  final class NotURLSessionDelegate: NSObject, @unchecked Sendable {
+    @objc
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+      completionHandler(.allow)
+    }
+  }
+
   nonisolated(unsafe) static var requestCopy: URLRequest!
   nonisolated(unsafe) static var responseCopy: HTTPURLResponse!
 
@@ -1027,6 +1041,24 @@ class URLSessionInstrumentationTests: XCTestCase {
       "Instrumentation should add missing completion callback implementation"
     )
     XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled, "Instrumentation should capture the response")
+  }
+
+  public func testDelegateDiscoveryRequiresURLSessionTaskDelegateConformance() {
+    let inheritedDelegate = InheritedEmptyTaskDelegate()
+    let nonDelegate = NotURLSessionDelegate()
+
+    XCTAssertTrue(
+      inheritedDelegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
+      "Instrumentation should add missing methods to URLSessionTaskDelegate subtypes"
+    )
+    XCTAssertTrue(
+      nonDelegate.responds(to: #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:completionHandler:))),
+      "NotURLSessionDelegate responds to selector"
+    )
+    XCTAssertFalse(
+      nonDelegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:))),
+      "Instrumentation should ignore classes that are not URLSessionTaskDelegate types"
+    )
   }
 
   public func testOldSemanticConvention() {


### PR DESCRIPTION
I encountered some IMO surprising behaviour of `URLSessionInstrumentation`


It swizzles the delegate classes to install its own hooks.
But this as far as i can tell only works when these conditions are met:


In order for the swizzling to kick in at all i must implement one of these.


```
    let selectors = [
      #selector(URLSessionDataDelegate.urlSession(_:dataTask:didReceive:)),
      #selector(
        URLSessionDataDelegate.urlSession(
          _:dataTask:didReceive:completionHandler:)),
      #selector(
        URLSessionDataDelegate.urlSession(_:task:didCompleteWithError:)),
      #selector(
        URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)
          as (URLSessionDataDelegate) -> (
            (URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void
          )?),
      #selector(
        URLSessionDataDelegate.urlSession(_:dataTask:didBecome:)
          as (URLSessionDataDelegate) -> (
            (URLSession, URLSessionDataTask, URLSessionStreamTask) -> Void
          )?),
      #selector(
        URLSessionTaskDelegate.urlSession(_:task:didFinishCollecting:))
    ]
```


Additionally if i dont implement one of them the hooks relying on this wont fire.

For instance `shouldRecordPayload` will only fire if the following method is implemented.

```
urlSession(
  _ session: URLSession, dataTask: URLSessionDataTask,
  didReceive response: URLResponse,
  completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
)
```

IMO This behaviour is a bit unintuitive.

I adapted the implementation so it searches for implementors of URLSessionTaskDelegate rather than just classes that have a matching method.

Please let me know what you think,
* Maybe this could also be solved by explicitly documenting these conditions?
* Or maybe some explicit way to opt in to the new behaviour, to avoid any unexpected behaviour changes.

