### PR TITLE
feat(otlp-http): add async HTTPClient.send

### DIFF
--- a/Examples/Custom HTTPClient/README.md
+++ b/Examples/Custom HTTPClient/README.md
@@ -46,6 +46,25 @@ class AuthTokenHTTPClient: HTTPClient {
         }
         task.resume()
     }
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+        var authorizedRequest = request
+
+        if let token = authToken {
+            authorizedRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await session.data(for: authorizedRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        if httpResponse.statusCode == 401 {
+            return try await refreshTokenAndRetry(request: request)
+        }
+
+        return httpResponse
+    }
     
     private func refreshTokenAndRetry(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
         // Implement your token refresh logic here
@@ -64,6 +83,24 @@ class AuthTokenHTTPClient: HTTPClient {
             }
         }
         task.resume()
+    }
+
+    private func refreshTokenAndRetry(request: URLRequest) async throws -> HTTPURLResponse {
+        var tokenRequest = URLRequest(url: tokenRefreshURL)
+        tokenRequest.httpMethod = "POST"
+
+        let (data, response) = try await session.data(for: tokenRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let newToken = json["access_token"] as? String {
+            authToken = newToken
+            return try await send(request: request)
+        }
+
+        throw URLError(.userAuthenticationRequired)
     }
 }
 
@@ -90,6 +127,10 @@ class RetryHTTPClient: HTTPClient {
     func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
         sendWithRetry(request: request, attempt: 0, completion: completion)
     }
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+        try await sendWithRetry(request: request, attempt: 0)
+    }
     
     private func sendWithRetry(request: URLRequest, attempt: Int, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
         baseClient.send(request: request) { [weak self] result in
@@ -112,6 +153,23 @@ class RetryHTTPClient: HTTPClient {
                     completion(result)
                 }
             }
+        }
+    }
+
+    private func sendWithRetry(request: URLRequest, attempt: Int) async throws -> HTTPURLResponse {
+        do {
+            let response = try await baseClient.send(request: request)
+            if response.statusCode >= 500 && attempt < maxRetries {
+                try await Task.sleep(nanoseconds: UInt64(pow(2.0, Double(attempt)) * 1_000_000_000))
+                return try await sendWithRetry(request: request, attempt: attempt + 1)
+            }
+            return response
+        } catch {
+            if attempt < maxRetries {
+                try await Task.sleep(nanoseconds: UInt64(pow(2.0, Double(attempt)) * 1_000_000_000))
+                return try await sendWithRetry(request: request, attempt: attempt + 1)
+            }
+            throw error
         }
     }
 }
@@ -139,6 +197,16 @@ class CustomHeadersHTTPClient: HTTPClient {
         
         baseClient.send(request: modifiedRequest, completion: completion)
     }
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+        var modifiedRequest = request
+
+        for (key, value) in customHeaders {
+            modifiedRequest.setValue(value, forHTTPHeaderField: key)
+        }
+
+        return try await baseClient.send(request: modifiedRequest)
+    }
 }
 
 // Usage
