### PR TITLE
feat(otlp): support dynamic export headers

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolCommon/common/OtlpConfiguration.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/common/OtlpConfiguration.swift
@@ -26,17 +26,33 @@ public struct OtlpConfiguration: Sendable {
   // let endpoint : URL? = URL(string: "https://localhost:4317")
   // let certificateFile
   // let compression
+  /// Static headers included with every export when `headersProvider` is not set.
   public let headers: [(String, String)]?
+  /// Returns the current headers immediately before each export.
+  ///
+  /// This callback may be invoked concurrently. Callers must synchronize any mutable state
+  /// captured by the callback. When set, it takes precedence over `headers`. Headers supplied
+  /// through an exporter's `envVarHeaders` parameter retain their existing precedence.
+  public let headersProvider: (@Sendable () -> [(String, String)]?)?
   public let timeout: TimeInterval
   public let compression: CompressionType
   public let exportAsJson: Bool
   public init(timeout: TimeInterval = OtlpConfiguration.DefaultTimeoutInterval,
               compression: CompressionType = .gzip,
               headers: [(String, String)]? = nil,
-              exportAsJson: Bool = true) {
+              exportAsJson: Bool = true,
+              headersProvider: (@Sendable () -> [(String, String)]?)? = nil) {
     self.headers = headers
+    self.headersProvider = headersProvider
     self.timeout = timeout
     self.compression = compression
     self.exportAsJson = exportAsJson
+  }
+
+  package func headersForExport() -> [(String, String)]? {
+    if let headersProvider {
+      return headersProvider()
+    }
+    return headers
   }
 }

