### PR TITLE
fix(otlp-http): return upload failures from log and metric exporters

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -55,6 +55,7 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
 
   public func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord],
                      explicitTimeout: TimeInterval? = nil) -> OpenTelemetrySdk.ExportResult {
+    var resultValue: ExportResult = .success
     var sendingLogRecords: [ReadableLogRecord] = []
     exporterLock.withLockVoid {
       pendingLogRecords.append(contentsOf: logRecords)
@@ -70,7 +71,9 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
 
     var request = createRequest(body: body, endpoint: endpoint)
     exporterMetrics?.addSeen(value: sendingLogRecords.count)
-    request.timeoutInterval = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let semaphore = DispatchSemaphore(value: 0)
+    request.timeoutInterval = timeout
     httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success:
@@ -81,10 +84,17 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
           self?.pendingLogRecords.append(contentsOf: sendingLogRecords)
         }
         OpenTelemetry.instance.feedbackHandler?("\(error)")
+        resultValue = .failure
       }
+      semaphore.signal()
     }
 
-    return .success
+    let waitResult = semaphore.wait(timeout: .now() + timeout)
+    if waitResult == .timedOut {
+      exporterMetrics?.addFailed(value: sendingLogRecords.count)
+      return .failure
+    }
+    return resultValue
   }
 
   public func forceFlush(explicitTimeout: TimeInterval? = nil) -> ExportResult {

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -85,6 +85,7 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
   // MARK: - StableMetricsExporter
 
   public func export(metrics: [MetricData]) -> ExportResult {
+    var resultValue: ExportResult = .success
     var sendingMetrics: [MetricData] = []
     exporterLock.withLockVoid {
       pendingMetrics.append(contentsOf: metrics)
@@ -95,10 +96,12 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
       Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest.with {
         $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(
           metricData: sendingMetrics)
-      }
+    }
     exporterMetrics?.addSeen(value: sendingMetrics.count)
     var request = createRequest(body: body, endpoint: endpoint)
-    request.timeoutInterval = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let timeout = config.timeout
+    let semaphore = DispatchSemaphore(value: 0)
+    request.timeoutInterval = timeout
     httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success:
@@ -109,10 +112,17 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
           self?.pendingMetrics.append(contentsOf: sendingMetrics)
         }
         OpenTelemetry.instance.feedbackHandler?("\(error)")
+        resultValue = .failure
       }
+      semaphore.signal()
     }
 
-    return .success
+    let waitResult = semaphore.wait(timeout: .now() + timeout)
+    if waitResult == .timedOut {
+      exporterMetrics?.addFailed(value: sendingMetrics.count)
+      return .failure
+    }
+    return resultValue
   }
 
   public func flush() -> ExportResult {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -58,6 +58,32 @@ private final class HangingAfterFirstFailureHTTPClient: HTTPClient {
   }
 }
 
