### PR TITLE
feat(otlp-http): async export on log, metric, and trace HTTP exporters

### DIFF
--- a/Examples/Custom HTTPClient/README.md
+++ b/Examples/Custom HTTPClient/README.md
@@ -46,6 +46,25 @@ class AuthTokenHTTPClient: HTTPClient {
         }
         task.resume()
     }
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+        var authorizedRequest = request
+
+        if let token = authToken {
+            authorizedRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await session.data(for: authorizedRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        if httpResponse.statusCode == 401 {
+            return try await refreshTokenAndRetry(request: request)
+        }
+
+        return httpResponse
+    }
     
     private func refreshTokenAndRetry(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
         // Implement your token refresh logic here
@@ -64,6 +83,24 @@ class AuthTokenHTTPClient: HTTPClient {
             }
         }
         task.resume()
+    }
+
+    private func refreshTokenAndRetry(request: URLRequest) async throws -> HTTPURLResponse {
+        var tokenRequest = URLRequest(url: tokenRefreshURL)
+        tokenRequest.httpMethod = "POST"
+
+        let (data, response) = try await session.data(for: tokenRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let newToken = json["access_token"] as? String {
+            authToken = newToken
+            return try await send(request: request)
+        }
+
+        throw URLError(.userAuthenticationRequired)
     }
 }
 
@@ -90,6 +127,10 @@ class RetryHTTPClient: HTTPClient {
     func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
         sendWithRetry(request: request, attempt: 0, completion: completion)
     }
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+        try await sendWithRetry(request: request, attempt: 0)
+    }
     
     private func sendWithRetry(request: URLRequest, attempt: Int, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
         baseClient.send(request: request) { [weak self] result in
@@ -112,6 +153,23 @@ class RetryHTTPClient: HTTPClient {
                     completion(result)
                 }
             }
+        }
+    }
+
+    private func sendWithRetry(request: URLRequest, attempt: Int) async throws -> HTTPURLResponse {
+        do {
+            let response = try await baseClient.send(request: request)
+            if response.statusCode >= 500 && attempt < maxRetries {
+                try await Task.sleep(nanoseconds: UInt64(pow(2.0, Double(attempt)) * 1_000_000_000))
+                return try await sendWithRetry(request: request, attempt: attempt + 1)
+            }
+            return response
+        } catch {
+            if attempt < maxRetries {
+                try await Task.sleep(nanoseconds: UInt64(pow(2.0, Double(attempt)) * 1_000_000_000))
+                return try await sendWithRetry(request: request, attempt: attempt + 1)
+            }
+            throw error
         }
     }
 }
@@ -139,6 +197,16 @@ class CustomHeadersHTTPClient: HTTPClient {
         
         baseClient.send(request: modifiedRequest, completion: completion)
     }
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+        var modifiedRequest = request
+
+        for (key, value) in customHeaders {
+            modifiedRequest.setValue(value, forHTTPHeaderField: key)
+        }
+
+        return try await baseClient.send(request: modifiedRequest)
+    }
 }
 
 // Usage
