### PR TITLE
Fix link format in Example Network Sample README.md

### DIFF
--- a/Examples/Network Sample/README.md
+++ b/Examples/Network Sample/README.md
@@ -1,4 +1,4 @@
 ### Network sample
 
 This example shows the `URLSessionInstrumentation` in action. 
-It only shows the minimum configuration: Just by initializing the class, all network request that happen after it will be captured by Opentelemetry as Spans. Check [`URLSessionInstrumentation` README](Sources/Instrumentation/URLSession/README.md) for more information.
+It only shows the minimum configuration: Just by initializing the class, all network request that happen after it will be captured by Opentelemetry as Spans. Check [`URLSessionInstrumentation` README](/Sources/Instrumentation/URLSession/README.md) for more information.


### PR DESCRIPTION
The Link was pointing to a dead end, fixed it to point to the correct Readme.