+private final class HangingHTTPClient: HTTPClient {
+  private(set) var sentRequests: [URLRequest] = []
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sentRequests.append(request)
+  }
+}
+
+private final class DelayedFailureHTTPClient: HTTPClient {
+  private let delay: TimeInterval
+  private(set) var sentRequests: [URLRequest] = []
+
+  init(delay: TimeInterval) {
+    self.delay = delay
+  }
+
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sentRequests.append(request)
+    nonisolated(unsafe) let completion = completion
+    DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+      completion(.failure(TransientNetworkError()))
+    }
+  }
+}
+
 private func sampleLogRecord() -> ReadableLogRecord {
   let ctx = SpanContext.create(traceId: TraceId.random(),
                                spanId: SpanId.random(),
@@ -94,10 +120,36 @@ final class OtlpHttpLogExporterCoverageTests: XCTestCase {
 
     let rec = sampleLogRecord()
     let result = exporter.export(logRecords: [rec])
-    XCTAssertEqual(result, .success)
+    XCTAssertEqual(result, .failure)
 
     // Failure path should put the record back into pendingLogRecords.
     XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testExportWaitsForDelayedFailureBeforeReturning() {
+    let delay: TimeInterval = 0.05
+    let client = DelayedFailureHTTPClient(delay: delay)
+    let exporter = OtlpHttpLogExporter(httpClient: client)
+
+    let start = Date()
+    let result = exporter.export(logRecords: [sampleLogRecord()])
+
+    XCTAssertEqual(result, .failure)
+    XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), delay)
+    XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testExportTimesOutWhenResponseNeverArrives() {
+    let timeout: TimeInterval = 0.05
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpLogExporter(config: OtlpConfiguration(timeout: timeout),
+                                       httpClient: client)
+
+    let start = Date()
+    XCTAssertEqual(exporter.export(logRecords: [sampleLogRecord()]), .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
     XCTAssertEqual(client.sentRequests.count, 1)
   }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
@@ -38,6 +38,32 @@ private final class StubHTTPClient: HTTPClient {
 
 private struct FakeError: Error {}
 
+private final class HangingHTTPClient: HTTPClient {
+  private(set) var sentRequests: [URLRequest] = []
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sentRequests.append(request)
+  }
+}
+
+private final class DelayedFailureHTTPClient: HTTPClient {
+  private let delay: TimeInterval
+  private(set) var sentRequests: [URLRequest] = []
+
+  init(delay: TimeInterval) {
+    self.delay = delay
+  }
+
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sentRequests.append(request)
+    nonisolated(unsafe) let completion = completion
+    DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+      completion(.failure(FakeError()))
+    }
+  }
+}
+
 final class OtlpHttpMetricExporterCoverageTests: XCTestCase {
   private let endpoint = URL(string: "http://localhost:4318/v1/metrics")!
 
@@ -52,8 +78,36 @@ final class OtlpHttpMetricExporterCoverageTests: XCTestCase {
   func testExportFailurePutsMetricsBackInPending() {
     let client = StubHTTPClient(outcomes: [.failure(FakeError())])
     let exporter = OtlpHttpMetricExporter(endpoint: endpoint, httpClient: client)
-    _ = exporter.export(metrics: [.empty])
+    let result = exporter.export(metrics: [.empty])
+    XCTAssertEqual(result, .failure)
     XCTAssertEqual(exporter.pendingMetrics.count, 1)
+  }
+
+  func testExportWaitsForDelayedFailureBeforeReturning() {
+    let delay: TimeInterval = 0.05
+    let client = DelayedFailureHTTPClient(delay: delay)
+    let exporter = OtlpHttpMetricExporter(endpoint: endpoint, httpClient: client)
+
+    let start = Date()
+    let result = exporter.export(metrics: [.empty])
+
+    XCTAssertEqual(result, .failure)
+    XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), delay)
+    XCTAssertEqual(exporter.pendingMetrics.count, 1)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testExportTimesOutWhenResponseNeverArrives() {
+    let timeout: TimeInterval = 0.05
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpMetricExporter(endpoint: endpoint,
+                                          config: OtlpConfiguration(timeout: timeout),
+                                          httpClient: client)
+
+    let start = Date()
+    XCTAssertEqual(exporter.export(metrics: [.empty]), .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+    XCTAssertEqual(client.sentRequests.count, 1)
   }
 
   func testFlushWithPendingReturnsSuccessAfterRetry() {


### PR DESCRIPTION
## Summary

- Make `OtlpHttpLogExporter.export` wait for the HTTP callback and return `.failure` when upload fails or times out.
- Make `OtlpHttpMetricExporter.export` do the same using `config.timeout`.
- Add regression coverage for immediate failure, delayed failure, and no-response timeout paths.

## Motivation

Persistence deletes or keeps stored batches based on the exporter’s synchronous return value. The HTTP log and metric exporters were returning `.success` immediately after scheduling an async upload, so durable batches could be deleted before the upload outcome was known.

[OtlpHttpTraceExporter.export](https://github.com/yasuradodo/opentelemetry-swift/blob/59ff8edf81d7ba77b691438beaba1337274bab5b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift#L57-L100) already waits for the callback and returns the real result. This change aligns log and metric export behavior with that existing contract.

## Notes

Timeout behavior remains trace-like: export returns `.failure` on timeout without adding new in-memory timeout requeue behavior.