@@ -155,6 +223,8 @@ let exporter = OtlpHttpLogExporter(
 ```
 
 ## Benefits
+
+Custom `HTTPClient` implementations must provide both the callback `send(request:completion:)` and the async `send(request:)`. Async export (Phase 1) calls the async method; sync export and persistence still use the callback API until those paths migrate.
 
 Using custom HTTPClient implementations allows you to:
 

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/HTTPClient.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/HTTPClient.swift
@@ -17,6 +17,11 @@ public protocol HTTPClient {
   ///   - completion: Completion handler called with Result<HTTPURLResponse, Error>
   func send(request: URLRequest,
             completion: @escaping (Result<HTTPURLResponse, Error>) -> Void)
+
+  /// Sends an HTTP request and returns the response on success.
+  /// - Parameter request: The URLRequest to send
+  /// - Returns: The HTTP response for successful (2xx) requests
+  func send(request: URLRequest) async throws -> HTTPURLResponse
 }
 
 /// Default implementation of HTTPClient using URLSession.
@@ -53,6 +58,11 @@ public final class BaseHTTPClient: HTTPClient {
       completion(httpClientResult(for: (data, response, error)))
     }
     task.resume()
+  }
+
+  public func send(request: URLRequest) async throws -> HTTPURLResponse {
+    let (data, response) = try await session.data(for: request)
+    return try httpClientResult(for: (data, response, nil)).get()
   }
 }
 

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExportSupport.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExportSupport.swift
@@ -1,0 +1,117 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+struct OtlpHttpExportTimeoutError: Error {}
+
+func sendWithTimeout(httpClient: HTTPClient,
+                     timeout: TimeInterval,
+                     request: URLRequest) async -> Result<HTTPURLResponse, Error> {
+  if timeout == .greatestFiniteMagnitude {
+    do {
+      return .success(try await httpClient.send(request: request))
+    } catch {
+      return .failure(error)
+    }
+  }
+
+  return await withCheckedContinuation { continuation in
+    let gate = SendResultGate()
+    let clientBox = HTTPClientBox(httpClient)
+    let sendTask = Task {
+      do {
+        let response = try await clientBox.client.send(request: request)
+        gate.complete(with: .success(response), continuation: continuation)
+      } catch {
+        gate.complete(with: .failure(error), continuation: continuation)
+      }
+    }
+    Task {
+      do {
+        try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+      } catch {
+        return
+      }
+      sendTask.cancel()
+      gate.complete(with: .failure(OtlpHttpExportTimeoutError()), continuation: continuation)
+    }
+  }
+}
+
+private final class HTTPClientBox: @unchecked Sendable {
+  let client: HTTPClient
+  init(_ client: HTTPClient) { self.client = client }
+}
+
+private final class SendResultGate: @unchecked Sendable {
+  private let lock = Lock()
+  private var completed = false
+
+  func complete(with result: Result<HTTPURLResponse, Error>,
+                continuation: CheckedContinuation<Result<HTTPURLResponse, Error>, Never>) {
+    lock.withLockVoid {
+      guard !completed else { return }
+      completed = true
+      continuation.resume(returning: result)
+    }
+  }
+}
+
+func waitSynchronously<R>(timeout: TimeInterval,
+                          operation: @Sendable @escaping () async -> R) -> R? {
+  let semaphore = DispatchSemaphore(value: 0)
+  let resultBox = WaitResultBox<R>()
+  Task.detached {
+    resultBox.value = await operation()
+    semaphore.signal()
+  }
+  let waitResult = semaphore.wait(timeout: .now() + timeout)
+  if waitResult == .timedOut {
+    return nil
+  }
+  return resultBox.value
+}
+
+private final class WaitResultBox<R>: @unchecked Sendable {
+  var value: R?
+}
+
+final class PendingQueue<Item>: @unchecked Sendable {
+  private var items: [Item] = []
+  private let lock = Lock()
+
+  func enqueueAndTakeAll(_ incoming: [Item]) -> [Item] {
+    lock.withLock {
+      items.append(contentsOf: incoming)
+      let batch = items
+      items = []
+      return batch
+    }
+  }
+
+  func requeue(_ batch: [Item]) {
+    lock.withLockVoid {
+      items.append(contentsOf: batch)
+    }
+  }
+
+  func snapshot() -> [Item] {
+    lock.withLock {
+      items
+    }
+  }
+
+  func dropPrefix(_ count: Int) {
+    lock.withLockVoid {
+      let n = min(count, items.count)
+      items.removeFirst(n)
+    }
+  }
+}

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -17,8 +17,10 @@ public func defaultOltpHttpLoggingEndpoint() -> URL {
 }
 
 public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unchecked Sendable {
-  var pendingLogRecords: [ReadableLogRecord] = []
-  private let exporterLock = Lock()
+  private let pendingQueue = PendingQueue<ReadableLogRecord>()
+  var pendingLogRecords: [ReadableLogRecord] {
+    pendingQueue.snapshot()
+  }
   private var exporterMetrics: ExporterMetrics?
 
   override public init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
@@ -55,60 +57,67 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
 
   public func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord],
                      explicitTimeout: TimeInterval? = nil) -> OpenTelemetrySdk.ExportResult {
-    var sendingLogRecords: [ReadableLogRecord] = []
-    exporterLock.withLockVoid {
-      pendingLogRecords.append(contentsOf: logRecords)
-      sendingLogRecords = pendingLogRecords
-      pendingLogRecords = []
-    }
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let estimatedCount = logRecords.count + pendingQueue.snapshot().count
+    return waitSynchronously(timeout: timeout) {
+      await self.export(logRecords: logRecords, explicitTimeout: explicitTimeout)
+    } ?? {
+      exporterMetrics?.addFailed(value: estimatedCount)
+      return .failure
+    }()
+  }
 
-    let body =
-      Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest.with { request in
-        request.resourceLogs = LogRecordAdapter.toProtoResourceRecordLog(
-          logRecordList: sendingLogRecords)
-      }
-
-    var request = createRequest(body: body, endpoint: endpoint)
-    exporterMetrics?.addSeen(value: sendingLogRecords.count)
-    request.timeoutInterval = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
-    httpClient.send(request: request) { [weak self] result in
-      switch result {
-      case .success:
-        self?.exporterMetrics?.addSuccess(value: sendingLogRecords.count)
-      case let .failure(error):
-        self?.exporterMetrics?.addFailed(value: sendingLogRecords.count)
-        self?.exporterLock.withLockVoid {
-          self?.pendingLogRecords.append(contentsOf: sendingLogRecords)
-        }
-        OpenTelemetry.instance.feedbackHandler?("\(error)")
-      }
-    }
-
-    return .success
+  public func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord],
+                     explicitTimeout: TimeInterval? = nil) async -> OpenTelemetrySdk.ExportResult {
+    let batch = pendingQueue.enqueueAndTakeAll(logRecords)
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    return await sendBatch(batch, timeout: timeout, isFlush: false)
   }
 
   public func forceFlush(explicitTimeout: TimeInterval? = nil) -> ExportResult {
     flush(explicitTimeout: explicitTimeout)
   }
 
-  public func flush(explicitTimeout: TimeInterval? = nil) -> ExportResult {
-    var exporterResult: ExportResult = .success
-    var pendingLogRecords: [ReadableLogRecord] = []
-    exporterLock.withLockVoid {
-      pendingLogRecords = self.pendingLogRecords
-    }
+  public func forceFlush(explicitTimeout: TimeInterval? = nil) async -> ExportResult {
+    await flush(explicitTimeout: explicitTimeout)
+  }
 
-    if !pendingLogRecords.isEmpty {
-      let sentCount = pendingLogRecords.count
-      let body =
-        Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest.with { request in
-          request.resourceLogs = LogRecordAdapter.toProtoResourceRecordLog(
-            logRecordList: pendingLogRecords)
-        }
-      let semaphore = DispatchSemaphore(value: 0)
-      var request = createRequest(body: body, endpoint: endpoint)
-      let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
-      request.timeoutInterval = timeout
+  public func flush(explicitTimeout: TimeInterval? = nil) -> ExportResult {
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let pendingCount = pendingQueue.snapshot().count
+    return waitSynchronously(timeout: timeout) {
+      await self.flush(explicitTimeout: explicitTimeout)
+    } ?? {
+      exporterMetrics?.addFailed(value: pendingCount)
+      return .failure
+    }()
+  }
+
+  public func flush(explicitTimeout: TimeInterval? = nil) async -> ExportResult {
+    let pending = pendingQueue.snapshot()
+    guard !pending.isEmpty else { return .success }
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let result = await sendBatch(pending, timeout: timeout, isFlush: true)
+    if case .success = result {
+      pendingQueue.dropPrefix(pending.count)
+    }
+    return result
+  }
+
+  public func shutdown(explicitTimeout: TimeInterval?) async {}
+
+  private func sendBatch(_ batch: [ReadableLogRecord],
+                         timeout: TimeInterval,
+                         isFlush: Bool) async -> ExportResult {
+    let body =
+      Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest.with { request in
+        request.resourceLogs = LogRecordAdapter.toProtoResourceRecordLog(
+          logRecordList: batch)
+      }
+
+    var request = createRequest(body: body, endpoint: endpoint)
+    request.timeoutInterval = timeout
+    if isFlush {
       if let headers = envVarHeaders {
         headers.forEach { key, value in
           request.addValue(value, forHTTPHeaderField: key)
@@ -118,34 +127,25 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
           request.addValue(value, forHTTPHeaderField: key)
         }
       }
-      httpClient.send(request: request) { [weak self] result in
-        switch result {
-        case .success:
-          self?.exporterMetrics?.addSuccess(value: sentCount)
-          // Drop the records we successfully flushed from the pending queue.
-          // Remove only the `sentCount` oldest entries so any records that
-          // `export()` appended concurrently are preserved for the next flush.
-          self?.exporterLock.withLockVoid {
-            guard let self else { return }
-            let n = min(sentCount, self.pendingLogRecords.count)
-            self.pendingLogRecords.removeFirst(n)
-          }
-          exporterResult = ExportResult.success
-        case let .failure(error):
-          self?.exporterMetrics?.addFailed(value: sentCount)
-          OpenTelemetry.instance.feedbackHandler?("\(error)")
-          exporterResult = ExportResult.failure
-        }
-        semaphore.signal()
-      }
-
-      let waitResult = semaphore.wait(timeout: .now() + timeout)
-      if waitResult == .timedOut {
-        exporterMetrics?.addFailed(value: sentCount)
-        return .failure
-      }
+    }
+    if !isFlush {
+      exporterMetrics?.addSeen(value: batch.count)
     }
 
-    return exporterResult
+    let sendResult = await sendWithTimeout(httpClient: httpClient, timeout: timeout, request: request)
+    switch sendResult {
+    case .success:
+      exporterMetrics?.addSuccess(value: batch.count)
+      return .success
+    case let .failure(error):
+      exporterMetrics?.addFailed(value: batch.count)
+      if !isFlush, !(error is OtlpHttpExportTimeoutError) {
+        pendingQueue.requeue(batch)
+      }
+      if !(error is OtlpHttpExportTimeoutError) {
+        OpenTelemetry.instance.feedbackHandler?("\(error)")
+      }
+      return .failure
+    }
   }
 }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -31,8 +31,10 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
   var aggregationTemporalitySelector: AggregationTemporalitySelector
   var defaultAggregationSelector: DefaultAggregationSelector
 
-  var pendingMetrics: [MetricData] = []
-  private let exporterLock = Lock()
+  private let pendingQueue = PendingQueue<MetricData>()
+  var pendingMetrics: [MetricData] {
+    pendingQueue.snapshot()
+  }
   private var exporterMetrics: ExporterMetrics?
 
   // MARK: - Init
@@ -85,84 +87,50 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
   // MARK: - StableMetricsExporter
 
   public func export(metrics: [MetricData]) -> ExportResult {
-    var sendingMetrics: [MetricData] = []
-    exporterLock.withLockVoid {
-      pendingMetrics.append(contentsOf: metrics)
-      sendingMetrics = pendingMetrics
-      pendingMetrics = []
-    }
-    let body =
-      Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest.with {
-        $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(
-          metricData: sendingMetrics)
-      }
-    exporterMetrics?.addSeen(value: sendingMetrics.count)
-    var request = createRequest(body: body, endpoint: endpoint)
-    request.timeoutInterval = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
-    httpClient.send(request: request) { [weak self] result in
-      switch result {
-      case .success:
-        self?.exporterMetrics?.addSuccess(value: sendingMetrics.count)
-      case let .failure(error):
-        self?.exporterMetrics?.addFailed(value: sendingMetrics.count)
-        self?.exporterLock.withLockVoid {
-          self?.pendingMetrics.append(contentsOf: sendingMetrics)
-        }
-        OpenTelemetry.instance.feedbackHandler?("\(error)")
-      }
-    }
+    let timeout = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let estimatedCount = metrics.count + pendingQueue.snapshot().count
+    return waitSynchronously(timeout: timeout) {
+      await self.export(metrics: metrics)
+    } ?? {
+      exporterMetrics?.addFailed(value: estimatedCount)
+      return .failure
+    }()
+  }
 
-    return .success
+  public func export(metrics: [MetricData]) async -> ExportResult {
+    let batch = pendingQueue.enqueueAndTakeAll(metrics)
+    let timeout = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+    return await sendBatch(batch, timeout: timeout, isFlush: false)
   }
 
   public func flush() -> ExportResult {
-    var exporterResult: ExportResult = .success
-    var pendingMetrics: [MetricData] = []
-    exporterLock.withLockVoid {
-      pendingMetrics = self.pendingMetrics
-    }
-    if !pendingMetrics.isEmpty {
-      let sentCount = pendingMetrics.count
-      let body =
-        Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest
-          .with {
-            $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(
-              metricData: pendingMetrics)
-          }
-      let semaphore = DispatchSemaphore(value: 0)
-      var request = createRequest(body: body, endpoint: endpoint)
-      let timeout = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
-      request.timeoutInterval = timeout
-      httpClient.send(request: request) { [weak self] result in
-        switch result {
-        case .success:
-          self?.exporterMetrics?.addSuccess(value: sentCount)
-          // Drop the records we successfully flushed from the pending queue.
-          self?.exporterLock.withLockVoid {
-            guard let self else { return }
-            let n = min(sentCount, self.pendingMetrics.count)
-            self.pendingMetrics.removeFirst(n)
-          }
-        case let .failure(error):
-          self?.exporterMetrics?.addFailed(value: sentCount)
-          OpenTelemetry.instance.feedbackHandler?("\(error)")
-          exporterResult = .failure
-        }
-        semaphore.signal()
-      }
+    let timeout = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let pendingCount = pendingQueue.snapshot().count
+    return waitSynchronously(timeout: timeout) {
+      await self.flush()
+    } ?? {
+      exporterMetrics?.addFailed(value: pendingCount)
+      return .failure
+    }()
+  }
 
-      let waitResult = semaphore.wait(timeout: .now() + timeout)
-      if waitResult == .timedOut {
-        exporterMetrics?.addFailed(value: sentCount)
-        return .failure
-      }
+  public func flush() async -> ExportResult {
+    let pending = pendingQueue.snapshot()
+    guard !pending.isEmpty else { return .success }
+    let timeout = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let result = await sendBatch(pending, timeout: timeout, isFlush: true)
+    if case .success = result {
+      pendingQueue.dropPrefix(pending.count)
     }
-
-    return exporterResult
+    return result
   }
 
   public func shutdown() -> ExportResult {
     return .success
+  }
+
+  public func shutdown() async -> ExportResult {
+    .success
   }
 
   // MARK: - AggregationTemporalitySelectorProtocol
@@ -180,5 +148,37 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
     for instrument: OpenTelemetrySdk.InstrumentType
   ) -> OpenTelemetrySdk.Aggregation {
     return defaultAggregationSelector.getDefaultAggregation(for: instrument)
+  }
+
+  private func sendBatch(_ batch: [MetricData],
+                         timeout: TimeInterval,
+                         isFlush: Bool) async -> ExportResult {
+    let body =
+      Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest
+        .with {
+          $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(
+            metricData: batch)
+        }
+    var request = createRequest(body: body, endpoint: endpoint)
+    request.timeoutInterval = timeout
+    if !isFlush {
+      exporterMetrics?.addSeen(value: batch.count)
+    }
+
+    let sendResult = await sendWithTimeout(httpClient: httpClient, timeout: timeout, request: request)
+    switch sendResult {
+    case .success:
+      exporterMetrics?.addSuccess(value: batch.count)
+      return .success
+    case let .failure(error):
+      exporterMetrics?.addFailed(value: batch.count)
+      if !isFlush, !(error is OtlpHttpExportTimeoutError) {
+        pendingQueue.requeue(batch)
+      }
+      if !(error is OtlpHttpExportTimeoutError) {
+        OpenTelemetry.instance.feedbackHandler?("\(error)")
+      }
+      return .failure
+    }
   }
 }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
@@ -17,9 +17,11 @@ public func defaultOltpHttpTracesEndpoint() -> URL {
 }
 
 public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @unchecked Sendable {
-  var pendingSpans: [SpanData] = []
+  private let pendingQueue = PendingQueue<SpanData>()
+  var pendingSpans: [SpanData] {
+    pendingQueue.snapshot()
+  }
 
-  private let exporterLock = Lock()
   private var exporterMetrics: ExporterMetrics?
 
   override public init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
@@ -56,92 +58,77 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
 
   public func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil)
     -> SpanExporterResultCode {
-    var resultValue: SpanExporterResultCode = .success
-    var sendingSpans: [SpanData] = []
-    exporterLock.withLockVoid {
-      pendingSpans.append(contentsOf: spans)
-      sendingSpans = pendingSpans
-      pendingSpans = []
-    }
-
-    let body =
-      Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest.with {
-        $0.resourceSpans = SpanAdapter.toProtoResourceSpans(
-          spanDataList: sendingSpans)
-      }
-    let semaphore = DispatchSemaphore(value: 0)
-    var request = createRequest(body: body, endpoint: endpoint)
-
     let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
-    request.timeoutInterval = timeout
-
-    exporterMetrics?.addSeen(value: sendingSpans.count)
-    httpClient.send(request: request) { [weak self] result in
-      switch result {
-      case .success:
-        self?.exporterMetrics?.addSuccess(value: sendingSpans.count)
-      case let .failure(error):
-        self?.exporterMetrics?.addFailed(value: sendingSpans.count)
-        self?.exporterLock.withLockVoid {
-          self?.pendingSpans.append(contentsOf: sendingSpans)
-        }
-        OpenTelemetry.instance.feedbackHandler?("\(error)")
-        resultValue = .failure
-      }
-      semaphore.signal()
-    }
-
-    let waitResult = semaphore.wait(timeout: .now() + timeout)
-    if waitResult == .timedOut {
-      exporterMetrics?.addFailed(value: sendingSpans.count)
+    let estimatedCount = spans.count + pendingQueue.snapshot().count
+    return waitSynchronously(timeout: timeout) {
+      await self.export(spans: spans, explicitTimeout: explicitTimeout)
+    } ?? {
+      exporterMetrics?.addFailed(value: estimatedCount)
       return .failure
-    }
-    return resultValue
+    }()
+  }
+
+  @discardableResult
+  public func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil) async
+    -> SpanExporterResultCode {
+    let batch = pendingQueue.enqueueAndTakeAll(spans)
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    return await sendBatch(batch, timeout: timeout, isFlush: false)
   }
 
   public func flush(explicitTimeout: TimeInterval? = nil)
     -> SpanExporterResultCode {
-    var resultValue: SpanExporterResultCode = .success
-    var pendingSpans: [SpanData] = []
-    exporterLock.withLockVoid {
-      pendingSpans = self.pendingSpans
-    }
-    if !pendingSpans.isEmpty {
-      let sentCount = pendingSpans.count
-      let body =
-        Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest.with {
-          $0.resourceSpans = SpanAdapter.toProtoResourceSpans(
-            spanDataList: pendingSpans)
-        }
-      let semaphore = DispatchSemaphore(value: 0)
-      var request = createRequest(body: body, endpoint: endpoint)
-      let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
-      request.timeoutInterval = timeout
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let pendingCount = pendingQueue.snapshot().count
+    return waitSynchronously(timeout: timeout) {
+      await self.flush(explicitTimeout: explicitTimeout)
+    } ?? {
+      exporterMetrics?.addFailed(value: pendingCount)
+      return .failure
+    }()
+  }
 
-      httpClient.send(request: request) { [weak self] result in
-        switch result {
-        case .success:
-          self?.exporterMetrics?.addSuccess(value: sentCount)
-          // Drop the records we successfully flushed from the pending queue.
-          self?.exporterLock.withLockVoid {
-            guard let self else { return }
-            let n = min(sentCount, self.pendingSpans.count)
-            self.pendingSpans.removeFirst(n)
-          }
-        case let .failure(error):
-          self?.exporterMetrics?.addFailed(value: sentCount)
-          OpenTelemetry.instance.feedbackHandler?("\(error)")
-          resultValue = .failure
-        }
-        semaphore.signal()
-      }
-
-      let waitResult = semaphore.wait(timeout: .now() + timeout)
-      if waitResult == .timedOut {
-        exporterMetrics?.addFailed(value: sentCount)
-        return .failure
-      }
+  public func flush(explicitTimeout: TimeInterval? = nil) async -> SpanExporterResultCode {
+    let pending = pendingQueue.snapshot()
+    guard !pending.isEmpty else { return .success }
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let result = await sendBatch(pending, timeout: timeout, isFlush: true)
+    if case .success = result {
+      pendingQueue.dropPrefix(pending.count)
     }
-    return resultValue
+    return result
+  }
+
+  public func shutdown(explicitTimeout: TimeInterval?) async {}
+
+  private func sendBatch(_ batch: [SpanData],
+                         timeout: TimeInterval,
+                         isFlush: Bool) async -> SpanExporterResultCode {
+    let body =
+      Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest.with {
+        $0.resourceSpans = SpanAdapter.toProtoResourceSpans(
+          spanDataList: batch)
+      }
+    var request = createRequest(body: body, endpoint: endpoint)
+    request.timeoutInterval = timeout
+    if !isFlush {
+      exporterMetrics?.addSeen(value: batch.count)
+    }
+
+    let sendResult = await sendWithTimeout(httpClient: httpClient, timeout: timeout, request: request)
+    switch sendResult {
+    case .success:
+      exporterMetrics?.addSuccess(value: batch.count)
+      return .success
+    case let .failure(error):
+      exporterMetrics?.addFailed(value: batch.count)
+      if !isFlush, !(error is OtlpHttpExportTimeoutError) {
+        pendingQueue.requeue(batch)
+      }
+      if !(error is OtlpHttpExportTimeoutError) {
+        OpenTelemetry.instance.feedbackHandler?("\(error)")
+      }
+      return .failure
+    }
   }
 }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/HTTPClientAsyncTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/HTTPClientAsyncTests.swift
@@ -1,0 +1,42 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+import OpenTelemetryProtocolExporterHttp
+import SharedTestUtils
+import XCTest
+
+final class HTTPClientAsyncTests: XCTestCase {
+  var testServer: HttpTestServer!
+
+  override func setUp() {
+    testServer = HttpTestServer()
+    XCTAssertNoThrow(try testServer.start())
+  }
+
+  override func tearDown() {
+    XCTAssertNoThrow(try testServer.stop())
+  }
+
+  func testBaseHTTPClientAsyncSendSuccess() async throws {
+    let endpoint = URL(string: "http://localhost:\(testServer.serverPort)/some-route")!
+    let httpClient = BaseHTTPClient()
+    var request = URLRequest(url: endpoint)
+    request.httpMethod = HTTPMethod.GET.rawValue
+
+    let response = try await httpClient.send(request: request)
+    XCTAssertEqual(HTTPResponseStatus.ok.code, UInt(response.statusCode))
+
+    XCTAssertNoThrow(try testServer.receiveHeadAndVerify { head in
+      XCTAssertEqual(head.version, .http1_1)
+      XCTAssertEqual(head.method.rawValue, "GET")
+      XCTAssertEqual(head.uri, "/some-route")
+    })
+    XCTAssertNoThrow(try testServer.receiveEnd())
+  }
+}

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersAsyncTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersAsyncTests.swift
@@ -1,0 +1,289 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+import OpenTelemetryApi
+import OpenTelemetryProtocolExporterCommon
+@testable import OpenTelemetryProtocolExporterHttp
+@testable import OpenTelemetrySdk
+import XCTest
+
+private final class StubHTTPClient: HTTPClient {
+  enum Outcome {
+    case success
+    case failure(Error)
+  }
+  var outcomes: [Outcome]
+  private(set) var sentRequests: [URLRequest] = []
+  private let lock = NSLock()
+
+  init(outcomes: [Outcome]) { self.outcomes = outcomes }
+
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    let next = lock.withLock {
+      sentRequests.append(request)
+      return outcomes.isEmpty ? .success : outcomes.removeFirst()
+    }
+    switch next {
+    case .success:
+      let resp = HTTPURLResponse(url: request.url!,
+                                 statusCode: 200,
+                                 httpVersion: "HTTP/1.1",
+                                 headerFields: nil)!
+      completion(.success(resp))
+    case .failure(let err):
+      completion(.failure(err))
+    }
+  }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    let next = lock.withLock {
+      sentRequests.append(request)
+      return outcomes.isEmpty ? .success : outcomes.removeFirst()
+    }
+    switch next {
+    case .success:
+      return HTTPURLResponse(url: request.url!,
+                             statusCode: 200,
+                             httpVersion: "HTTP/1.1",
+                             headerFields: nil)!
+    case .failure(let err):
+      throw err
+    }
+  }
+}
+
+private struct TransientNetworkError: Error {}
+
+private final class HangingHTTPClient: HTTPClient {
+  private(set) var sendCount = 0
+  private let lock = NSLock()
+
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    lock.withLock { sendCount += 1 }
+  }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    lock.withLock { sendCount += 1 }
+    return await withCheckedContinuation { (_: CheckedContinuation<HTTPURLResponse, Never>) in }
+  }
+}
+
+private func sampleLogRecord() -> ReadableLogRecord {
+  let ctx = SpanContext.create(traceId: TraceId.random(),
+                               spanId: SpanId.random(),
+                               traceFlags: TraceFlags(),
+                               traceState: TraceState())
+  return ReadableLogRecord(resource: Resource(),
+                           instrumentationScopeInfo: InstrumentationScopeInfo(name: "scope"),
+                           timestamp: Date(),
+                           observedTimestamp: Date(),
+                           spanContext: ctx,
+                           severity: .info,
+                           body: .string("hello"),
+                           attributes: [:])
+}
+
+private func sampleSpanData() -> SpanData {
+  SpanData(traceId: TraceId.random(),
+           spanId: SpanId.random(),
+           traceFlags: TraceFlags(),
+           traceState: TraceState(),
+           resource: Resource(),
+           instrumentationScope: InstrumentationScopeInfo(),
+           name: "span",
+           kind: .internal,
+           startTime: Date(),
+           endTime: Date(),
+           hasRemoteParent: false)
+}
+
+final class OtlpHttpExportersAsyncTests: XCTestCase {
+  private let timeout: TimeInterval = 0.5
+  private let metricsEndpoint = URL(string: "http://localhost:4318/v1/metrics")!
+
+  func testLogAsyncExportSuccess() async {
+    let client = StubHTTPClient(outcomes: [.success])
+    let exporter = OtlpHttpLogExporter(httpClient: client)
+    let result = await exporter.export(logRecords: [sampleLogRecord()])
+    XCTAssertEqual(result, .success)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testLogAsyncExportFailureRequeuesPending() async {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpLogExporter(httpClient: client)
+    let result = await exporter.export(logRecords: [sampleLogRecord()])
+    XCTAssertEqual(result, .failure)
+    XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+  }
+
+  func testLogAsyncExportTimesOut() async {
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpLogExporter(config: OtlpConfiguration(timeout: timeout),
+                                       httpClient: client)
+    let start = Date()
+    let result = await exporter.export(logRecords: [sampleLogRecord()])
+    XCTAssertEqual(result, .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+  }
+
+  func testLogAsyncFlushDropsPendingAfterRetry() async {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError()), .success])
+    let exporter = OtlpHttpLogExporter(httpClient: client)
+    _ = await exporter.export(logRecords: [sampleLogRecord()])
+    XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+    let flushResult = await exporter.flush()
+    XCTAssertEqual(flushResult, .success)
+    XCTAssertEqual(exporter.pendingLogRecords.count, 0)
+    XCTAssertEqual(client.sentRequests.count, 2)
+  }
+
+  func testLogConcurrentAsyncExport() async {
+    let client = StubHTTPClient(outcomes: Array(repeating: .success, count: 10))
+    let exporter = OtlpHttpLogExporter(httpClient: client)
+    await withTaskGroup(of: ExportResult.self) { group in
+      for _ in 0..<10 {
+        group.addTask {
+          await exporter.export(logRecords: [sampleLogRecord()])
+        }
+      }
+      for await result in group {
+        XCTAssertEqual(result, .success)
+      }
+    }
+    XCTAssertEqual(client.sentRequests.count, 10)
+  }
+
+  func testLogSyncExportFailureWithFailingStub() {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpLogExporter(httpClient: client)
+    XCTAssertEqual(exporter.export(logRecords: [sampleLogRecord()]), .failure)
+  }
+
+  func testMetricAsyncExportSuccess() async {
+    let client = StubHTTPClient(outcomes: [.success])
+    let exporter = OtlpHttpMetricExporter(endpoint: metricsEndpoint, httpClient: client)
+    let result = await exporter.export(metrics: [.empty])
+    XCTAssertEqual(result, .success)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testMetricAsyncExportFailureRequeuesPending() async {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpMetricExporter(endpoint: metricsEndpoint, httpClient: client)
+    let result = await exporter.export(metrics: [.empty])
+    XCTAssertEqual(result, .failure)
+    XCTAssertEqual(exporter.pendingMetrics.count, 1)
+  }
+
+  func testMetricAsyncExportTimesOut() async {
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpMetricExporter(endpoint: metricsEndpoint,
+                                          config: OtlpConfiguration(timeout: timeout),
+                                          httpClient: client)
+    let start = Date()
+    let result = await exporter.export(metrics: [.empty])
+    XCTAssertEqual(result, .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+  }
+
+  func testMetricAsyncFlushDropsPendingAfterRetry() async {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError()), .success])
+    let exporter = OtlpHttpMetricExporter(endpoint: metricsEndpoint, httpClient: client)
+    _ = await exporter.export(metrics: [.empty])
+    XCTAssertEqual(exporter.pendingMetrics.count, 1)
+    let flushResult = await exporter.flush()
+    XCTAssertEqual(flushResult, .success)
+    XCTAssertEqual(exporter.pendingMetrics.count, 0)
+    XCTAssertEqual(client.sentRequests.count, 2)
+  }
+
+  func testMetricConcurrentAsyncExport() async {
+    let client = StubHTTPClient(outcomes: Array(repeating: .success, count: 10))
+    let exporter = OtlpHttpMetricExporter(endpoint: metricsEndpoint, httpClient: client)
+    await withTaskGroup(of: ExportResult.self) { group in
+      for _ in 0..<10 {
+        group.addTask {
+          await exporter.export(metrics: [.empty])
+        }
+      }
+      for await result in group {
+        XCTAssertEqual(result, .success)
+      }
+    }
+    XCTAssertEqual(client.sentRequests.count, 10)
+  }
+
+  func testMetricSyncExportFailureWithFailingStub() {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpMetricExporter(endpoint: metricsEndpoint, httpClient: client)
+    XCTAssertEqual(exporter.export(metrics: [.empty]), .failure)
+  }
+
+  func testTraceAsyncExportSuccess() async {
+    let client = StubHTTPClient(outcomes: [.success])
+    let exporter = OtlpHttpTraceExporter(httpClient: client)
+    let result = await exporter.export(spans: [sampleSpanData()])
+    XCTAssertEqual(result, .success)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testTraceAsyncExportFailureRequeuesPending() async {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpTraceExporter(httpClient: client)
+    let result = await exporter.export(spans: [sampleSpanData()])
+    XCTAssertEqual(result, .failure)
+    XCTAssertEqual(exporter.pendingSpans.count, 1)
+  }
+
+  func testTraceAsyncExportTimesOut() async {
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpTraceExporter(config: OtlpConfiguration(timeout: timeout),
+                                         httpClient: client)
+    let start = Date()
+    let result = await exporter.export(spans: [sampleSpanData()])
+    XCTAssertEqual(result, .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+  }
+
+  func testTraceAsyncFlushDropsPendingAfterRetry() async {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError()), .success])
+    let exporter = OtlpHttpTraceExporter(httpClient: client)
+    _ = await exporter.export(spans: [sampleSpanData()])
+    XCTAssertEqual(exporter.pendingSpans.count, 1)
+    let flushResult = await exporter.flush()
+    XCTAssertEqual(flushResult, .success)
+    XCTAssertEqual(exporter.pendingSpans.count, 0)
+    XCTAssertEqual(client.sentRequests.count, 2)
+  }
+
+  func testTraceConcurrentAsyncExport() async {
+    let client = StubHTTPClient(outcomes: Array(repeating: .success, count: 10))
+    let exporter = OtlpHttpTraceExporter(httpClient: client)
+    await withTaskGroup(of: SpanExporterResultCode.self) { group in
+      for _ in 0..<10 {
+        group.addTask {
+          await exporter.export(spans: [sampleSpanData()])
+        }
+      }
+      for await result in group {
+        XCTAssertEqual(result, .success)
+      }
+    }
+    XCTAssertEqual(client.sentRequests.count, 10)
+  }
+
+  func testTraceSyncExportFailureWithFailingStub() {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpTraceExporter(httpClient: client)
+    XCTAssertEqual(exporter.export(spans: [sampleSpanData()]), .failure)
+  }
+}

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -116,7 +116,7 @@ final class OtlpHttpLogExporterCoverageTests: XCTestCase {
 
     let rec = sampleLogRecord()
     let result = exporter.export(logRecords: [rec])
-    XCTAssertEqual(result, .success)
+    XCTAssertEqual(result, .failure)
 
     // Failure path should put the record back into pendingLogRecords.
     XCTAssertEqual(exporter.pendingLogRecords.count, 1)
@@ -273,6 +273,37 @@ final class OtlpHttpTraceExporterCoverageTests: XCTestCase {
 
 final class OtlpHttpExporterFlushTimeoutTests: XCTestCase {
   private let timeout: TimeInterval = 0.5
+
+  private final class HangingHTTPClient: HTTPClient {
+    func send(request: URLRequest,
+              completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {}
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+      await withCheckedContinuation { (_: CheckedContinuation<HTTPURLResponse, Never>) in }
+    }
+  }
+
+  func testLogExportTimesOutWhenResponseNeverArrives() {
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpLogExporter(config: OtlpConfiguration(timeout: timeout),
+                                       httpClient: client)
+
+    let start = Date()
+    XCTAssertEqual(exporter.export(logRecords: [sampleLogRecord()]), .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+  }
+
+  func testMetricExportTimesOutWhenResponseNeverArrives() {
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpMetricExporter(
+      endpoint: URL(string: "http://localhost:4318/v1/metrics")!,
+      config: OtlpConfiguration(timeout: timeout),
+      httpClient: client)
+
+    let start = Date()
+    XCTAssertEqual(exporter.export(metrics: [.empty]), .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+  }
 
   func testMetricFlushTimesOutWhenResponseNeverArrives() {
     let client = HangingAfterFirstFailureHTTPClient()

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -40,6 +40,20 @@ private final class StubHTTPClient: HTTPClient {
       completion(.failure(err))
     }
   }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sentRequests.append(request)
+    let next = outcomes.isEmpty ? .success : outcomes.removeFirst()
+    switch next {
+    case .success:
+      return HTTPURLResponse(url: request.url!,
+                             statusCode: 200,
+                             httpVersion: "HTTP/1.1",
+                             headerFields: nil)!
+    case .failure(let err):
+      throw err
+    }
+  }
 }
 
 private struct TransientNetworkError: Error {}
@@ -55,6 +69,14 @@ private final class HangingAfterFirstFailureHTTPClient: HTTPClient {
     if sendCount == 1 {
       completion(.failure(TransientNetworkError()))
     }
+  }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sendCount += 1
+    if sendCount == 1 {
+      throw TransientNetworkError()
+    }
+    return await withCheckedContinuation { (_: CheckedContinuation<HTTPURLResponse, Never>) in }
   }
 }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
@@ -64,7 +64,8 @@ final class OtlpHttpMetricExporterCoverageTests: XCTestCase {
   func testExportFailurePutsMetricsBackInPending() {
     let client = StubHTTPClient(outcomes: [.failure(FakeError())])
     let exporter = OtlpHttpMetricExporter(endpoint: endpoint, httpClient: client)
-    _ = exporter.export(metrics: [.empty])
+    let result = exporter.export(metrics: [.empty])
+    XCTAssertEqual(result, .failure)
     XCTAssertEqual(exporter.pendingMetrics.count, 1)
   }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
@@ -34,6 +34,18 @@ private final class StubHTTPClient: HTTPClient {
       completion(.failure(err))
     }
   }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sentRequests.append(request)
+    let next = outcomes.isEmpty ? .success : outcomes.removeFirst()
+    switch next {
+    case .success:
+      return HTTPURLResponse(url: request.url!, statusCode: 200,
+                             httpVersion: "HTTP/1.1", headerFields: nil)!
+    case .failure(let err):
+      throw err
+    }
+  }
 }
 
 private struct FakeError: Error {}


### PR DESCRIPTION
## Summary

- Add shared OTLP HTTP export helpers (`sendWithTimeout`, `waitSynchronously`, `PendingQueue`).
- Refactor log, metric, and trace OTLP HTTP exporters so async `export`/`flush` is canonical; sync callers use a timeout-bounded bridge.
- Log and metric sync `export` now returns `.failure` on HTTP error (was fire-and-forget `.success`).

**Depends on #1152.** After that PR merges, this diff will shrink to the async exporter commit only.

## Test plan

- [x] `swift build --build-tests`
- [x] `swift test --filter OtlpHttp` — 81 tests, 0 failures

<details>
<summary>Technical details</summary>

**Async path:** `PendingQueue.enqueueAndTakeAll` → protobuf body → `sendWithTimeout` → success metrics / requeue on HTTP failure (not on timeout).

**Sync bridge:** `waitSynchronously` via `Task.detached` + `DispatchSemaphore`; bridge timeout returns `.failure` and increments failed metrics.

**Timeout semantics:**

| Signal | Export timeout | Flush timeout |
|--------|----------------|---------------|
| Logs / traces | `min(explicitTimeout ?? ∞, config.timeout)` | same |
| Metrics | `config.timeout` only | `config.timeout` |

</details>
