### PR TITLE
fix(exporter): log OTLP trace export failures

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceExporter.swift
@@ -55,7 +55,11 @@ public final class OtlpTraceExporter: SpanExporter, @unchecked Sendable {
 
     do {
       // wait() on the response to stop the program from exiting before the response is received.
-      _ = try export.response.wait()
+      let response = try export.response.wait()
+      if response.hasPartialSuccess {
+        logPartialSuccess(response.partialSuccess, logger: perCallOptions.logger)
+      }
+      // OTLP partial-success responses must not be retried.
       return .success
     } catch {
       perCallOptions.logger.error("OTLP trace export failed", error: error)
@@ -69,5 +73,29 @@ public final class OtlpTraceExporter: SpanExporter, @unchecked Sendable {
 
   public func shutdown(explicitTimeout: TimeInterval? = nil) {
     _ = channel.close()
+  }
+
+  private func logPartialSuccess(
+    _ partialSuccess: Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess,
+    logger: Logging.Logger
+  ) {
+    let rejectedSpans = partialSuccess.rejectedSpans
+    let errorMessage = partialSuccess.errorMessage
+    guard rejectedSpans != 0 || !errorMessage.isEmpty else {
+      return
+    }
+
+    var metadata: Logging.Logger.Metadata = [
+      "rejected_spans": .stringConvertible(rejectedSpans)
+    ]
+    if !errorMessage.isEmpty {
+      metadata["error_message"] = .string(errorMessage)
+    }
+
+    if rejectedSpans != 0 {
+      logger.error("OTLP trace export partially succeeded", metadata: metadata)
+    } else {
+      logger.warning("OTLP trace export succeeded with a warning", metadata: metadata)
+    }
   }
 }

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceExporter.swift
@@ -58,6 +58,7 @@ public final class OtlpTraceExporter: SpanExporter, @unchecked Sendable {
       _ = try export.response.wait()
       return .success
     } catch {
+      perCallOptions.logger.error("OTLP trace export failed", error: error)
       return .failure
     }
   }

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceExporter.swift
@@ -57,12 +57,12 @@ public final class OtlpTraceExporter: SpanExporter, @unchecked Sendable {
       // wait() on the response to stop the program from exiting before the response is received.
       let response = try export.response.wait()
       if response.hasPartialSuccess {
-        logPartialSuccess(response.partialSuccess, logger: perCallOptions.logger)
+        reportPartialSuccess(response.partialSuccess)
       }
       // OTLP partial-success responses must not be retried.
       return .success
     } catch {
-      perCallOptions.logger.error("OTLP trace export failed", error: error)
+      OpenTelemetry.instance.feedbackHandler?("OTLP trace export failed: \(error)")
       return .failure
     }
   }
@@ -75,9 +75,8 @@ public final class OtlpTraceExporter: SpanExporter, @unchecked Sendable {
     _ = channel.close()
   }
 
