### PR TITLE
fix(otlp-http): bound flush semaphore wait in metric and log exporters

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -107,7 +107,8 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
         }
       let semaphore = DispatchSemaphore(value: 0)
       var request = createRequest(body: body, endpoint: endpoint)
-      request.timeoutInterval = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+      let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+      request.timeoutInterval = timeout
       if let headers = envVarHeaders {
         headers.forEach { key, value in
           request.addValue(value, forHTTPHeaderField: key)
@@ -137,7 +138,12 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
         }
         semaphore.signal()
       }
-      semaphore.wait()
+
+      let waitResult = semaphore.wait(timeout: .now() + timeout)
+      if waitResult == .timedOut {
+        exporterMetrics?.addFailed(value: sentCount)
+        return .failure
+      }
     }
 
     return exporterResult

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -131,7 +131,8 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
           }
       let semaphore = DispatchSemaphore(value: 0)
       var request = createRequest(body: body, endpoint: endpoint)
-      request.timeoutInterval = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+      let timeout = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+      request.timeoutInterval = timeout
       httpClient.send(request: request) { [weak self] result in
         switch result {
         case .success:
@@ -149,7 +150,12 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
         }
         semaphore.signal()
       }
-      semaphore.wait()
+
+      let waitResult = semaphore.wait(timeout: .now() + timeout)
+      if waitResult == .timedOut {
+        exporterMetrics?.addFailed(value: sentCount)
+        return .failure
+      }
     }
 
     return exporterResult

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -44,6 +44,20 @@ private final class StubHTTPClient: HTTPClient {
 
 private struct TransientNetworkError: Error {}
 
+/// Fails the first request, then never invokes the completion handler. This gives
+/// `flush()` pending data to send and no response to wait on — the shape that made
+/// an unbounded `semaphore.wait()` block the calling thread forever.
+private final class HangingAfterFirstFailureHTTPClient: HTTPClient {
+  private var sendCount = 0
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sendCount += 1
+    if sendCount == 1 {
+      completion(.failure(TransientNetworkError()))
+    }
+  }
+}
+
 private func sampleLogRecord() -> ReadableLogRecord {
   let ctx = SpanContext.create(traceId: TraceId.random(),
                                spanId: SpanId.random(),
@@ -232,6 +246,35 @@ final class OtlpHttpTraceExporterCoverageTests: XCTestCase {
                                           httpClient: client,
                                           envVarHeaders: nil)
     XCTAssertNotNil(exporter)
+  }
+}
+
+final class OtlpHttpExporterFlushTimeoutTests: XCTestCase {
+  private let timeout: TimeInterval = 0.5
+
+  func testMetricFlushTimesOutWhenResponseNeverArrives() {
+    let client = HangingAfterFirstFailureHTTPClient()
+    let exporter = OtlpHttpMetricExporter(endpoint: URL(string: "http://localhost:4318/v1/metrics")!,
+                                          config: OtlpConfiguration(timeout: timeout),
+                                          httpClient: client)
+    _ = exporter.export(metrics: [.empty])
+    XCTAssertEqual(exporter.pendingMetrics.count, 1)
+
+    let start = Date()
+    XCTAssertEqual(exporter.flush(), .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+  }
+
+  func testLogFlushTimesOutWhenResponseNeverArrives() {
+    let client = HangingAfterFirstFailureHTTPClient()
+    let exporter = OtlpHttpLogExporter(config: OtlpConfiguration(timeout: timeout),
+                                       httpClient: client)
+    _ = exporter.export(logRecords: [sampleLogRecord()])
+    XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+
+    let start = Date()
+    XCTAssertEqual(exporter.flush(), .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
   }
 }
 


### PR DESCRIPTION
Hi maintainers,

Follow-up to #1005: `OtlpHttpMetricExporter.flush()` and `OtlpHttpLogExporter.flush()` still block on a bare `semaphore.wait()`, so a request that never completes hangs the calling thread forever.

## The problem

- `flush()` in both the metric and log exporters waits on its completion semaphore with no timeout
- If the HTTP completion handler never fires, the calling thread is parked for good
- On iOS this can be fatal: a common integration flushes telemetry from a lifecycle callback on the main thread when the app goes to the background. If the request stalls there, the scene-update watchdog kills the app after 10 seconds (`0x8BADF00D`) — and the default `OtlpConfiguration.timeout` is also 10 seconds, so the request timeout can never fire first

The spec is explicit about this:

> Export() MUST NOT block indefinitely, there MUST be a reasonable upper limit after which the call must time out with an error result.

This is the same reason the semaphore timeout was requested in review on #1005, which fixed it for `OtlpHttpTraceExporter`. The metric and log exporters just weren't covered by that change.

## What I changed

- Both `flush()` implementations now bound the wait with the already-computed request timeout and return `.failure` when it expires — the same pattern the trace exporter uses since #1005:

```swift
let waitResult = semaphore.wait(timeout: .now() + timeout)
if waitResult == .timedOut {
  exporterMetrics?.addFailed(value: sentCount)
  return .failure
}
```

- Pending records stay in the queue on timeout, so the next export retries them instead of dropping data
- `export()` is left alone on purpose: the metric and log `export()` implementations don't wait on the semaphore at all today, so they don't have this defect. Making them synchronous like #1005 did for traces would be a bigger behavioral change and feels like a separate discussion.

## Tests

Added two tests that drive each exporter with an `HTTPClient` stub that fails the first request (to fill the pending queue) and then never invokes its completion handler. Before this change they hang; with it they fail at the configured timeout:

```
testLogFlushTimesOutWhenResponseNeverArrives     passed (0.504 seconds)
testMetricFlushTimesOutWhenResponseNeverArrives  passed (0.501 seconds)
```

Full OTLP exporter test target: 161 tests, 0 failures. `swift build --build-tests` clean.

Let me know if you want any changes. Thanks!
