### PR TITLE
improve renovate for docker

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,7 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["patch", "digest"],
       "schedule": ["before 8am every weekday"]
     },
     {

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -140,7 +140,7 @@ jobs:
     needs: should-run
     if: ${{ needs.should-run.outputs.should-run == 'true' }}
     runs-on: ubuntu-latest
-    container: swift:6.3@sha256:70680d9f3bfca824d7c1242d9fa35152513137531c6c2e98797877139b4bab28
+    container: swift:6.3.2@sha256:c4336909a71b2e69b884f4078cdf98c0cd081911632cb349ef72abc4cbed69fc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build tests for Linux

--- a/.github/workflows/Nightly-Build-Core-Main.yml
+++ b/.github/workflows/Nightly-Build-Core-Main.yml
@@ -93,7 +93,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    container: swift:6.3@sha256:70680d9f3bfca824d7c1242d9fa35152513137531c6c2e98797877139b4bab28
+    container: swift:6.3.2@sha256:c4336909a71b2e69b884f4078cdf98c0cd081911632cb349ef72abc4cbed69fc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use opentelemetry-swift-core from main

--- a/Examples/OTLP Exporter/docker-compose.yaml
+++ b/Examples/OTLP Exporter/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
   # Zipkin
   zipkin-all-in-one:
     platform: linux/amd64
-    image: openzipkin/zipkin:latest@sha256:d17e856dcbba7ffeefbbfc252f89ab78a4ab6faed47e646d46daad78f91b5ee2
+    image: openzipkin/zipkin:3.6.1@sha256:d17e856dcbba7ffeefbbfc252f89ab78a4ab6faed47e646d46daad78f91b5ee2
     ports:
       - "9411:9411"
 
@@ -27,7 +27,7 @@ services:
   prometheus:
     platform: linux/amd64
     container_name: prometheus
-    image: prom/prometheus:latest@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+    image: prom/prometheus:3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
     volumes:
       - ./prometheus.yaml:/etc/prometheus/prometheus.yml
     ports:

--- a/Examples/OTLP HTTP Exporter/docker-compose.yaml
+++ b/Examples/OTLP HTTP Exporter/docker-compose.yaml
@@ -2,9 +2,7 @@ version: "3"
 services:
   # Collector
   collector:
-    image: otel/opentelemetry-collector:latest@sha256:6ed874ea083d67a3085acfc75343f2ad11d9abe6006d7ea4a16e2dba9af14e49
-#    The latest image of the otel-collector may not work, so specifying the version that works with this release
-#    image: otel/opentelemetry-collector:latest
+    image: otel/opentelemetry-collector:0.155.0@sha256:4935caa35e9a4cb387e35732e8fb22b2b5759af8d12e7043357f03837f6e8df5
     command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml
@@ -18,14 +16,14 @@ services:
 
   # Zipkin
   zipkin-all-in-one:
-    image: openzipkin/zipkin:latest@sha256:d17e856dcbba7ffeefbbfc252f89ab78a4ab6faed47e646d46daad78f91b5ee2
+    image: openzipkin/zipkin:3.6.1@sha256:d17e856dcbba7ffeefbbfc252f89ab78a4ab6faed47e646d46daad78f91b5ee2
     ports:
       - "9411:9411"
 
   # Prometheus
   prometheus:
     container_name: prometheus
-    image: prom/prometheus:latest@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+    image: prom/prometheus:3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
     volumes:
       - ./prometheus.yaml:/etc/prometheus/prometheus.yml
     ports:


### PR DESCRIPTION
This improves how renovate handles docker updates as:

- digest updates treated the same as patches ie grouped as opposed to individual arriving anytime
- Docker images pinned to patch version where possible to provide insight on pr’s if it is major, minor etc

in the end this should result in less pr’s while not reducing time to raise other than by a few days in worst case for major/minor docker updates and few hours for digest updates.