@@ -155,6 +223,8 @@ let exporter = OtlpHttpLogExporter(
 ```
 
 ## Benefits
+
+Custom `HTTPClient` implementations must provide both the callback `send(request:completion:)` and the async `send(request:)`. Async export (Phase 1) calls the async method; sync export and persistence still use the callback API until those paths migrate.
 
 Using custom HTTPClient implementations allows you to:
 

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/HTTPClient.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/HTTPClient.swift
@@ -17,6 +17,11 @@ public protocol HTTPClient {
   ///   - completion: Completion handler called with Result<HTTPURLResponse, Error>
   func send(request: URLRequest,
             completion: @escaping (Result<HTTPURLResponse, Error>) -> Void)
+
+  /// Sends an HTTP request and returns the response on success.
+  /// - Parameter request: The URLRequest to send
+  /// - Returns: The HTTP response for successful (2xx) requests
+  func send(request: URLRequest) async throws -> HTTPURLResponse
 }
 
 /// Default implementation of HTTPClient using URLSession.
@@ -53,6 +58,11 @@ public final class BaseHTTPClient: HTTPClient {
       completion(httpClientResult(for: (data, response, error)))
     }
     task.resume()
+  }
+
+  public func send(request: URLRequest) async throws -> HTTPURLResponse {
+    let (data, response) = try await session.data(for: request)
+    return try httpClientResult(for: (data, response, nil)).get()
   }
 }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/HTTPClientAsyncTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/HTTPClientAsyncTests.swift
@@ -1,0 +1,42 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+import OpenTelemetryProtocolExporterHttp
+import SharedTestUtils
+import XCTest
+
+final class HTTPClientAsyncTests: XCTestCase {
+  var testServer: HttpTestServer!
+
+  override func setUp() {
+    testServer = HttpTestServer()
+    XCTAssertNoThrow(try testServer.start())
+  }
+
+  override func tearDown() {
+    XCTAssertNoThrow(try testServer.stop())
+  }
+
+  func testBaseHTTPClientAsyncSendSuccess() async throws {
+    let endpoint = URL(string: "http://localhost:\(testServer.serverPort)/some-route")!
+    let httpClient = BaseHTTPClient()
+    var request = URLRequest(url: endpoint)
+    request.httpMethod = HTTPMethod.GET.rawValue
+
+    let response = try await httpClient.send(request: request)
+    XCTAssertEqual(HTTPResponseStatus.ok.code, UInt(response.statusCode))
+
+    XCTAssertNoThrow(try testServer.receiveHeadAndVerify { head in
+      XCTAssertEqual(head.version, .http1_1)
+      XCTAssertEqual(head.method.rawValue, "GET")
+      XCTAssertEqual(head.uri, "/some-route")
+    })
+    XCTAssertNoThrow(try testServer.receiveEnd())
+  }
+}

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -40,6 +40,20 @@ private final class StubHTTPClient: HTTPClient {
       completion(.failure(err))
     }
   }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sentRequests.append(request)
+    let next = outcomes.isEmpty ? .success : outcomes.removeFirst()
+    switch next {
+    case .success:
+      return HTTPURLResponse(url: request.url!,
+                             statusCode: 200,
+                             httpVersion: "HTTP/1.1",
+                             headerFields: nil)!
+    case .failure(let err):
+      throw err
+    }
+  }
 }
 
 private struct TransientNetworkError: Error {}
@@ -55,6 +69,14 @@ private final class HangingAfterFirstFailureHTTPClient: HTTPClient {
     if sendCount == 1 {
       completion(.failure(TransientNetworkError()))
     }
+  }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sendCount += 1
+    if sendCount == 1 {
+      throw TransientNetworkError()
+    }
+    return await withCheckedContinuation { (_: CheckedContinuation<HTTPURLResponse, Never>) in }
   }
 }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
@@ -34,6 +34,18 @@ private final class StubHTTPClient: HTTPClient {
       completion(.failure(err))
     }
   }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sentRequests.append(request)
+    let next = outcomes.isEmpty ? .success : outcomes.removeFirst()
+    switch next {
+    case .success:
+      return HTTPURLResponse(url: request.url!, statusCode: 200,
+                             httpVersion: "HTTP/1.1", headerFields: nil)!
+    case .failure(let err):
+      throw err
+    }
+  }
 }
 
 private struct FakeError: Error {}


### PR DESCRIPTION
## Motivation

To support async functions in HTTP exporters.

More context:
- https://github.com/open-telemetry/opentelemetry-swift/pull/1153
- https://github.com/open-telemetry/opentelemetry-swift/pull/1146#issuecomment-5207600952

## Summary

- Add `HTTPClient.send(request:) async throws -> HTTPURLResponse` as a protocol requirement (no extension default).
- Implement native async send on `BaseHTTPClient` via `URLSession.data(for:)`, reusing existing 2xx mapping.
- Update in-tree test stubs and Custom HTTPClient README examples with explicit async implementations.
- Add `HTTPClientAsyncTests.testBaseHTTPClientAsyncSendSuccess` against `HttpTestServer`.

## Test plan

- [x] `swift build --build-tests`
- [x] `swift test --filter OpenTelemetryProtocolExporterTests`
- [x] `HTTPClientAsyncTests.testBaseHTTPClientAsyncSendSuccess`
- [x] Linux CI (`BuildAndTest.yml` linux job)