### PR TITLE
chore: Update Jaeger image in README

### DIFF
--- a/Examples/Simple Exporter/README.md
+++ b/Examples/Simple Exporter/README.md
@@ -6,8 +6,6 @@ The sample expects a local Jaeger installation as explained in [Jaeger docs](htt
 
 ```
 docker run -d --name jaeger \
-  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
-  -e COLLECTOR_OTLP_ENABLED=true \
   -p 6831:6831/udp \
   -p 6832:6832/udp \
   -p 5778:5778 \

--- a/Examples/Simple Exporter/README.md
+++ b/Examples/Simple Exporter/README.md
@@ -18,6 +18,6 @@ docker run -d --name jaeger \
   -p 14268:14268 \
   -p 14269:14269 \
   -p 9411:9411 \
-  jaegertracing/all-in-one:1.41
+  jaegertracing/jaeger
 ```
 


### PR DESCRIPTION
The jaegar tracing image has been switched as existing image is eol https://github.com/jaegertracing/jaeger/issues/6321