--- a/Sources/Exporters/OpenTelemetryProtocolCommon/common/OtlpConfiguration.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/common/OtlpConfiguration.swift
@@ -30,9 +30,10 @@ public struct OtlpConfiguration: Sendable {
   public let headers: [(String, String)]?
   /// Returns the current headers immediately before each export.
   ///
-  /// This callback may be invoked concurrently. Callers must synchronize any mutable state
-  /// captured by the callback. When set, it takes precedence over `headers`. Headers supplied
-  /// through an exporter's `envVarHeaders` parameter retain their existing precedence.
+  /// This callback is invoked synchronously and may be called concurrently. It should return
+  /// cached credentials quickly rather than perform I/O. Callers must synchronize any mutable
+  /// state captured by the callback. When set, it takes precedence over `headers`. Headers
+  /// supplied through an exporter's `envVarHeaders` parameter retain their existing precedence.
   public let headersProvider: (@Sendable () -> [(String, String)]?)?
   public let timeout: TimeInterval
   public let compression: CompressionType
@@ -49,7 +50,11 @@ public struct OtlpConfiguration: Sendable {
     self.exportAsJson = exportAsJson
   }
 
-  package func headersForExport() -> [(String, String)]? {
+  /// Returns the headers to include in the next export.
+  ///
+  /// When a provider is configured, its result takes precedence over static headers, including
+  /// when the provider returns `nil`.
+  public func headersForExport() -> [(String, String)]? {
     if let headersProvider {
       return headersProvider()
     }

--- a/Sources/Exporters/OpenTelemetryProtocolCommon/common/OtlpConfiguration.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/common/OtlpConfiguration.swift
@@ -26,14 +26,15 @@ public struct OtlpConfiguration: Sendable {
   // let endpoint : URL? = URL(string: "https://localhost:4317")
   // let certificateFile
   // let compression
-  /// Static headers included with every export when `headersProvider` is not set.
+  /// Static headers included with every export.
   public let headers: [(String, String)]?
   /// Returns the current headers immediately before each export.
   ///
   /// This callback is invoked synchronously and may be called concurrently. It should return
   /// cached credentials quickly rather than perform I/O. Callers must synchronize any mutable
-  /// state captured by the callback. When set, it takes precedence over `headers`. Headers
-  /// supplied through an exporter's `envVarHeaders` parameter retain their existing precedence.
+  /// state captured by the callback. Provider values replace static headers with matching names
+  /// case-insensitively. Headers supplied through an exporter's `envVarHeaders` parameter retain
+  /// their existing precedence.
   public let headersProvider: (@Sendable () -> [(String, String)]?)?
   public let timeout: TimeInterval
   public let compression: CompressionType
@@ -52,12 +53,17 @@ public struct OtlpConfiguration: Sendable {
 
   /// Returns the headers to include in the next export.
   ///
-  /// When a provider is configured, its result takes precedence over static headers, including
-  /// when the provider returns `nil`.
+  /// Provider values replace matching static headers case-insensitively. A `nil` provider result
+  /// leaves the static headers unchanged.
   public func headersForExport() -> [(String, String)]? {
-    if let headersProvider {
-      return headersProvider()
+    guard let providerHeaders = headersProvider?() else {
+      return headers
     }
-    return headers
+
+    let providerHeaderNames = Set(providerHeaders.map { $0.0.lowercased() })
+    let retainedStaticHeaders = (headers ?? []).filter {
+      !providerHeaderNames.contains($0.0.lowercased())
+    }
+    return retainedStaticHeaders + providerHeaders
   }
 }

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/OtlpGrpcCallOptions.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/OtlpGrpcCallOptions.swift
@@ -7,6 +7,10 @@ import GRPC
 import NIOHPACK
 import OpenTelemetryProtocolExporterCommon
 
+/// Rebuilds export metadata while preserving the other base call options.
+///
+/// The base options' `customMetadata` is intentionally replaced so dynamic headers are read
+/// immediately before each export.
 func makeOtlpGrpcCallOptions(from baseCallOptions: CallOptions,
                              config: OtlpConfiguration,
                              envVarHeaders: [(String, String)]?,

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/OtlpGrpcCallOptions.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/OtlpGrpcCallOptions.swift
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import GRPC
+import NIOHPACK
+import OpenTelemetryProtocolExporterCommon
+
+func makeOtlpGrpcCallOptions(from baseCallOptions: CallOptions,
+                             config: OtlpConfiguration,
+                             envVarHeaders: [(String, String)]?,
+                             additionalHeaders: [(String, String)] = []) -> CallOptions {
+  var callOptions = baseCallOptions
+  var headers = envVarHeaders ?? config.headersForExport() ?? []
+  headers.append(contentsOf: additionalHeaders)
+  callOptions.customMetadata = HPACKHeaders(headers)
+  return callOptions
+}

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/logs/OtlpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/logs/OtlpLogExporter.swift
@@ -17,6 +17,7 @@ public final class OtlpLogExporter: LogRecordExporter {
   let logClient: Opentelemetry_Proto_Collector_Logs_V1_LogsServiceNIOClient
   let config: OtlpConfiguration
   let callOptions: CallOptions
+  let envVarHeaders: [(String, String)]?
 
   public init(channel: GRPCChannel,
               config: OtlpConfiguration = OtlpConfiguration(),
@@ -25,12 +26,13 @@ public final class OtlpLogExporter: LogRecordExporter {
     self.channel = channel
     logClient = Opentelemetry_Proto_Collector_Logs_V1_LogsServiceNIOClient(channel: channel)
     self.config = config
+    self.envVarHeaders = envVarHeaders
     let userAgentHeader = (Constants.HTTP.userAgent, Headers.getUserAgentHeader())
     if let headers = envVarHeaders {
       var updatedHeaders = headers
       updatedHeaders.append(userAgentHeader)
       callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
-    } else if let headers = config.headers {
+    } else if config.headersProvider == nil, let headers = config.headers {
       var updatedHeaders = headers
       updatedHeaders.append(userAgentHeader)
       callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
@@ -46,7 +48,12 @@ public final class OtlpLogExporter: LogRecordExporter {
       request.resourceLogs = LogRecordAdapter.toProtoResourceRecordLog(logRecordList: logRecords)
     }
     let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
-    var callOptions = callOptions
+    var callOptions = makeOtlpGrpcCallOptions(
+      from: callOptions,
+      config: config,
+      envVarHeaders: envVarHeaders,
+      additionalHeaders: [(Constants.HTTP.userAgent, Headers.getUserAgentHeader())]
+    )
     if timeout > 0 {
       callOptions.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(timeout.toNanoseconds)))
     }

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
@@ -19,7 +19,8 @@ public final class OtlpMetricExporter: MetricExporter {
   let channel: GRPCChannel
   let metricClient: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceNIOClient
   let config: OtlpConfiguration
-  let callOptions: CallOptions?
+  let callOptions: CallOptions
+  let envVarHeaders: [(String, String)]?
   let aggregationTemporalitySelector: AggregationTemporalitySelector
   let defaultAggregationSelector: DefaultAggregationSelector
 
@@ -30,10 +31,11 @@ public final class OtlpMetricExporter: MetricExporter {
     self.aggregationTemporalitySelector = aggregationTemporalitySelector
     self.channel = channel
     self.config = config
+    self.envVarHeaders = envVarHeaders
     metricClient = Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceNIOClient(channel: self.channel)
     if let headers = envVarHeaders {
       callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
-    } else if let headers = config.headers {
+    } else if config.headersProvider == nil, let headers = config.headers {
       callOptions = CallOptions(customMetadata: HPACKHeaders(headers), logger: logger)
     } else {
       callOptions = CallOptions(logger: logger)
@@ -48,6 +50,11 @@ public final class OtlpMetricExporter: MetricExporter {
     if config.timeout > 0 {
         metricClient.defaultCallOptions.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds)))
     }
+    let callOptions = makeOtlpGrpcCallOptions(
+      from: callOptions,
+      config: config,
+      envVarHeaders: envVarHeaders
+    )
     let export = metricClient.export(exportRequest, callOptions: callOptions)
     do {
       _ = try export.response.wait()

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/metric/OtlpMetricExporter.swift
@@ -46,15 +46,14 @@ public final class OtlpMetricExporter: MetricExporter {
     let exportRequest = Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest.with {
       $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(metricData: metrics)
     }
-    var metricClient = self.metricClient
-    if config.timeout > 0 {
-        metricClient.defaultCallOptions.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds)))
-    }
-    let callOptions = makeOtlpGrpcCallOptions(
+    var callOptions = makeOtlpGrpcCallOptions(
       from: callOptions,
       config: config,
       envVarHeaders: envVarHeaders
     )
+    if config.timeout > 0 {
+      callOptions.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(config.timeout.toNanoseconds)))
+    }
     let export = metricClient.export(exportRequest, callOptions: callOptions)
     do {
       _ = try export.response.wait()

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceExporter.swift
@@ -20,17 +20,19 @@ public final class OtlpTraceExporter: SpanExporter, @unchecked Sendable {
   // with the desired timeLimit rather than mutating a shared instance field,
   // so concurrent calls cannot race on `callOptions`.
   let callOptions: CallOptions
+  let envVarHeaders: [(String, String)]?
 
   public init(channel: GRPCChannel, config: OtlpConfiguration = OtlpConfiguration(), logger: Logging.Logger = Logging.Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() }), envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
     self.channel = channel
     traceClient = Opentelemetry_Proto_Collector_Trace_V1_TraceServiceNIOClient(channel: channel)
     self.config = config
+    self.envVarHeaders = envVarHeaders
     let userAgentHeader = (Constants.HTTP.userAgent, Headers.getUserAgentHeader())
     if let headers = envVarHeaders {
       var updatedHeaders = headers
       updatedHeaders.append(userAgentHeader)
       callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
-    } else if let headers = config.headers {
+    } else if config.headersProvider == nil, let headers = config.headers {
       var updatedHeaders = headers
       updatedHeaders.append(userAgentHeader)
       callOptions = CallOptions(customMetadata: HPACKHeaders(updatedHeaders), logger: logger)
@@ -46,7 +48,12 @@ public final class OtlpTraceExporter: SpanExporter, @unchecked Sendable {
       $0.resourceSpans = SpanAdapter.toProtoResourceSpans(spanDataList: spans)
     }
     let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
-    var perCallOptions = callOptions
+    var perCallOptions = makeOtlpGrpcCallOptions(
+      from: callOptions,
+      config: config,
+      envVarHeaders: envVarHeaders,
+      additionalHeaders: [(Constants.HTTP.userAgent, Headers.getUserAgentHeader())]
+    )
     if timeout > 0 {
       perCallOptions.timeLimit = TimeLimit.timeout(TimeAmount.nanoseconds(Int64(timeout.toNanoseconds)))
     }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
@@ -52,12 +52,7 @@ public class OtlpHttpExporterBase: @unchecked Sendable {
   public func createRequest(body: Message, endpoint: URL) -> URLRequest {
     var request = URLRequest(url: endpoint)
 
-    if let headers = envVarHeaders {
-      headers.forEach { key, value in
-        request.addValue(value, forHTTPHeaderField: key)
-      }
-
-    } else if let headers = config.headers {
+    if let headers = envVarHeaders ?? config.headersForExport() {
       headers.forEach { key, value in
         request.addValue(value, forHTTPHeaderField: key)
       }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -109,15 +109,6 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
       var request = createRequest(body: body, endpoint: endpoint)
       let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
       request.timeoutInterval = timeout
-      if let headers = envVarHeaders {
-        headers.forEach { key, value in
-          request.addValue(value, forHTTPHeaderField: key)
-        }
-      } else if let headers = config.headers {
-        headers.forEach { key, value in
-          request.addValue(value, forHTTPHeaderField: key)
-        }
-      }
       httpClient.send(request: request) { [weak self] result in
         switch result {
         case .success:

--- a/Tests/ExportersTests/OpenTelemetryProtocol/MutableHeadersProvider.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/MutableHeadersProvider.swift
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+final class MutableHeadersProvider: @unchecked Sendable {
+  private let lock = NSLock()
+  private var headers: [(String, String)]?
+  private var calls = 0
+
+  init(_ headers: [(String, String)]?) {
+    self.headers = headers
+  }
+
+  func currentHeaders() -> [(String, String)]? {
+    lock.lock()
+    defer { lock.unlock() }
+    calls += 1
+    return headers
+  }
+
+  func update(_ headers: [(String, String)]?) {
+    lock.lock()
+    defer { lock.unlock() }
+    self.headers = headers
+  }
+
+  var callCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return calls
+  }
+}

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
@@ -41,6 +41,51 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
     XCTAssertEqual(request.value(forHTTPHeaderField: "X-Cfg-Header"), "cfg-value")
   }
 
+  func testHeadersProviderIsEvaluatedForEveryRequest() throws {
+    let provider = MutableHeadersProvider([("Authorization", "Bearer first")])
+    let exporter = try OtlpHttpExporterBase(
+      endpoint: XCTUnwrap(URL(string: "http://example.com")),
+      config: OtlpConfiguration(
+        headers: [("Authorization", "Bearer static")],
+        headersProvider: provider.currentHeaders
+      ),
+      httpClient: BaseHTTPClient(),
+      envVarHeaders: nil
+    )
+
+    let firstRequest = try exporter.createRequest(
+      body: makeBody(),
+      endpoint: XCTUnwrap(URL(string: "http://example.com"))
+    )
+    provider.update([("Authorization", "Bearer second")])
+    let secondRequest = try exporter.createRequest(
+      body: makeBody(),
+      endpoint: XCTUnwrap(URL(string: "http://example.com"))
+    )
+
+    XCTAssertEqual(firstRequest.value(forHTTPHeaderField: "Authorization"), "Bearer first")
+    XCTAssertEqual(secondRequest.value(forHTTPHeaderField: "Authorization"), "Bearer second")
+    XCTAssertEqual(provider.callCount, 2)
+  }
+
+  func testEnvVarHeadersTakePrecedenceOverHeadersProvider() throws {
+    let provider = MutableHeadersProvider([("Authorization", "Bearer provider")])
+    let exporter = try OtlpHttpExporterBase(
+      endpoint: XCTUnwrap(URL(string: "http://example.com")),
+      config: OtlpConfiguration(headersProvider: provider.currentHeaders),
+      httpClient: BaseHTTPClient(),
+      envVarHeaders: [("Authorization", "Bearer environment")]
+    )
+
+    let request = try exporter.createRequest(
+      body: makeBody(),
+      endpoint: XCTUnwrap(URL(string: "http://example.com"))
+    )
+
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer environment")
+    XCTAssertEqual(provider.callCount, 0)
+  }
+
   func testContentTypeAndUserAgentSet() {
     let exporter = OtlpHttpExporterBase(
       endpoint: URL(string: "http://example.com")!,

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
@@ -86,6 +86,27 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
     XCTAssertEqual(provider.callCount, 0)
   }
 
+  func testNilHeadersProviderSuppressesStaticHeaders() throws {
+    let provider = MutableHeadersProvider(nil)
+    let exporter = try OtlpHttpExporterBase(
+      endpoint: XCTUnwrap(URL(string: "http://example.com")),
+      config: OtlpConfiguration(
+        headers: [("Authorization", "Bearer static")],
+        headersProvider: provider.currentHeaders
+      ),
+      httpClient: BaseHTTPClient(),
+      envVarHeaders: nil
+    )
+
+    let request = try exporter.createRequest(
+      body: makeBody(),
+      endpoint: XCTUnwrap(URL(string: "http://example.com"))
+    )
+
+    XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    XCTAssertEqual(provider.callCount, 1)
+  }
+
   func testContentTypeAndUserAgentSet() {
     let exporter = OtlpHttpExporterBase(
       endpoint: URL(string: "http://example.com")!,

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
@@ -46,7 +46,10 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
     let exporter = try OtlpHttpExporterBase(
       endpoint: XCTUnwrap(URL(string: "http://example.com")),
       config: OtlpConfiguration(
-        headers: [("Authorization", "Bearer static")],
+        headers: [
+          ("X-Static-Header", "static-value"),
+          ("authorization", "Bearer static")
+        ],
         headersProvider: provider.currentHeaders
       ),
       httpClient: BaseHTTPClient(),
@@ -65,6 +68,8 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
 
     XCTAssertEqual(firstRequest.value(forHTTPHeaderField: "Authorization"), "Bearer first")
     XCTAssertEqual(secondRequest.value(forHTTPHeaderField: "Authorization"), "Bearer second")
+    XCTAssertEqual(firstRequest.value(forHTTPHeaderField: "X-Static-Header"), "static-value")
+    XCTAssertEqual(secondRequest.value(forHTTPHeaderField: "X-Static-Header"), "static-value")
     XCTAssertEqual(provider.callCount, 2)
   }
 
@@ -86,7 +91,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
     XCTAssertEqual(provider.callCount, 0)
   }
 
-  func testNilHeadersProviderSuppressesStaticHeaders() throws {
+  func testNilHeadersProviderRetainsStaticHeaders() throws {
     let provider = MutableHeadersProvider(nil)
     let exporter = try OtlpHttpExporterBase(
       endpoint: XCTUnwrap(URL(string: "http://example.com")),
@@ -103,7 +108,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
       endpoint: XCTUnwrap(URL(string: "http://example.com"))
     )
 
-    XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer static")
     XCTAssertEqual(provider.callCount, 1)
   }
 

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -158,10 +158,7 @@ final class OtlpHttpLogExporterCoverageTests: XCTestCase {
       envVarHeaders: [("X-Test", "value")])
     _ = exporter.export(logRecords: [sampleLogRecord()])
     _ = exporter.flush()
-    // Header may be appended twice (export + flush); accept either "value" or
-    // the comma-joined duplicate form that URLRequest produces on addValue.
-    let header = client.sentRequests.last?.value(forHTTPHeaderField: "X-Test") ?? ""
-    XCTAssertTrue(header.contains("value"))
+    XCTAssertEqual(client.sentRequests.last?.value(forHTTPHeaderField: "X-Test"), "value")
   }
 
   func testFlushWithConfigHeadersAppliesHeaders() {
@@ -170,8 +167,25 @@ final class OtlpHttpLogExporterCoverageTests: XCTestCase {
     let exporter = OtlpHttpLogExporter(config: config, httpClient: client, envVarHeaders: nil)
     _ = exporter.export(logRecords: [sampleLogRecord()])
     _ = exporter.flush()
-    let header = client.sentRequests.last?.value(forHTTPHeaderField: "X-Config") ?? ""
-    XCTAssertTrue(header.contains("c-value"))
+    XCTAssertEqual(client.sentRequests.last?.value(forHTTPHeaderField: "X-Config"), "c-value")
+  }
+
+  func testFlushRefreshesHeadersProvider() {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError()), .success])
+    let provider = MutableHeadersProvider([("Authorization", "Bearer first")])
+    let exporter = OtlpHttpLogExporter(
+      config: OtlpConfiguration(headersProvider: provider.currentHeaders),
+      httpClient: client,
+      envVarHeaders: nil
+    )
+
+    _ = exporter.export(logRecords: [sampleLogRecord()])
+    provider.update([("Authorization", "Bearer second")])
+    XCTAssertEqual(exporter.flush(), .success)
+
+    XCTAssertEqual(client.sentRequests[0].value(forHTTPHeaderField: "Authorization"), "Bearer first")
+    XCTAssertEqual(client.sentRequests[1].value(forHTTPHeaderField: "Authorization"), "Bearer second")
+    XCTAssertEqual(provider.callCount, 2)
   }
 
   func testFlushFailureAfterRetryReturnsFailure() {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpLogRecordExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpLogRecordExporterTests.swift
@@ -109,6 +109,31 @@ class OtlpLogRecordExporterTests: XCTestCase {
     XCTAssertEqual("BAR", exporter.callOptions.customMetadata.first(name: "FOO"))
   }
 
+  func testHeadersProviderIsEvaluatedForEveryExport() {
+    let provider = MutableHeadersProvider([("authorization", "Bearer first")])
+    let exporter = OtlpLogExporter(
+      channel: channel,
+      config: OtlpConfiguration(headersProvider: provider.currentHeaders),
+      envVarHeaders: nil
+    )
+    defer { exporter.shutdown() }
+    let logRecord = ReadableLogRecord(resource: Resource(),
+                                      instrumentationScopeInfo: InstrumentationScopeInfo(name: "scope"),
+                                      timestamp: Date(),
+                                      observedTimestamp: Date.distantPast,
+                                      spanContext: spanContext,
+                                      severity: .info,
+                                      body: AttributeValue.string("message"),
+                                      attributes: [:])
+
+    XCTAssertEqual(exporter.export(logRecords: [logRecord]), .success)
+    provider.update([("authorization", "Bearer second")])
+    XCTAssertEqual(exporter.export(logRecords: [logRecord]), .success)
+
+    XCTAssertEqual(fakeCollector.receivedAuthorizationHeaders, ["Bearer first", "Bearer second"])
+    XCTAssertEqual(provider.callCount, 2)
+  }
+
   func testExportAfterShutdown() {
     let logRecord = ReadableLogRecord(resource: Resource(),
                                       instrumentationScopeInfo: InstrumentationScopeInfo(name: "scope"),
@@ -147,6 +172,7 @@ class FakeLogCollector: Opentelemetry_Proto_Collector_Logs_V1_LogsServiceProvide
 
   func export(request: Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest, context: GRPC.StatusOnlyCallContext) -> NIOCore.EventLoopFuture<Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse> {
     receivedLogs.append(contentsOf: request.resourceLogs)
+    receivedAuthorizationHeaders.append(context.headers.first(name: "authorization"))
     if returnedStatus != GRPCStatus.ok {
       return context.eventLoop.makeFailedFuture(returnedStatus)
     }
@@ -154,5 +180,6 @@ class FakeLogCollector: Opentelemetry_Proto_Collector_Logs_V1_LogsServiceProvide
   }
 
   var receivedLogs = [Opentelemetry_Proto_Logs_V1_ResourceLogs]()
+  var receivedAuthorizationHeaders = [String?]()
   var returnedStatus = GRPCStatus.ok
 }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterCoverageTests.swift
@@ -83,7 +83,7 @@ final class OtlpMetricExporterCoverageTests: XCTestCase {
       channel: channel,
       config: OtlpConfiguration(headers: [("x-k", "x-v")]),
       envVarHeaders: nil)
-    XCTAssertTrue(exporter.callOptions?.customMetadata.contains(name: "x-k") ?? false)
+    XCTAssertTrue(exporter.callOptions.customMetadata.contains(name: "x-k"))
     _ = exporter.shutdown()
   }
 
@@ -91,8 +91,25 @@ final class OtlpMetricExporterCoverageTests: XCTestCase {
     let exporter = OtlpMetricExporter(
       channel: channel,
       envVarHeaders: [("x-env", "v")])
-    XCTAssertTrue(exporter.callOptions?.customMetadata.contains(name: "x-env") ?? false)
+    XCTAssertTrue(exporter.callOptions.customMetadata.contains(name: "x-env"))
     _ = exporter.shutdown()
+  }
+
+  func testHeadersProviderIsEvaluatedForEveryExport() {
+    let provider = MutableHeadersProvider([("authorization", "Bearer first")])
+    let exporter = OtlpMetricExporter(
+      channel: channel,
+      config: OtlpConfiguration(headersProvider: provider.currentHeaders),
+      envVarHeaders: nil
+    )
+    defer { _ = exporter.shutdown() }
+
+    XCTAssertEqual(exporter.export(metrics: [sampleMetric()]), .success)
+    provider.update([("authorization", "Bearer second")])
+    XCTAssertEqual(exporter.export(metrics: [sampleMetric()]), .success)
+
+    XCTAssertEqual(fakeCollector.receivedAuthorizationHeaders, ["Bearer first", "Bearer second"])
+    XCTAssertEqual(provider.callCount, 2)
   }
 
   func testGetAggregationTemporalityReturnsConfigured() {
@@ -115,12 +132,14 @@ final class OtlpMetricExporterCoverageTests: XCTestCase {
 
 private final class FakeMetricCollector: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceProvider, @unchecked Sendable {
   var receivedMetrics = [Opentelemetry_Proto_Metrics_V1_ResourceMetrics]()
+  var receivedAuthorizationHeaders = [String?]()
   var returnedStatus = GRPCStatus.ok
   var interceptors: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceServerInterceptorFactoryProtocol?
 
   func export(request: Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest,
               context: StatusOnlyCallContext) -> EventLoopFuture<Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse> {
     receivedMetrics.append(contentsOf: request.resourceMetrics)
+    receivedAuthorizationHeaders.append(context.headers.first(name: "authorization"))
     if returnedStatus != GRPCStatus.ok {
       return context.eventLoop.makeFailedFuture(returnedStatus)
     }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpMetricExporterCoverageTests.swift
@@ -71,10 +71,12 @@ final class OtlpMetricExporterCoverageTests: XCTestCase {
   }
 
   func testExportAppliesTimeout() {
+    fakeCollector.responseDelay = .milliseconds(100)
     let exporter = OtlpMetricExporter(
       channel: channel,
-      config: OtlpConfiguration(timeout: 5))
-    XCTAssertEqual(exporter.export(metrics: [sampleMetric()]), .success)
+      config: OtlpConfiguration(timeout: 0.01))
+
+    XCTAssertEqual(exporter.export(metrics: [sampleMetric()]), .failure)
     _ = exporter.shutdown()
   }
 
@@ -134,6 +136,7 @@ private final class FakeMetricCollector: Opentelemetry_Proto_Collector_Metrics_V
   var receivedMetrics = [Opentelemetry_Proto_Metrics_V1_ResourceMetrics]()
   var receivedAuthorizationHeaders = [String?]()
   var returnedStatus = GRPCStatus.ok
+  var responseDelay: TimeAmount?
   var interceptors: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceServerInterceptorFactoryProtocol?
 
   func export(request: Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest,
@@ -143,6 +146,10 @@ private final class FakeMetricCollector: Opentelemetry_Proto_Collector_Metrics_V
     if returnedStatus != GRPCStatus.ok {
       return context.eventLoop.makeFailedFuture(returnedStatus)
     }
-    return context.eventLoop.makeSucceededFuture(Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse())
+    let response = Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse()
+    if let responseDelay {
+      return context.eventLoop.scheduleTask(in: responseDelay) { response }.futureResult
+    }
+    return context.eventLoop.makeSucceededFuture(response)
   }
 }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -98,6 +98,19 @@ class OtlpTraceExporterTests: XCTestCase {
     verifyUserAgentIsSet(exporter: exporter)
   }
 
+  func testStaticConfigHeadersReachCollector() {
+    let exporter = OtlpTraceExporter(
+      channel: channel,
+      config: OtlpConfiguration(headers: [("authorization", "Bearer static")]),
+      envVarHeaders: nil
+    )
+    defer { exporter.shutdown() }
+
+    XCTAssertEqual(exporter.export(spans: [generateFakeSpan()]), .success)
+
+    XCTAssertEqual(fakeCollector.receivedAuthorizationHeaders, ["Bearer static"])
+  }
+
   func testHeadersProviderIsEvaluatedForEveryExport() {
     let provider = MutableHeadersProvider([("authorization", "Bearer first")])
     let exporter = OtlpTraceExporter(

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -115,7 +115,13 @@ class OtlpTraceExporterTests: XCTestCase {
     let provider = MutableHeadersProvider([("authorization", "Bearer first")])
     let exporter = OtlpTraceExporter(
       channel: channel,
-      config: OtlpConfiguration(headersProvider: provider.currentHeaders),
+      config: OtlpConfiguration(
+        headers: [
+          ("x-static-header", "static-value"),
+          ("Authorization", "Bearer static")
+        ],
+        headersProvider: provider.currentHeaders
+      ),
       envVarHeaders: nil
     )
     defer { exporter.shutdown() }
@@ -125,6 +131,7 @@ class OtlpTraceExporterTests: XCTestCase {
     XCTAssertEqual(exporter.export(spans: [generateFakeSpan()]), .success)
 
     XCTAssertEqual(fakeCollector.receivedAuthorizationHeaders, ["Bearer first", "Bearer second"])
+    XCTAssertEqual(fakeCollector.receivedStaticHeaders, ["static-value", "static-value"])
     XCTAssertEqual(fakeCollector.receivedUserAgentHeaders, [
       Headers.getUserAgentHeader(),
       Headers.getUserAgentHeader()
@@ -318,6 +325,7 @@ private final class FeedbackRecorder: @unchecked Sendable {
 class FakeCollector: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceProvider {
   var receivedSpans = [Opentelemetry_Proto_Trace_V1_ResourceSpans]()
   var receivedAuthorizationHeaders = [String?]()
+  var receivedStaticHeaders = [String?]()
   var receivedUserAgentHeaders = [String?]()
   var returnedStatus = GRPCStatus.ok
   var returnedResponse = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse()
@@ -326,6 +334,7 @@ class FakeCollector: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceProvider
   func export(request: Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse> {
     receivedSpans.append(contentsOf: request.resourceSpans)
     receivedAuthorizationHeaders.append(context.headers.first(name: "authorization"))
+    receivedStaticHeaders.append(context.headers.first(name: "x-static-header"))
     receivedUserAgentHeaders.append(context.headers.first(name: Constants.HTTP.userAgent))
     if returnedStatus != GRPCStatus.ok {
       return context.eventLoop.makeFailedFuture(returnedStatus)

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceExporterTests.swift
@@ -98,6 +98,42 @@ class OtlpTraceExporterTests: XCTestCase {
     verifyUserAgentIsSet(exporter: exporter)
   }
 
+  func testHeadersProviderIsEvaluatedForEveryExport() {
+    let provider = MutableHeadersProvider([("authorization", "Bearer first")])
+    let exporter = OtlpTraceExporter(
+      channel: channel,
+      config: OtlpConfiguration(headersProvider: provider.currentHeaders),
+      envVarHeaders: nil
+    )
+    defer { exporter.shutdown() }
+
+    XCTAssertEqual(exporter.export(spans: [generateFakeSpan()]), .success)
+    provider.update([("authorization", "Bearer second")])
+    XCTAssertEqual(exporter.export(spans: [generateFakeSpan()]), .success)
+
+    XCTAssertEqual(fakeCollector.receivedAuthorizationHeaders, ["Bearer first", "Bearer second"])
+    XCTAssertEqual(fakeCollector.receivedUserAgentHeaders, [
+      Headers.getUserAgentHeader(),
+      Headers.getUserAgentHeader()
+    ])
+    XCTAssertEqual(provider.callCount, 2)
+  }
+
+  func testEnvVarHeadersTakePrecedenceOverHeadersProvider() {
+    let provider = MutableHeadersProvider([("authorization", "Bearer provider")])
+    let exporter = OtlpTraceExporter(
+      channel: channel,
+      config: OtlpConfiguration(headersProvider: provider.currentHeaders),
+      envVarHeaders: [("authorization", "Bearer environment")]
+    )
+    defer { exporter.shutdown() }
+
+    XCTAssertEqual(exporter.export(spans: [generateFakeSpan()]), .success)
+
+    XCTAssertEqual(fakeCollector.receivedAuthorizationHeaders, ["Bearer environment"])
+    XCTAssertEqual(provider.callCount, 0)
+  }
+
   func testExportMultipleSpans() {
     var spans = [SpanData]()
     for _ in 0 ..< 10 {
@@ -268,12 +304,16 @@ private final class FeedbackRecorder: @unchecked Sendable {
 
 class FakeCollector: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceProvider {
   var receivedSpans = [Opentelemetry_Proto_Trace_V1_ResourceSpans]()
+  var receivedAuthorizationHeaders = [String?]()
+  var receivedUserAgentHeaders = [String?]()
   var returnedStatus = GRPCStatus.ok
   var returnedResponse = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse()
   var interceptors: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceServerInterceptorFactoryProtocol?
 
   func export(request: Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse> {
     receivedSpans.append(contentsOf: request.resourceSpans)
+    receivedAuthorizationHeaders.append(context.headers.first(name: "authorization"))
+    receivedUserAgentHeaders.append(context.headers.first(name: Constants.HTTP.userAgent))
     if returnedStatus != GRPCStatus.ok {
       return context.eventLoop.makeFailedFuture(returnedStatus)
     }


### PR DESCRIPTION
Closes #651

Added an optional headers provider to `OtlpConfiguration` so expiring auth tokens can be refreshed without rebuilding exporters. It is evaluated for each HTTP and gRPC export while preserving static and environment header behavior.

Also:
- Fixes duplicate headers when retrying HTTP log exports.
- Enforces `config.timeout` for gRPC metric exports, which was previously ignored.