### PR TITLE
Fix Concurrency Issues

### DIFF
--- a/Examples/Logging Tracer/LoggingSpan.swift
+++ b/Examples/Logging Tracer/LoggingSpan.swift
@@ -103,4 +103,12 @@ class LoggingSpan: Span {
   public func end(time: Date) {
     Logger.log("Span.End, Name: \(name), time:\(time)) }")
   }
+    
+  public func addLink(spanContext: SpanContext) {
+    Logger.log("Span.addEvent(\(name))")
+  }
+  
+  public func addLink(spanContext: SpanContext, attributes: [String : AttributeValue]) {
+    Logger.log("Span.addEvent(\(name), attributes:\(attributes) )")
+  }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     .executable(name: "StableMetricSample", targets: ["StableMetricSample"])
   ],
   dependencies: [
-    .package(url: "https://github.com/simonbility/opentelemetry-swift-core.git", branch: "feature/concurrency-issues"), // TODO: Revert once PR is merged
+    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.5.1"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.100.0"),
     .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.27.5"),
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.38.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     .executable(name: "StableMetricSample", targets: ["StableMetricSample"])
   ],
   dependencies: [
-    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.4.1"),
+    .package(url: "https://github.com/simonbility/opentelemetry-swift-core.git", branch: "feature/concurrency-issues"), // TODO: Revert once PR is merged
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.100.0"),
     .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.27.5"),
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.38.0"),

--- a/Sources/Exporters/OpenTelemetryProtocolCommon/common/OtlpConfiguration.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/common/OtlpConfiguration.swift
@@ -5,13 +5,13 @@
 
 import Foundation
 
-public enum CompressionType {
+public enum CompressionType: Sendable {
   case gzip
   case deflate
   case none
 }
 
-public struct OtlpConfiguration {
+public struct OtlpConfiguration: Sendable {
   public static let DefaultTimeoutInterval: TimeInterval = .init(10)
 
   /*

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/logs/OtlpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/logs/OtlpLogExporter.swift
@@ -12,11 +12,11 @@ import OpenTelemetryApi
 import OpenTelemetryProtocolExporterCommon
 import OpenTelemetrySdk
 
-public class OtlpLogExporter: LogRecordExporter {
+public final class OtlpLogExporter: LogRecordExporter {
   let channel: GRPCChannel
-  var logClient: Opentelemetry_Proto_Collector_Logs_V1_LogsServiceNIOClient
+  let logClient: Opentelemetry_Proto_Collector_Logs_V1_LogsServiceNIOClient
   let config: OtlpConfiguration
-  var callOptions: CallOptions
+  let callOptions: CallOptions
 
   public init(channel: GRPCChannel,
               config: OtlpConfiguration = OtlpConfiguration(),
@@ -46,6 +46,7 @@ public class OtlpLogExporter: LogRecordExporter {
       request.resourceLogs = LogRecordAdapter.toProtoResourceRecordLog(logRecordList: logRecords)
     }
     let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    var callOptions = callOptions
     if timeout > 0 {
       callOptions.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(timeout.toNanoseconds)))
     }

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
@@ -44,16 +44,11 @@ public final class OtlpMetricExporter: MetricExporter {
     let exportRequest = Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest.with {
       $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(metricData: metrics)
     }
-    var perCallOptions = callOptions
+    var metricClient = self.metricClient
     if config.timeout > 0 {
-      if var options = perCallOptions {
-        options.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds)))
-        perCallOptions = options
-      } else {
-        perCallOptions = CallOptions(timeLimit: .timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds))))
-      }
+        metricClient.defaultCallOptions.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds)))
     }
-    let export = metricClient.export(exportRequest, callOptions: perCallOptions)
+    let export = metricClient.export(exportRequest, callOptions: callOptions)
     do {
       _ = try export.response.wait()
       return .success

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
@@ -11,17 +11,17 @@ import NIOHPACK
 import OpenTelemetryProtocolExporterCommon
 import OpenTelemetrySdk
 
-public class OtlpMetricExporter: MetricExporter {
+public final class OtlpMetricExporter: MetricExporter {
   public func getAggregationTemporality(for instrument: OpenTelemetrySdk.InstrumentType) -> OpenTelemetrySdk.AggregationTemporality {
     return aggregationTemporalitySelector.getAggregationTemporality(for: instrument)
   }
 
   let channel: GRPCChannel
-  var metricClient: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceNIOClient
+  let metricClient: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceNIOClient
   let config: OtlpConfiguration
-  var callOptions: CallOptions?
-  var aggregationTemporalitySelector: AggregationTemporalitySelector
-  var defaultAggregationSelector: DefaultAggregationSelector
+  let callOptions: CallOptions?
+  let aggregationTemporalitySelector: AggregationTemporalitySelector
+  let defaultAggregationSelector: DefaultAggregationSelector
 
   public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), aggregationTemporalitySelector: AggregationTemporalitySelector = AggregationTemporality.alwaysCumulative(),
               defaultAggregationSelector: DefaultAggregationSelector = AggregationSelector.instance,
@@ -44,10 +44,16 @@ public class OtlpMetricExporter: MetricExporter {
     let exportRequest = Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest.with {
       $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(metricData: metrics)
     }
+    var perCallOptions = callOptions
     if config.timeout > 0 {
-      metricClient.defaultCallOptions.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds)))
+      if var options = perCallOptions {
+        options.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds)))
+        perCallOptions = options
+      } else {
+        perCallOptions = CallOptions(timeLimit: .timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds))))
+      }
     }
-    let export = metricClient.export(exportRequest, callOptions: callOptions)
+    let export = metricClient.export(exportRequest, callOptions: perCallOptions)
     do {
       _ = try export.response.wait()
       return .success

--- a/Sources/Exporters/Persistence/Export/DataExportDelay.swift
+++ b/Sources/Exporters/Persistence/Export/DataExportDelay.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-protocol Delay {
+protocol Delay: Sendable {
   var current: TimeInterval { get }
   mutating func decrease()
   mutating func increase()

--- a/Sources/Exporters/Persistence/Export/DataExportStatus.swift
+++ b/Sources/Exporters/Persistence/Export/DataExportStatus.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// The status of a single export attempt.
-struct DataExportStatus {
+struct DataExportStatus: Sendable {
   /// If export needs to be retried (`true`) because its associated data was not delivered but it may succeed
   /// in the next attempt (i.e. it failed due to device leaving signal range or a temporary server unavailability occurred).
   /// If set to `false` then data associated with the upload should be deleted as it does not need any more export

--- a/Sources/Exporters/Persistence/Export/DataExportWorker.swift
+++ b/Sources/Exporters/Persistence/Export/DataExportWorker.swift
@@ -4,19 +4,20 @@
  */
 
 import Foundation
+import OpenTelemetrySdk
 
 // a protocol for an exporter of `Data` to which a `DataExportWorker` can delegate persisted
 // data export
-protocol DataExporter {
+protocol DataExporter: Sendable {
   func export(data: Data) -> DataExportStatus
 }
 
 // a protocol needed for mocking `DataExportWorker`
-protocol DataExportWorkerProtocol {
+protocol DataExportWorkerProtocol: Sendable {
   func flush() -> Bool
 }
 
-class DataExportWorker: DataExportWorkerProtocol {
+final class DataExportWorker: DataExportWorkerProtocol {
   /// Queue to execute exports.
   let queue = DispatchQueue(label: "com.otel.persistence.dataExportWorker", target: .global(qos: .utility))
   /// File reader providing data to export.
@@ -24,22 +25,22 @@ class DataExportWorker: DataExportWorkerProtocol {
   /// Data exporter sending data to server.
   private let dataExporter: DataExporter
   /// Variable system conditions determining if export should be performed.
-  private let exportCondition: () -> Bool
+  private let exportCondition: @Sendable () -> Bool
 
   /// Delay used to schedule consecutive exports.
-  private var delay: Delay
+  private let delay: Locked<any Delay>
 
   /// Export work scheduled by this worker.
-  private var exportWork: DispatchWorkItem?
+  private let exportWork = Locked<DispatchWorkItem?>(initialValue: nil)
 
   init(fileReader: FileReader,
        dataExporter: DataExporter,
-       exportCondition: @escaping () -> Bool,
+       exportCondition: @escaping @Sendable () -> Bool,
        delay: Delay) {
     self.fileReader = fileReader
     self.exportCondition = exportCondition
     self.dataExporter = dataExporter
-    self.delay = delay
+    self.delay = Locked(initialValue: delay)
 
     let exportWork = DispatchWorkItem { [weak self] in
       guard let self else {
@@ -54,25 +55,25 @@ class DataExportWorker: DataExportWorkerProtocol {
 
         // Delete or keep batch depending on the export status
         if exportStatus.needsRetry {
-          self.delay.increase()
+          self.delay.locking { $0.increase() }
         } else {
           self.fileReader.markBatchAsRead(batch)
-          self.delay.decrease()
+          self.delay.locking { $0.decrease() }
         }
       } else {
-        self.delay.increase()
+        self.delay.locking { $0.increase() }
       }
 
-      scheduleNextExport(after: self.delay.current)
+      scheduleNextExport(after: self.delay.locking { $0.current })
     }
 
-    self.exportWork = exportWork
+    self.exportWork.locking { $0 = exportWork }
 
-    scheduleNextExport(after: self.delay.current)
+    scheduleNextExport(after: self.delay.locking { $0.current })
   }
 
   private func scheduleNextExport(after delay: TimeInterval) {
-    guard let work = exportWork else {
+    guard let work = exportWork.locking({ $0 }) else {
       return
     }
 
@@ -101,8 +102,10 @@ class DataExportWorker: DataExportWorkerProtocol {
       // This cancellation must be performed on the `queue` to ensure that it is not called
       // in the middle of a `DispatchWorkItem` execution - otherwise, as the pending block would be
       // fully executed, it will schedule another export by calling `nextScheduledWork(after:)` at the end.
-      self.exportWork?.cancel()
-      self.exportWork = nil
+      self.exportWork.locking { work in
+        work?.cancel()
+        work = nil
+      }
     }
   }
 }

--- a/Sources/Exporters/Persistence/PersistenceExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceExporterDecorator.swift
@@ -7,19 +7,19 @@ import Foundation
 import OpenTelemetrySdk
 
 // protocol for exporters that can be decorated with `PersistenceExporterDecorator`
-protocol DecoratedExporter {
-  associatedtype SignalType
+protocol DecoratedExporter: Sendable {
+  associatedtype SignalType: Sendable
 
   func export(values: [SignalType]) -> DataExportStatus
 }
 
 // a generic decorator of `DecoratedExporter` adding filesystem persistence of batches of `[T.SignalType]`.
 // `T.SignalType` must conform to `Codable`.
-class PersistenceExporterDecorator<T>
+final class PersistenceExporterDecorator<T>: Sendable
   where T: DecoratedExporter, T.SignalType: Codable {
   // a wrapper of `DecoratedExporter` (T) to add conformance to `DataExporter` that can be
   // used with `DataExportWorker`.
-  private class DecoratedDataExporter: DataExporter {
+  private final class DecoratedDataExporter: DataExporter {
     private let decoratedExporter: T
 
     init(decoratedExporter: T) {
@@ -55,7 +55,7 @@ class PersistenceExporterDecorator<T>
 
   public convenience init(decoratedExporter: T,
                           storageURL: URL,
-                          exportCondition: @escaping () -> Bool = { true },
+                          exportCondition: @escaping @Sendable () -> Bool = { true },
                           performancePreset: PersistencePerformancePreset = .default) {
     // orchestrate writes and reads over the folder given by `storageURL`
     let filesOrchestrator = FilesOrchestrator(directory: Directory(url: storageURL),

--- a/Sources/Exporters/Persistence/PersistenceLogExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceLogExporterDecorator.swift
@@ -8,7 +8,7 @@ import OpenTelemetrySdk
 
 // a persistence exporter decorator for `LogRecords`.
 // specialization of `PersistenceExporterDecorator` for `LogExporter`.
-public class PersistenceLogExporterDecorator: LogRecordExporter {
+public final class PersistenceLogExporterDecorator: LogRecordExporter {
   struct LogRecordDecoratedExporter: DecoratedExporter {
     typealias SignalType = ReadableLogRecord
 
@@ -30,7 +30,7 @@ public class PersistenceLogExporterDecorator: LogRecordExporter {
 
   public init(logRecordExporter: LogRecordExporter,
               storageURL: URL,
-              exportCondition: @escaping () -> Bool = { true },
+              exportCondition: @escaping @Sendable () -> Bool = { true },
               performancePreset: PersistencePerformancePreset = .default) throws {
     persistenceExporter =
       PersistenceExporterDecorator<LogRecordDecoratedExporter>(decoratedExporter: LogRecordDecoratedExporter(

--- a/Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift
@@ -8,7 +8,7 @@ import OpenTelemetrySdk
 
 // a persistence exporter decorator for `Metric`.
 // specialization of `PersistenceExporterDecorator` for `MetricExporter`.
-public class PersistenceMetricExporterDecorator: MetricExporter {
+public final class PersistenceMetricExporterDecorator: MetricExporter {
   struct MetricDecoratedExporter: DecoratedExporter {
     typealias SignalType = MetricData
 
@@ -30,7 +30,7 @@ public class PersistenceMetricExporterDecorator: MetricExporter {
 
   public init(metricExporter: MetricExporter,
               storageURL: URL,
-              exportCondition: @escaping () -> Bool = { true },
+              exportCondition: @escaping @Sendable () -> Bool = { true },
               performancePreset: PersistencePerformancePreset = .default) throws {
     persistenceExporter =
       PersistenceExporterDecorator<MetricDecoratedExporter>(decoratedExporter: MetricDecoratedExporter(

--- a/Sources/Exporters/Persistence/PersistencePerformancePreset.swift
+++ b/Sources/Exporters/Persistence/PersistencePerformancePreset.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-protocol StoragePerformancePreset {
+protocol StoragePerformancePreset: Sendable {
   /// Maximum size of a single file (in bytes).
   /// Each feature (logging, tracing, ...) serializes its objects data to that file for later export.
   /// If last written file is too big to append next data, new file is created.
@@ -32,7 +32,7 @@ protocol StoragePerformancePreset {
   var maxObjectSize: UInt64 { get }
 }
 
-protocol ExportPerformancePreset {
+protocol ExportPerformancePreset: Sendable {
   /// First export delay (in seconds).
   /// It is used as a base value until no more files eligible for export are found - then `defaultExportDelay` is used as a new base.
   var initialExportDelay: TimeInterval { get }

--- a/Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift
@@ -30,7 +30,7 @@ public final class PersistenceSpanExporterDecorator: SpanExporter, @unchecked Se
 
   public init(spanExporter: SpanExporter,
               storageURL: URL,
-              exportCondition: @escaping () -> Bool = { true },
+              exportCondition: @escaping @Sendable () -> Bool = { true },
               performancePreset: PersistencePerformancePreset = .default) throws {
     self.spanExporter = spanExporter
 

--- a/Sources/Exporters/Persistence/Storage/File.swift
+++ b/Sources/Exporters/Persistence/Storage/File.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Provides convenient interface for reading metadata and appending data to the file.
-protocol WritableFile {
+protocol WritableFile: Sendable {
   /// Name of this file.
   var name: String { get }
 
@@ -18,7 +18,7 @@ protocol WritableFile {
 }
 
 /// Provides convenient interface for reading contents and metadata of the file.
-protocol ReadableFile {
+protocol ReadableFile: Sendable {
   /// Name of this file.
   var name: String { get }
 

--- a/Sources/Exporters/Persistence/Storage/FileReader.swift
+++ b/Sources/Exporters/Persistence/Storage/FileReader.swift
@@ -4,15 +4,16 @@
  */
 
 import Foundation
+import OpenTelemetrySdk
 
-struct Batch {
+struct Batch: Sendable {
   /// Data read from file
   let data: Data
   /// File from which `data` was read.
   let file: ReadableFile
 }
 
-protocol FileReader {
+protocol FileReader: Sendable {
   func readNextBatch() -> Batch?
 
   func onRemainingBatches(process: (Batch) -> Void) -> Bool
@@ -25,7 +26,7 @@ final class OrchestratedFileReader: FileReader {
   private let orchestrator: FilesOrchestrator
 
   /// Files marked as read.
-  private var filesRead: [ReadableFile] = []
+  private let filesRead = Locked(initialValue: [ReadableFile]())
 
   init(orchestrator: FilesOrchestrator) {
     self.orchestrator = orchestrator
@@ -34,7 +35,8 @@ final class OrchestratedFileReader: FileReader {
   // MARK: - Reading batches
 
   func readNextBatch() -> Batch? {
-    if let file = orchestrator.getReadableFile(excludingFilesNamed: Set(filesRead.map(\.name))) {
+    let excludedFileNames = filesRead.locking { Set($0.map(\.name)) }
+    if let file = orchestrator.getReadableFile(excludingFilesNamed: excludedFileNames) {
       do {
         let fileData = try file.read()
         return Batch(data: fileData, file: file)
@@ -50,7 +52,8 @@ final class OrchestratedFileReader: FileReader {
   /// Currently called from flush method
   func onRemainingBatches(process: (Batch) -> Void) -> Bool {
     do {
-      try orchestrator.getAllFiles(excludingFilesNamed: Set(filesRead.map(\.name)))?.forEach {
+      let excludedFileNames = filesRead.locking { Set($0.map(\.name)) }
+      try orchestrator.getAllFiles(excludingFilesNamed: excludedFileNames)?.forEach {
         let fileData = try $0.read()
         process(Batch(data: fileData, file: $0))
       }
@@ -64,6 +67,6 @@ final class OrchestratedFileReader: FileReader {
 
   func markBatchAsRead(_ batch: Batch) {
     orchestrator.delete(readableFile: batch.file)
-    filesRead.append(batch.file)
+    filesRead.locking { $0.append(batch.file) }
   }
 }

--- a/Sources/Exporters/Persistence/Storage/FileWriter.swift
+++ b/Sources/Exporters/Persistence/Storage/FileWriter.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-protocol FileWriter {
+protocol FileWriter: Sendable {
   func write(data: Data)
 
   func writeSync(data: Data)
@@ -13,7 +13,7 @@ protocol FileWriter {
   func flush()
 }
 
-final class OrchestratedFileWriter: FileWriter, @unchecked Sendable {
+final class OrchestratedFileWriter: FileWriter {
   /// Orchestrator producing reference to writable file.
   private let orchestrator: FilesOrchestrator
   /// Queue used to synchronize files access (read / write) and perform decoding on background thread.

--- a/Sources/Exporters/Persistence/Storage/FilesOrchestrator.swift
+++ b/Sources/Exporters/Persistence/Storage/FilesOrchestrator.swift
@@ -4,19 +4,24 @@
  */
 
 import Foundation
+import OpenTelemetrySdk
 
-class FilesOrchestrator {
+final class FilesOrchestrator: Sendable {
+  private struct WritableState: Sendable {
+    /// Name of the last file returned by `getWritableFile()`.
+    var lastWritableFileName: String?
+    /// Tracks number of times the file at `lastWritableFileURL` was returned from `getWritableFile()`.
+    /// This should correspond with number of objects stored in file, assuming that majority of writes succeed (the difference is negligible).
+    var lastWritableFileUsesCount: Int = 0
+  }
+
   /// Directory where files are stored.
   private let directory: Directory
   /// Date provider.
   private let dateProvider: DateProvider
   /// Performance rules for writing and reading files.
   private let performance: StoragePerformancePreset
-  /// Name of the last file returned by `getWritableFile()`.
-  private var lastWritableFileName: String?
-  /// Tracks number of times the file at `lastWritableFileURL` was returned from `getWritableFile()`.
-  /// This should correspond with number of objects stored in file, assuming that majority of writes succeed (the difference is negligible).
-  private var lastWritableFileUsesCount: Int = 0
+  private let lastWritableState = Locked(initialValue: WritableState())
 
   init(directory: Directory,
        performance: StoragePerformancePreset,
@@ -33,10 +38,11 @@ class FilesOrchestrator {
       throw StorageError.dataExceedsMaxSizeError(dataSize: writeSize, maxSize: performance.maxObjectSize)
     }
 
-    let lastWritableFileOrNil = reuseLastWritableFileIfPossible(writeSize: writeSize)
+    let lastWritableFileOrNil = lastWritableState.locking { state in
+      reuseLastWritableFileIfPossible(writeSize: writeSize, state: &state)
+    }
 
     if let lastWritableFile = lastWritableFileOrNil { // if last writable file can be reused
-      lastWritableFileUsesCount += 1
       return lastWritableFile
     } else {
       // NOTE: As purging files directory is a memory-expensive operation, do it only when we know
@@ -47,14 +53,17 @@ class FilesOrchestrator {
 
       let newFileName = fileNameFrom(fileCreationDate: dateProvider.currentDate())
       let newFile = try directory.createFile(named: newFileName)
-      lastWritableFileName = newFile.name
-      lastWritableFileUsesCount = 1
+      lastWritableState.locking { state in
+        state.lastWritableFileName = newFile.name
+        state.lastWritableFileUsesCount = 1
+      }
       return newFile
     }
   }
 
-  private func reuseLastWritableFileIfPossible(writeSize: UInt64) -> WritableFile? {
-    if let lastFileName = lastWritableFileName {
+  private func reuseLastWritableFileIfPossible(writeSize: UInt64,
+                                               state: inout WritableState) -> WritableFile? {
+    if let lastFileName = state.lastWritableFileName {
       do {
         guard let lastFile = directory.file(named: lastFileName) else {
           return nil
@@ -64,9 +73,10 @@ class FilesOrchestrator {
 
         let fileIsRecentEnough = lastFileAge <= performance.maxFileAgeForWrite
         let fileHasRoomForMore = try (lastFile.size() + writeSize) <= performance.maxFileSize
-        let fileCanBeUsedMoreTimes = (lastWritableFileUsesCount + 1) <= performance.maxObjectsInFile
+        let fileCanBeUsedMoreTimes = (state.lastWritableFileUsesCount + 1) <= performance.maxObjectsInFile
 
         if fileIsRecentEnough, fileHasRoomForMore, fileCanBeUsedMoreTimes {
+          state.lastWritableFileUsesCount += 1
           return lastFile
         }
       } catch {

--- a/Sources/Exporters/Persistence/Utils/DateProvider.swift
+++ b/Sources/Exporters/Persistence/Utils/DateProvider.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Interface for date provider used for files orchestration.
-protocol DateProvider {
+protocol DateProvider: Sendable {
   func currentDate() -> Date
 }
 

--- a/Sources/Exporters/Prometheus/PrometheusExporter.swift
+++ b/Sources/Exporters/Prometheus/PrometheusExporter.swift
@@ -7,8 +7,8 @@ import Foundation
 import NIOConcurrencyHelpers
 import OpenTelemetrySdk
 
-public class PrometheusExporter: MetricExporter {
-  var aggregationTemporalitySelector: AggregationTemporalitySelector
+public final class PrometheusExporter: MetricExporter {
+  let aggregationTemporalitySelector: AggregationTemporalitySelector
 
   public func getAggregationTemporality(for instrument: OpenTelemetrySdk.InstrumentType) -> OpenTelemetrySdk.AggregationTemporality {
     return aggregationTemporalitySelector.getAggregationTemporality(for: instrument)
@@ -26,7 +26,9 @@ public class PrometheusExporter: MetricExporter {
 
   fileprivate let metricsLock = NIOLock()
   let options: PrometheusExporterOptions
-  private var metrics = [MetricData]()
+  
+  // nonisolated(unsafe) but protected by metricsLock
+  private nonisolated(unsafe) var metrics = [MetricData]()
 
   public init(options: PrometheusExporterOptions, aggregationTemoralitySelector: AggregationTemporalitySelector = AggregationTemporality.alwaysCumulative()) {
     self.options = options
@@ -49,7 +51,7 @@ public class PrometheusExporter: MetricExporter {
   }
 }
 
-public struct PrometheusExporterOptions {
+public struct PrometheusExporterOptions: Sendable {
   var url: String
 
   public init(url: String) {

--- a/Sources/Exporters/Prometheus/PrometheusExporterHttpServer.swift
+++ b/Sources/Exporters/Prometheus/PrometheusExporterHttpServer.swift
@@ -47,7 +47,7 @@ public class PrometheusExporterHttpServer {
     // server) and `PrometheusHTTPHandler` aren't Sendable. Capture the
     // exporter through a nonisolated(unsafe) alias so the closure doesn't
     // capture `self`; PrometheusExporter is already lock-protected internally.
-    nonisolated(unsafe) let exporter = self.exporter
+    let exporter = self.exporter
     return ServerBootstrap(group: group)
       // Specify backlog and enable SO_REUSEADDR for the server itself
       .serverChannelOption(ChannelOptions.backlog, value: 256)

--- a/Tests/ExportersTests/OpenTelemetryProtocol/ExporterMetricsCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/ExporterMetricsCoverageTests.swift
@@ -10,9 +10,14 @@ import XCTest
 
 final class ExporterMetricsCoverageTests: XCTestCase {
   private final class CapturingMetricExporter: MetricExporter {
-    var captured: [MetricData] = []
+    private let capturedMetrics = Locked(initialValue: [MetricData]())
+
+    var captured: [MetricData] {
+      capturedMetrics.locking { $0 }
+    }
+
     func export(metrics: [MetricData]) -> ExportResult {
-      captured.append(contentsOf: metrics)
+      capturedMetrics.locking { $0.append(contentsOf: metrics) }
       return .success
     }
     func flush() -> ExportResult { .success }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHTTPMetricsExporterTest.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHTTPMetricsExporterTest.swift
@@ -216,7 +216,7 @@ class OtlpHttpMetricsExporterTest: XCTestCase {
   }
 }
 
-public class CustomDefaultAggregationSelector: DefaultAggregationSelector {
+public final class CustomDefaultAggregationSelector: DefaultAggregationSelector {
   public func getDefaultAggregation(for instrument: OpenTelemetrySdk.InstrumentType) -> OpenTelemetrySdk.Aggregation {
     switch instrument {
     case .counter, .histogram:

--- a/Tests/ExportersTests/PersistenceExporter/Export/DataExportWorkerTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/Export/DataExportWorkerTests.swift
@@ -254,12 +254,12 @@ class DataExportWorkerTests: XCTestCase {
   }
 }
 
-struct MockDelay: Delay {
+struct MockDelay: Delay, Sendable {
   enum Command {
     case increase, decrease
   }
 
-  var callback: ((Command) -> Void)?
+  var callback: (@Sendable (Command) -> Void)?
   let current: TimeInterval = 0.1
 
   mutating func decrease() {

--- a/Tests/ExportersTests/PersistenceExporter/Helpers/CoreMocks.swift
+++ b/Tests/ExportersTests/PersistenceExporter/Helpers/CoreMocks.swift
@@ -115,7 +115,7 @@ final class RelativeDateProvider: DateProvider, @unchecked Sendable {
   }
 }
 
-struct DataExporterMock: DataExporter {
+struct DataExporterMock: DataExporter, @unchecked Sendable {
   let exportStatus: DataExportStatus
 
   var onExport: ((Data) -> Void)? = nil
@@ -132,7 +132,7 @@ extension DataExportStatus {
   }
 }
 
-class FileWriterMock: FileWriter {
+final class FileWriterMock: FileWriter, @unchecked Sendable {
   var onWrite: ((Bool, Data) -> Void)? = nil
 
   func write(data: Data) {
@@ -150,8 +150,8 @@ class FileWriterMock: FileWriter {
   }
 }
 
-class FileReaderMock: FileReader {
-  private class ReadableFileMock: ReadableFile {
+final class FileReaderMock: FileReader, @unchecked Sendable {
+  private final class ReadableFileMock: ReadableFile, @unchecked Sendable {
     private var deleted = false
     private let data: Data
 

--- a/Tests/ExportersTests/PersistenceExporter/Helpers/FoundationMocks.swift
+++ b/Tests/ExportersTests/PersistenceExporter/Helpers/FoundationMocks.swift
@@ -90,7 +90,7 @@ struct ErrorMock: Error, CustomStringConvertible {
   }
 }
 
-struct FailingCodableMock: Codable {
+struct FailingCodableMock: Codable, Sendable {
   init() {}
 
   init(from decoder: Decoder) throws {

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceExporterDecoratorTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceExporterDecoratorTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 
 class PersistenceExporterDecoratorTests: XCTestCase {
-  class DecoratedExporterMock<T>: DecoratedExporter {
+  final class DecoratedExporterMock<T: Sendable>: DecoratedExporter, @unchecked Sendable {
     typealias SignalType = T
     let exporter: ([T]) -> DataExportStatus
     init(exporter: @escaping ([T]) -> DataExportStatus) {
@@ -19,7 +19,7 @@ class PersistenceExporterDecoratorTests: XCTestCase {
     }
   }
 
-  class DataExportWorkerMock: DataExportWorkerProtocol {
+  final class DataExportWorkerMock: DataExportWorkerProtocol, @unchecked Sendable {
     var dataExporter: DataExporter? = nil
     var onFlush: (() -> Bool)? = nil
 
@@ -28,9 +28,9 @@ class PersistenceExporterDecoratorTests: XCTestCase {
     }
   }
 
-  private typealias PersistenceExporter<T: Codable> = PersistenceExporterDecorator<DecoratedExporterMock<T>>
+  private typealias PersistenceExporter<T: Codable & Sendable> = PersistenceExporterDecorator<DecoratedExporterMock<T>>
 
-  private func createPersistenceExporter<T: Codable>(fileWriter: FileWriterMock = FileWriterMock(),
+  private func createPersistenceExporter<T: Codable & Sendable>(fileWriter: FileWriterMock = FileWriterMock(),
                                                      worker: inout DataExportWorkerMock,
                                                      decoratedExporter: DecoratedExporterMock<T> = DecoratedExporterMock(exporter: { _ in
                                                        return DataExportStatus(needsRetry: false)

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceLogExporterDecoratorCoverageTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceLogExporterDecoratorCoverageTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class PersistenceLogExporterDecoratorCoverageTests: XCTestCase {
   @UniqueTemporaryDirectory private var temporaryDirectory: Directory
 
-  final class LogExporterMock: LogRecordExporter {
+  final class LogExporterMock: LogRecordExporter, @unchecked Sendable {
     let onExport: ([ReadableLogRecord]) -> ExportResult
     var shutdownCalled = false
     var flushCalled = false

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceMetricExporterDecoratorTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceMetricExporterDecoratorTests.swift
@@ -11,7 +11,7 @@ import XCTest
 class PersistenceMetricExporterDecoratorTests: XCTestCase {
   @UniqueTemporaryDirectory private var temporaryDirectory: Directory
 
-  class MetricExporterMock: MetricExporter {
+  final class MetricExporterMock: MetricExporter, @unchecked Sendable {
     func flush() -> OpenTelemetrySdk.ExportResult {
       .success
     }

--- a/Tests/ImportersTests/SwiftMetricsShim/SwiftMetricsShimTests.swift
+++ b/Tests/ImportersTests/SwiftMetricsShim/SwiftMetricsShimTests.swift
@@ -9,7 +9,7 @@
 @testable import SwiftMetricsShim
 import XCTest
 
-class MetricExporterMock: MetricExporter {
+final class MetricExporterMock: MetricExporter, @unchecked Sendable {
   func flush() -> OpenTelemetrySdk.ExportResult {
     .success
   }


### PR DESCRIPTION
Fixes all the build errors related to concurrency.

This required changes in the open-telemetry-swift-core package as well. See here https://github.com/open-telemetry/opentelemetry-swift-core/pull/87

My goal was to stay away from unsafe as much as possible (with some exceptions in tests)

Because of that i marked quite a few protocols/classes as `Sendable`.

I havent done any deep investigation but i assume requiring `Sendable` in some of the protocols will be a breaking-change for users.