### PR TITLE
docs: add OTLP gRPC TLS example

### DIFF
--- a/Examples/OTLP Exporter/README.md
+++ b/Examples/OTLP Exporter/README.md
@@ -46,6 +46,21 @@ Note: It may take some time for the application metrics to appear on the Prometh
     ```
 This will create a service and spans with the name `my-swift-app`
 
+## Connect with TLS
+
+The checked-in example uses plaintext so it can connect to the local collector from the Docker
+setup above. To connect to a TLS-enabled collector, update the collector settings in `main.swift`:
+
+```swift
+let collectorHost = "collector.example.com"
+let collectorPort = 4317
+let collectorTransport = CollectorTransport.tls
+```
+
+The TLS configuration uses the platform's default trust roots and performs full certificate
+verification. The value of `collectorHost` must match a name or address covered by the collector
+certificate.
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/Examples/OTLP Exporter/main.swift
+++ b/Examples/OTLP Exporter/main.swift
@@ -46,18 +46,13 @@
   let collectorHost = "localhost"
   let collectorPort = 4317
   let collectorTransport = CollectorTransport.plaintext
-  let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+  let eventLoopGroup = PlatformSupport.makeEventLoopGroup(loopCount: 1)
   let client = makeCollectorClient(
     host: collectorHost,
     port: collectorPort,
     transport: collectorTransport,
     eventLoopGroup: eventLoopGroup
   )
-
-  defer {
-    try? client.close().wait()
-    try? eventLoopGroup.syncShutdownGracefully()
-  }
 
   let otlpTraceExporter = OtlpTraceExporter(channel: client)
   let stdoutExporter = StdoutSpanExporter()

--- a/Examples/OTLP Exporter/main.swift
+++ b/Examples/OTLP Exporter/main.swift
@@ -8,7 +8,6 @@
   import Foundation
   import GRPC
   import NIO
-  import NIOSSL
   import OpenTelemetryApi
   import OpenTelemetryProtocolExporterGrpc
   import OpenTelemetrySdk
@@ -25,9 +24,40 @@
   let instrumentationScopeName = "OTLPExporter"
   let instrumentationScopeVersion = "semver:0.1.0"
 
-  let configuration = ClientConnection.Configuration.default(target: .hostAndPort("localhost", 4317),
-                                                             eventLoopGroup: MultiThreadedEventLoopGroup(numberOfThreads: 1))
-  let client = ClientConnection(configuration: configuration)
+  enum CollectorTransport {
+    case plaintext
+    case tls
+  }
+
+  func makeCollectorClient(host: String,
+                           port: Int,
+                           transport: CollectorTransport,
+                           eventLoopGroup: EventLoopGroup) -> ClientConnection {
+    switch transport {
+    case .plaintext:
+      return .insecure(group: eventLoopGroup)
+        .connect(host: host, port: port)
+    case .tls:
+      return .usingPlatformAppropriateTLS(for: eventLoopGroup)
+        .connect(host: host, port: port)
+    }
+  }
+
+  let collectorHost = "localhost"
+  let collectorPort = 4317
+  let collectorTransport = CollectorTransport.plaintext
+  let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+  let client = makeCollectorClient(
+    host: collectorHost,
+    port: collectorPort,
+    transport: collectorTransport,
+    eventLoopGroup: eventLoopGroup
+  )
+
+  defer {
+    try? client.close().wait()
+    try? eventLoopGroup.syncShutdownGracefully()
+  }
 
   let otlpTraceExporter = OtlpTraceExporter(channel: client)
   let stdoutExporter = StdoutSpanExporter()

--- a/Package.swift
+++ b/Package.swift
@@ -369,6 +369,8 @@ extension Package {
           dependencies: [
             .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
             "OpenTelemetryProtocolExporterGrpc",
+            .product(name: "GRPC", package: "grpc-swift"),
+            .product(name: "NIO", package: "swift-nio"),
             .product(name: "StdoutExporter", package: "opentelemetry-swift-core"),
             "ZipkinExporter", "ResourceExtension", "SignPostIntegration"
           ],


### PR DESCRIPTION
Adds TLS support to the OTLP gRPC example while keeping plaintext as the local default. Also declares GRPC and NIO as direct dependencies.

Closes #332