### PR TITLE
fix(persistence): remove unnecessary throws from decorator inits

### DIFF
--- a/Sources/Exporters/Persistence/PersistenceLogExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceLogExporterDecorator.swift
@@ -31,7 +31,7 @@ public final class PersistenceLogExporterDecorator: LogRecordExporter {
   public init(logRecordExporter: LogRecordExporter,
               storageURL: URL,
               exportCondition: @escaping @Sendable () -> Bool = { true },
-              performancePreset: PersistencePerformancePreset = .default) throws {
+              performancePreset: PersistencePerformancePreset = .default) {
     persistenceExporter =
       PersistenceExporterDecorator<LogRecordDecoratedExporter>(decoratedExporter: LogRecordDecoratedExporter(
         logRecordExporter: logRecordExporter),

--- a/Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift
@@ -31,7 +31,7 @@ public final class PersistenceMetricExporterDecorator: MetricExporter {
   public init(metricExporter: MetricExporter,
               storageURL: URL,
               exportCondition: @escaping @Sendable () -> Bool = { true },
-              performancePreset: PersistencePerformancePreset = .default) throws {
+              performancePreset: PersistencePerformancePreset = .default) {
     persistenceExporter =
       PersistenceExporterDecorator<MetricDecoratedExporter>(decoratedExporter: MetricDecoratedExporter(
         metricExporter: metricExporter),

--- a/Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift
@@ -31,7 +31,7 @@ public final class PersistenceSpanExporterDecorator: SpanExporter, @unchecked Se
   public init(spanExporter: SpanExporter,
               storageURL: URL,
               exportCondition: @escaping @Sendable () -> Bool = { true },
-              performancePreset: PersistencePerformancePreset = .default) throws {
+              performancePreset: PersistencePerformancePreset = .default) {
     self.spanExporter = spanExporter
 
     persistenceExporter =

--- a/Sources/Exporters/Persistence/README.md
+++ b/Sources/Exporters/Persistence/README.md
@@ -15,7 +15,7 @@ An example of decorating a `MetricExporter`:
 
 ```swift
 let metricExporter = ... // create some MetricExporter
-let persistenceMetricExporter = try PersistenceMetricExporterDecorator(
+let persistenceMetricExporter = PersistenceMetricExporterDecorator(
   metricExporter: metricExporter,
   storageURL: metricsSubdirectoryURL)
 ```
@@ -24,7 +24,7 @@ An example of decorating a `SpanExporter`:
 
 ```swift
 let spanExporter = ... // create some SpanExporter
-let persistenceTraceExporter = try PersistenceSpanExporterDecorator(
+let persistenceTraceExporter = PersistenceSpanExporterDecorator(
   spanExporter: spanExporter,
   storageURL: tracesSubdirectoryURL)
 ```

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceLogExporterDecoratorCoverageTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceLogExporterDecoratorCoverageTests.swift
@@ -49,7 +49,7 @@ final class PersistenceLogExporterDecoratorCoverageTests: XCTestCase {
                       attributes: [:])
   }
 
-  func testExportDelegatesToPersistenceExporter() throws {
+  func testExportDelegatesToPersistenceExporter() {
     let exportExpectation = expectation(description: "log record forwarded")
     exportExpectation.assertForOverFulfill = false
 
@@ -60,7 +60,7 @@ final class PersistenceLogExporterDecoratorCoverageTests: XCTestCase {
       return .success
     }
 
-    let decorator = try PersistenceLogExporterDecorator(
+    let decorator = PersistenceLogExporterDecorator(
       logRecordExporter: inner,
       storageURL: temporaryDirectory.url,
       exportCondition: { true },
@@ -75,18 +75,18 @@ final class PersistenceLogExporterDecoratorCoverageTests: XCTestCase {
     wait(for: [exportExpectation], timeout: 5)
   }
 
-  func testShutdownFlushesAndCallsInner() throws {
+  func testShutdownFlushesAndCallsInner() {
     let inner = LogExporterMock()
-    let decorator = try PersistenceLogExporterDecorator(
+    let decorator = PersistenceLogExporterDecorator(
       logRecordExporter: inner,
       storageURL: temporaryDirectory.url)
     decorator.shutdown()
     XCTAssertTrue(inner.shutdownCalled)
   }
 
-  func testForceFlushFlushesAndCallsInner() throws {
+  func testForceFlushFlushesAndCallsInner() {
     let inner = LogExporterMock()
-    let decorator = try PersistenceLogExporterDecorator(
+    let decorator = PersistenceLogExporterDecorator(
       logRecordExporter: inner,
       storageURL: temporaryDirectory.url)
     let result = decorator.forceFlush()

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceMetricExporterDecoratorTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceMetricExporterDecoratorTests.swift
@@ -44,7 +44,7 @@ class PersistenceMetricExporterDecoratorTests: XCTestCase {
     super.tearDown()
   }
 
-  func testWhenExportMetricIsCalled_thenMetricsAreExported() throws {
+  func testWhenExportMetricIsCalled_thenMetricsAreExported() {
     let metricsExportExpectation = expectation(description: "metrics exported")
     let mockMetricExporter = MetricExporterMock(onExport: { metrics in
       metrics.forEach { metric in
@@ -60,12 +60,12 @@ class PersistenceMetricExporterDecoratorTests: XCTestCase {
     })
 
     let persistenceMetricExporter =
-      try PersistenceMetricExporterDecorator(metricExporter: mockMetricExporter,
-                                             storageURL: temporaryDirectory.url,
-                                             exportCondition: { return true },
-                                             performancePreset: PersistencePerformancePreset.mockWith(storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,
-                                                                                                      synchronousWrite: true,
-                                                                                                      exportPerformance: ExportPerformanceMock.veryQuick))
+      PersistenceMetricExporterDecorator(metricExporter: mockMetricExporter,
+                                         storageURL: temporaryDirectory.url,
+                                         exportCondition: { return true },
+                                         performancePreset: PersistencePerformancePreset.mockWith(storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,
+                                                                                                synchronousWrite: true,
+                                                                                                exportPerformance: ExportPerformanceMock.veryQuick))
 
     let provider = MeterProviderSdk.builder().registerMetricReader(
       reader: PeriodicMetricReaderBuilder(

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceSpanExporterDecoratorTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceSpanExporterDecoratorTests.swift
@@ -47,7 +47,7 @@ class PersistenceSpanExporterDecoratorTests: XCTestCase {
     super.tearDown()
   }
 
-  func testWhenExportSpansIsCalled_thenSpansAreExported() throws {
+  func testWhenExportSpansIsCalled_thenSpansAreExported() {
     let spansExportExpectation = expectation(description: "spans exported")
     let exporterShutdownExpectation = expectation(description: "exporter shut down")
 
@@ -66,12 +66,12 @@ class PersistenceSpanExporterDecoratorTests: XCTestCase {
     })
 
     let persistenceSpanExporter =
-      try PersistenceSpanExporterDecorator(spanExporter: mockSpanExporter,
-                                           storageURL: temporaryDirectory.url,
-                                           exportCondition: { true },
-                                           performancePreset: PersistencePerformancePreset.mockWith(storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,
-                                                                                                    synchronousWrite: true,
-                                                                                                    exportPerformance: ExportPerformanceMock.veryQuick))
+      PersistenceSpanExporterDecorator(spanExporter: mockSpanExporter,
+                                       storageURL: temporaryDirectory.url,
+                                       exportCondition: { true },
+                                       performancePreset: PersistencePerformancePreset.mockWith(storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,
+                                                                                            synchronousWrite: true,
+                                                                                            exportPerformance: ExportPerformanceMock.veryQuick))
 
     let instrumentationScopeName = "SimpleExporter"
     let instrumentationScopeVersion = "semver:0.1.0"
@@ -88,7 +88,7 @@ class PersistenceSpanExporterDecoratorTests: XCTestCase {
     wait(for: [spansExportExpectation, exporterShutdownExpectation], timeout: 10)
   }
 
-  func testWhenExportFails_thenSpansAreRetried() throws {
+  func testWhenExportFails_thenSpansAreRetried() {
     let exportAttemptsLock = NSLock()
     nonisolated(unsafe) var exportAttempts = 0
     let firstExportExpectation = expectation(description: "first export attempt")
@@ -110,12 +110,12 @@ class PersistenceSpanExporterDecoratorTests: XCTestCase {
     })
 
     let persistenceSpanExporter =
-      try PersistenceSpanExporterDecorator(spanExporter: mockSpanExporter,
-                                           storageURL: temporaryDirectory.url,
-                                           exportCondition: { true },
-                                           performancePreset: PersistencePerformancePreset.mockWith(storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,
-                                                                                                    synchronousWrite: true,
-                                                                                                    exportPerformance: ExportPerformanceMock.veryQuick))
+      PersistenceSpanExporterDecorator(spanExporter: mockSpanExporter,
+                                       storageURL: temporaryDirectory.url,
+                                       exportCondition: { true },
+                                       performancePreset: PersistencePerformancePreset.mockWith(storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,
+                                                                                            synchronousWrite: true,
+                                                                                            exportPerformance: ExportPerformanceMock.veryQuick))
 
     let instrumentationScopeName = "RetryExporter"
     let instrumentationScopeVersion = "semver:0.1.0"


### PR DESCRIPTION
## Summary

- Remove `throws` from `PersistenceSpanExporterDecorator`, `PersistenceMetricExporterDecorator`, and `PersistenceLogExporterDecorator` initializers because they won't fail 
- Update tests and README examples to drop unnecessary `try`.

## Test plan

- [x] `swift build --build-tests`
- [x] `swift test --filter PersistenceSpanExporterDecoratorTests`
- [x] `swift test --filter PersistenceMetricExporterDecoratorTests`
- [x] `swift test --filter PersistenceLogExporterDecoratorCoverageTests`

<details>
<summary>API impact</summary>

Source-compatible: callers that still use `try` on these inits will compile.
<img width="819" height="159" alt="Screenshot 2026-08-17 at 22 16 31" src="https://github.com/user-attachments/assets/41713df1-9356-4f4d-80ea-569ed59462c2" />


</details>