### PR TITLE
fix(MetricKit): accept unwrapped MXCallStackTree JSON in stacktrace transform

### DIFF
--- a/Sources/Instrumentation/MetricKit/StackTraceFormat.md
+++ b/Sources/Instrumentation/MetricKit/StackTraceFormat.md
@@ -85,7 +85,7 @@ This format is based on Apple's `MXCallStackTree.jsonRepresentation()` format bu
 
 ### 1. Removed `callStackTree` Wrapper
 
-The `callStackTree` wrapper adds an unnecessary level of nesting. Since the entire JSON document represents call stack data, the wrapper provides no additional information and only complicates parsing.
+`MXCallStackTree.jsonRepresentation()` emits the tree unwrapped; the `callStackTree` wrapper only appears when a whole `MXDiagnosticPayload` is serialized. Either way, the wrapper adds an unnecessary level of nesting: since the entire JSON document represents call stack data, it provides no additional information and only complicates parsing, so this format omits it and accepts both shapes as input.
 
 ### 2. Flattened Stack Frames
 

--- a/Sources/Instrumentation/MetricKit/StackTraceTransform.swift
+++ b/Sources/Instrumentation/MetricKit/StackTraceTransform.swift
@@ -68,12 +68,15 @@
         }
 
         do {
-            // Decode Apple's format
+            // Decode Apple's format. `MXCallStackTree.jsonRepresentation()` emits the tree
+            // unwrapped; the `callStackTree` wrapper only appears when a whole
+            // MXDiagnosticPayload is serialized. Accept both.
             let decoder = JSONDecoder()
-            let appleTree = try decoder.decode(AppleCallStackTree.self, from: appleJsonData)
+            let appleTree = try (try? decoder.decode(AppleCallStackTreeContent.self, from: appleJsonData))
+                ?? decoder.decode(AppleCallStackTree.self, from: appleJsonData).callStackTree
 
             // Transform to simplified format
-            let simplifiedCallStacks = appleTree.callStackTree.callStacks.map { appleStack in
+            let simplifiedCallStacks = appleTree.callStacks.map { appleStack in
                 // Flatten all root frames and their subframes
                 let allFrames = appleStack.callStackRootFrames.flatMap { flattenFrames($0) }
 
@@ -84,7 +87,7 @@
             }
 
             let simplifiedTree = SimplifiedCallStackTree(
-                callStackPerThread: appleTree.callStackTree.callStackPerThread,
+                callStackPerThread: appleTree.callStackPerThread,
                 callStacks: simplifiedCallStacks
             )
 

--- a/Tests/InstrumentationTests/MetricKitTests/MetricKitInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/MetricKitTests/MetricKitInstrumentationTests.swift
@@ -642,8 +642,10 @@ class MetricKitDiagnosticTests: XCTestCase {
         let json = try? JSONSerialization.jsonObject(with: stacktraceData) as? [String: Any]
 
         XCTAssertNotNil(json)
-        XCTAssertTrue(json?.keys.contains("callStackTree") ?? false, "Should have Apple's callStackTree wrapper")
-        XCTAssertFalse(json?.keys.contains("callStacks") ?? true, "Should not have OTel's callStacks")
+        let callStacks = json?["callStacks"] as? [[String: Any]]
+        XCTAssertNotNil(callStacks)
+        XCTAssertNotNil(callStacks?.first?["callStackRootFrames"], "Should have Apple's callStackRootFrames")
+        XCTAssertNil(callStacks?.first?["callStackFrames"], "Should not have OTel's flattened callStackFrames")
     }
 
     func testConfiguration_UseOTelStacktraceFormat() {
@@ -664,8 +666,10 @@ class MetricKitDiagnosticTests: XCTestCase {
         let json = try? JSONSerialization.jsonObject(with: stacktraceData) as? [String: Any]
 
         XCTAssertNotNil(json)
-        XCTAssertTrue(json?.keys.contains("callStacks") ?? false, "Should have OTel's callStacks")
-        XCTAssertFalse(json?.keys.contains("callStackTree") ?? true, "Should not have Apple's callStackTree wrapper")
+        let callStacks = json?["callStacks"] as? [[String: Any]]
+        XCTAssertNotNil(callStacks)
+        XCTAssertNotNil(callStacks?.first?["callStackFrames"], "Should have OTel's flattened callStackFrames")
+        XCTAssertNil(callStacks?.first?["callStackRootFrames"], "Should not have Apple's callStackRootFrames")
     }
 
     func testConfiguration_UsesCustomTracerForDiagnostics() {

--- a/Tests/InstrumentationTests/MetricKitTests/MetricKitTestHelpers.swift
+++ b/Tests/InstrumentationTests/MetricKitTests/MetricKitTestHelpers.swift
@@ -439,24 +439,24 @@ class FakeMetricPayload: MXMetricPayload {
 @available(iOS 14.0, *)
 class FakeCallStackTree: MXCallStackTree {
     override func jsonRepresentation() -> Data {
+        // Matches the real MXCallStackTree.jsonRepresentation() output, which has no
+        // callStackTree wrapper.
         let appleFormat = """
         {
-            "callStackTree": {
-                "callStackPerThread": true,
-                "callStacks": [
-                    {
-                        "threadAttributed": true,
-                        "callStackRootFrames": [
-                            {
-                                "binaryName": "TestApp",
-                                "binaryUUID": "12345678-1234-1234-1234-123456789012",
-                                "offsetIntoBinaryTextSegment": 1000,
-                                "subFrames": []
-                            }
-                        ]
-                    }
-                ]
-            }
+            "callStackPerThread": true,
+            "callStacks": [
+                {
+                    "threadAttributed": true,
+                    "callStackRootFrames": [
+                        {
+                            "binaryName": "TestApp",
+                            "binaryUUID": "12345678-1234-1234-1234-123456789012",
+                            "offsetIntoBinaryTextSegment": 1000,
+                            "subFrames": []
+                        }
+                    ]
+                }
+            ]
         }
         """
         return Data(appleFormat.utf8)

--- a/Tests/InstrumentationTests/MetricKitTests/StackTraceTransformTests.swift
+++ b/Tests/InstrumentationTests/MetricKitTests/StackTraceTransformTests.swift
@@ -252,6 +252,64 @@ class StackTraceTransformTests: XCTestCase {
         XCTAssertNotNil(json["callStacks"])
     }
 
+    func testTransformStackTrace_AcceptsUnwrappedTree() throws {
+        // MXCallStackTree.jsonRepresentation() emits the tree without a callStackTree
+        // wrapper, which is what the instrumentation actually feeds in.
+        let appleFormat = """
+        {
+          "callStackPerThread": true,
+          "callStacks": [
+            {
+              "threadAttributed": true,
+              "callStackRootFrames": [
+                {
+                  "binaryName": "MyApp",
+                  "binaryUUID": "A1B2C3D4-5678-90AB-CDEF-1234567890AB",
+                  "offsetIntoBinaryTextSegment": 100,
+                  "address": 12345678,
+                  "sampleCount": 1,
+                  "subFrames": [
+                    {
+                      "binaryName": "dyld",
+                      "binaryUUID": "B2C3D4E5-6789-01BC-DEF0-234567890ABC",
+                      "offsetIntoBinaryTextSegment": 200,
+                      "address": 23456789,
+                      "sampleCount": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "threadAttributed": false,
+              "callStackRootFrames": []
+            }
+          ]
+        }
+        """
+
+        let appleData = appleFormat.data(using: .utf8)!
+        let transformedData = transformStackTrace(appleData)
+        XCTAssertNotNil(transformedData, "Unwrapped trees must transform, not fall back")
+
+        let json = try JSONSerialization.jsonObject(with: transformedData!, options: []) as! [String: Any]
+        XCTAssertEqual(json["callStackPerThread"] as? Bool, true)
+
+        let callStacks = json["callStacks"] as! [[String: Any]]
+        XCTAssertEqual(callStacks.count, 2)
+
+        let frames = callStacks[0]["callStackFrames"] as! [[String: Any]]
+        XCTAssertEqual(frames.count, 2)
+        XCTAssertEqual(frames[0]["binaryName"] as? String, "MyApp")
+        XCTAssertEqual(frames[0]["offsetAddress"] as? Int, 100)
+        XCTAssertEqual(frames[1]["binaryName"] as? String, "dyld")
+        XCTAssertNil(frames[0]["subFrames"], "subFrames should be flattened away")
+        XCTAssertNil(frames[0]["sampleCount"], "sampleCount should be dropped")
+        XCTAssertNil(frames[0]["address"], "address should be dropped")
+
+        XCTAssertEqual((callStacks[1]["callStackFrames"] as! [[String: Any]]).count, 0)
+    }
+
     func testTransformStackTrace_HandlesInvalidJSON() {
         // Test with invalid JSON
         let invalidData = "not valid json".data(using: .utf8)!


### PR DESCRIPTION
### Issue summary
`transformStackTrace` required a top-level `callStackTree` wrapper key, but
`MXCallStackTree.jsonRepresentation()` emits the tree unwrapped -- the wrapper
only appears when a whole `MXDiagnosticPayload` is serialized. Decoding always
threw on device, so every crash and hang diagnostic silently fell back to
Apple's native format via the `?? appleJson` path, and `exception.stacktrace`
shipped nested `subFrames`, `sampleCount` and ASLR-dependent address fields
instead of the documented OTel format.

### Fix
Decode the unwrapped form first and keep the wrapped form as a fallback, so
both shapes transform.

### Tests
The existing tests could not catch this: FakeCallStackTree hand-wrote the
wrapper that the real API never produces, and both format tests keyed off the
presence of that wrapper. Because the fallback output also has `callStacks`
and also lacks `callStackTree`, testConfiguration_UseOTelStacktraceFormat
passed whether the transform succeeded or failed.

- Fix the fake to emit what MXCallStackTree.jsonRepresentation() returns
- Re-anchor both format tests on callStackRootFrames vs callStackFrames,
the actual discriminator between the two formats
- Add coverage for unwrapped input, asserting subFrames, sampleCount and
address are dropped

Verified against a real MXCrashDiagnostic on iOS 26.5 (iPhone17,1): the OTLP
log record now carries flat callStackFrames with binaryName, binaryUUID and
offsetAddress only.

Resolves https://github.com/open-telemetry/opentelemetry-swift/issues/1148