-  private func logPartialSuccess(
-    _ partialSuccess: Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess,
-    logger: Logging.Logger
+  private func reportPartialSuccess(
+    _ partialSuccess: Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess
   ) {
     let rejectedSpans = partialSuccess.rejectedSpans
     let errorMessage = partialSuccess.errorMessage
@@ -85,17 +84,15 @@ public final class OtlpTraceExporter: SpanExporter, @unchecked Sendable {
       return
     }
 
-    var metadata: Logging.Logger.Metadata = [
-      "rejected_spans": .stringConvertible(rejectedSpans)
-    ]
+    var details = "rejected_spans=\(rejectedSpans)"
     if !errorMessage.isEmpty {
-      metadata["error_message"] = .string(errorMessage)
+      details += ", error_message=\(errorMessage)"
     }
 
     if rejectedSpans != 0 {
-      logger.error("OTLP trace export partially succeeded", metadata: metadata)
+      OpenTelemetry.instance.feedbackHandler?("OTLP trace export partially succeeded: \(details)")
     } else {
-      logger.warning("OTLP trace export succeeded with a warning", metadata: metadata)
+      OpenTelemetry.instance.feedbackHandler?("OTLP trace export succeeded with a warning: \(details)")
     }
   }
 }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -131,10 +131,7 @@ class OtlpTraceExporterTests: XCTestCase {
     let expectedStatus = GRPCStatus(code: .unavailable, message: "collector unavailable")
     fakeCollector.returnedStatus = expectedStatus
     let recorder = LogRecorder()
-    let logger = Logging.Logger(label: "otlp-trace-exporter-test") { _ in
-      RecordingLogHandler(recorder: recorder)
-    }
-    let exporter = OtlpTraceExporter(channel: channel, logger: logger)
+    let exporter = OtlpTraceExporter(channel: channel, logger: makeLogger(recorder: recorder))
     defer { exporter.shutdown() }
 
     let result = exporter.export(spans: [generateFakeSpan()])
@@ -143,10 +140,81 @@ class OtlpTraceExporterTests: XCTestCase {
     let exportFailureEvents = recorder.events.filter {
       $0.message.description == "OTLP trace export failed"
     }
-    let event = try XCTUnwrap(exportFailureEvents.first)
     XCTAssertEqual(exportFailureEvents.count, 1)
+    let event = try XCTUnwrap(exportFailureEvents.first)
     XCTAssertEqual(event.level, .error)
     XCTAssertEqual(event.error as? GRPCStatus, expectedStatus)
+  }
+
+  func testRejectedSpansAreLogged() throws {
+    fakeCollector.returnedResponse = .with {
+      $0.partialSuccess = .with {
+        $0.rejectedSpans = 2
+        $0.errorMessage = "invalid span data"
+      }
+    }
+    let recorder = LogRecorder()
+    let exporter = OtlpTraceExporter(channel: channel, logger: makeLogger(recorder: recorder))
+    defer { exporter.shutdown() }
+
+    let result = exporter.export(spans: [generateFakeSpan()])
+
+    XCTAssertEqual(result, .success)
+    let partialSuccessEvents = recorder.events.filter {
+      $0.message.description == "OTLP trace export partially succeeded"
+    }
+    XCTAssertEqual(partialSuccessEvents.count, 1)
+    let event = try XCTUnwrap(partialSuccessEvents.first)
+    XCTAssertEqual(event.level, .error)
+    XCTAssertEqual(event.metadata?["rejected_spans"]?.description, "2")
+    XCTAssertEqual(event.metadata?["error_message"]?.description, "invalid span data")
+  }
+
+  func testPartialSuccessWarningIsLogged() throws {
+    fakeCollector.returnedResponse = .with {
+      $0.partialSuccess = .with {
+        $0.errorMessage = "consider reducing the batch size"
+      }
+    }
+    let recorder = LogRecorder()
+    let exporter = OtlpTraceExporter(channel: channel, logger: makeLogger(recorder: recorder))
+    defer { exporter.shutdown() }
+
+    let result = exporter.export(spans: [generateFakeSpan()])
+
+    XCTAssertEqual(result, .success)
+    let warningEvents = recorder.events.filter {
+      $0.message.description == "OTLP trace export succeeded with a warning"
+    }
+    XCTAssertEqual(warningEvents.count, 1)
+    let event = try XCTUnwrap(warningEvents.first)
+    XCTAssertEqual(event.level, .warning)
+    XCTAssertEqual(event.metadata?["rejected_spans"]?.description, "0")
+    XCTAssertEqual(event.metadata?["error_message"]?.description, "consider reducing the batch size")
+  }
+
+  func testEmptyPartialSuccessIsNotLogged() {
+    fakeCollector.returnedResponse = .with {
+      $0.partialSuccess = Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess()
+    }
+    let recorder = LogRecorder()
+    let exporter = OtlpTraceExporter(channel: channel, logger: makeLogger(recorder: recorder))
+    defer { exporter.shutdown() }
+
+    let result = exporter.export(spans: [generateFakeSpan()])
+
+    XCTAssertEqual(result, .success)
+    let partialSuccessEvents = recorder.events.filter {
+      $0.message.description == "OTLP trace export partially succeeded"
+        || $0.message.description == "OTLP trace export succeeded with a warning"
+    }
+    XCTAssertTrue(partialSuccessEvents.isEmpty)
+  }
+
+  private func makeLogger(recorder: LogRecorder) -> Logging.Logger {
+    Logging.Logger(label: "otlp-trace-exporter-test") { _ in
+      RecordingLogHandler(recorder: recorder)
+    }
   }
 
   private func generateFakeSpan() -> SpanData {
@@ -227,6 +295,7 @@ private struct RecordingLogHandler: LogHandler {
 class FakeCollector: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceProvider {
   var receivedSpans = [Opentelemetry_Proto_Trace_V1_ResourceSpans]()
   var returnedStatus = GRPCStatus.ok
+  var returnedResponse = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse()
   var interceptors: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceServerInterceptorFactoryProtocol?
 
   func export(request: Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse> {
@@ -234,6 +303,6 @@ class FakeCollector: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceProvider
     if returnedStatus != GRPCStatus.ok {
       return context.eventLoop.makeFailedFuture(returnedStatus)
     }
-    return context.eventLoop.makeSucceededFuture(Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse())
+    return context.eventLoop.makeSucceededFuture(returnedResponse)
   }
 }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -127,6 +127,28 @@ class OtlpTraceExporterTests: XCTestCase {
     exporter.shutdown()
   }
 
+  func testExportFailureIsLogged() throws {
+    let expectedStatus = GRPCStatus(code: .unavailable, message: "collector unavailable")
+    fakeCollector.returnedStatus = expectedStatus
+    let recorder = LogRecorder()
+    let logger = Logging.Logger(label: "otlp-trace-exporter-test") { _ in
+      RecordingLogHandler(recorder: recorder)
+    }
+    let exporter = OtlpTraceExporter(channel: channel, logger: logger)
+    defer { exporter.shutdown() }
+
+    let result = exporter.export(spans: [generateFakeSpan()])
+
+    XCTAssertEqual(result, .failure)
+    let exportFailureEvents = recorder.events.filter {
+      $0.message.description == "OTLP trace export failed"
+    }
+    let event = try XCTUnwrap(exportFailureEvents.first)
+    XCTAssertEqual(exportFailureEvents.count, 1)
+    XCTAssertEqual(event.level, .error)
+    XCTAssertEqual(event.error as? GRPCStatus, expectedStatus)
+  }
+
   private func generateFakeSpan() -> SpanData {
     let duration = 0.9
     let start = Date()
@@ -163,6 +185,42 @@ class OtlpTraceExporterTests: XCTestCase {
     let channel = ClientConnection.insecure(group: channelGroup)
       .connect(host: "localhost", port: 4317)
     return channel
+  }
+}
+
+private final class LogRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var recordedEvents = [LogEvent]()
+
+  var events: [LogEvent] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recordedEvents
+  }
+
+  func record(_ event: LogEvent) {
+    lock.lock()
+    defer { lock.unlock() }
+    recordedEvents.append(event)
+  }
+}
+
+private struct RecordingLogHandler: LogHandler {
+  var metadata = Logging.Logger.Metadata()
+  var logLevel = Logging.Logger.Level.trace
+  private let recorder: LogRecorder
+
+  init(recorder: LogRecorder) {
+    self.recorder = recorder
+  }
+
+  subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+    get { metadata[key] }
+    set { metadata[key] = newValue }
+  }
+
+  func log(event: LogEvent) {
+    recorder.record(event)
   }
 }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -127,94 +127,87 @@ class OtlpTraceExporterTests: XCTestCase {
     exporter.shutdown()
   }
 
-  func testExportFailureIsLogged() throws {
+  func testExportFailureIsReported() {
     let expectedStatus = GRPCStatus(code: .unavailable, message: "collector unavailable")
     fakeCollector.returnedStatus = expectedStatus
-    let recorder = LogRecorder()
-    let exporter = OtlpTraceExporter(channel: channel, logger: makeLogger(recorder: recorder))
-    defer { exporter.shutdown() }
+    withFeedbackRecorder { recorder in
+      let exporter = OtlpTraceExporter(channel: channel)
+      defer { exporter.shutdown() }
 
-    let result = exporter.export(spans: [generateFakeSpan()])
+      let result = exporter.export(spans: [generateFakeSpan()])
 
-    XCTAssertEqual(result, .failure)
-    let exportFailureEvents = recorder.events.filter {
-      $0.message.description == "OTLP trace export failed"
+      XCTAssertEqual(result, .failure)
+      XCTAssertEqual(recorder.messages.count, 1)
+      guard let message = recorder.messages.first else {
+        return XCTFail("Expected export failure feedback")
+      }
+      XCTAssertTrue(message.contains("OTLP trace export failed"))
+      XCTAssertTrue(message.contains("collector unavailable"))
     }
-    XCTAssertEqual(exportFailureEvents.count, 1)
-    let event = try XCTUnwrap(exportFailureEvents.first)
-    XCTAssertEqual(event.level, .error)
-    XCTAssertEqual(event.error as? GRPCStatus, expectedStatus)
   }
 
-  func testRejectedSpansAreLogged() throws {
+  func testRejectedSpansAreReported() {
     fakeCollector.returnedResponse = .with {
       $0.partialSuccess = .with {
         $0.rejectedSpans = 2
         $0.errorMessage = "invalid span data"
       }
     }
-    let recorder = LogRecorder()
-    let exporter = OtlpTraceExporter(channel: channel, logger: makeLogger(recorder: recorder))
-    defer { exporter.shutdown() }
+    withFeedbackRecorder { recorder in
+      let exporter = OtlpTraceExporter(channel: channel)
+      defer { exporter.shutdown() }
 
-    let result = exporter.export(spans: [generateFakeSpan()])
+      let result = exporter.export(spans: [generateFakeSpan()])
 
-    XCTAssertEqual(result, .success)
-    let partialSuccessEvents = recorder.events.filter {
-      $0.message.description == "OTLP trace export partially succeeded"
+      XCTAssertEqual(result, .success)
+      XCTAssertEqual(recorder.messages, [
+        "OTLP trace export partially succeeded: rejected_spans=2, error_message=invalid span data"
+      ])
     }
-    XCTAssertEqual(partialSuccessEvents.count, 1)
-    let event = try XCTUnwrap(partialSuccessEvents.first)
-    XCTAssertEqual(event.level, .error)
-    XCTAssertEqual(event.metadata?["rejected_spans"]?.description, "2")
-    XCTAssertEqual(event.metadata?["error_message"]?.description, "invalid span data")
   }
 
-  func testPartialSuccessWarningIsLogged() throws {
+  func testPartialSuccessWarningIsReported() {
     fakeCollector.returnedResponse = .with {
       $0.partialSuccess = .with {
         $0.errorMessage = "consider reducing the batch size"
       }
     }
-    let recorder = LogRecorder()
-    let exporter = OtlpTraceExporter(channel: channel, logger: makeLogger(recorder: recorder))
-    defer { exporter.shutdown() }
+    withFeedbackRecorder { recorder in
+      let exporter = OtlpTraceExporter(channel: channel)
+      defer { exporter.shutdown() }
 
-    let result = exporter.export(spans: [generateFakeSpan()])
+      let result = exporter.export(spans: [generateFakeSpan()])
 
-    XCTAssertEqual(result, .success)
-    let warningEvents = recorder.events.filter {
-      $0.message.description == "OTLP trace export succeeded with a warning"
+      XCTAssertEqual(result, .success)
+      XCTAssertEqual(recorder.messages, [
+        "OTLP trace export succeeded with a warning: rejected_spans=0, error_message=consider reducing the batch size"
+      ])
     }
-    XCTAssertEqual(warningEvents.count, 1)
-    let event = try XCTUnwrap(warningEvents.first)
-    XCTAssertEqual(event.level, .warning)
-    XCTAssertEqual(event.metadata?["rejected_spans"]?.description, "0")
-    XCTAssertEqual(event.metadata?["error_message"]?.description, "consider reducing the batch size")
   }
 
-  func testEmptyPartialSuccessIsNotLogged() {
+  func testEmptyPartialSuccessIsNotReported() {
     fakeCollector.returnedResponse = .with {
       $0.partialSuccess = Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess()
     }
-    let recorder = LogRecorder()
-    let exporter = OtlpTraceExporter(channel: channel, logger: makeLogger(recorder: recorder))
-    defer { exporter.shutdown() }
+    withFeedbackRecorder { recorder in
+      let exporter = OtlpTraceExporter(channel: channel)
+      defer { exporter.shutdown() }
 
-    let result = exporter.export(spans: [generateFakeSpan()])
+      let result = exporter.export(spans: [generateFakeSpan()])
 
-    XCTAssertEqual(result, .success)
-    let partialSuccessEvents = recorder.events.filter {
-      $0.message.description == "OTLP trace export partially succeeded"
-        || $0.message.description == "OTLP trace export succeeded with a warning"
+      XCTAssertEqual(result, .success)
+      XCTAssertTrue(recorder.messages.isEmpty)
     }
-    XCTAssertTrue(partialSuccessEvents.isEmpty)
   }
 
-  private func makeLogger(recorder: LogRecorder) -> Logging.Logger {
-    Logging.Logger(label: "otlp-trace-exporter-test") { _ in
-      RecordingLogHandler(recorder: recorder)
+  private func withFeedbackRecorder(_ operation: (FeedbackRecorder) -> Void) {
+    let previousHandler = OpenTelemetry.instance.feedbackHandler
+    let recorder = FeedbackRecorder()
+    OpenTelemetry.registerFeedbackHandler(recorder.record)
+    defer {
+      OpenTelemetry.registerFeedbackHandler(previousHandler ?? { _ in })
     }
+    operation(recorder)
   }
 
   private func generateFakeSpan() -> SpanData {
@@ -256,39 +249,20 @@ class OtlpTraceExporterTests: XCTestCase {
   }
 }
 
-private final class LogRecorder: @unchecked Sendable {
+private final class FeedbackRecorder: @unchecked Sendable {
   private let lock = NSLock()
-  private var recordedEvents = [LogEvent]()
+  private var recordedMessages = [String]()
 
-  var events: [LogEvent] {
+  var messages: [String] {
     lock.lock()
     defer { lock.unlock() }
-    return recordedEvents
+    return recordedMessages
   }
 
-  func record(_ event: LogEvent) {
+  func record(_ message: String) {
     lock.lock()
     defer { lock.unlock() }
-    recordedEvents.append(event)
-  }
-}
-
-private struct RecordingLogHandler: LogHandler {
-  var metadata = Logging.Logger.Metadata()
-  var logLevel = Logging.Logger.Level.trace
-  private let recorder: LogRecorder
-
-  init(recorder: LogRecorder) {
-    self.recorder = recorder
-  }
-
-  subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
-    get { metadata[key] }
-    set { metadata[key] = newValue }
-  }
-
-  func log(event: LogEvent) {
-    recorder.record(event)
+    recordedMessages.append(message)
   }
 }
 


### PR DESCRIPTION
- report trace export failures through the SDK feedback handler
- report partial-success responses when the collector rejects spans or returns a warning
- include the underlying gRPC error and partial-success details in the diagnostic message
- keep partial-success responses non-retryable, as required by OTLP

On Apple platforms, diagnostics use the default `os_log` feedback handler. Callers can replace it with `OpenTelemetry.registerFeedbackHandler`.

Fixes #334.

#### Example output

With a simulated unavailable collector:

```text
OTLP trace export failed: unavailable (14): collector unavailable
```

#### Scope

This PR only updates the gRPC trace exporter. Metric and log gRPC exporters can be handled separately.
