### PR TITLE
fix(URLSession): honour shouldRecordPayload on the completion handler paths

### DIFF
--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -353,13 +353,16 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
           if completionBlock != nil {
             if objc_getAssociatedObject(argument, &idKey) == nil {
               let completionWrapper: (Any?, URLResponse?, Error?) -> Void = { object, response, error in
+                // Payload recording is opt-in and off by default. The caller still receives
+                // `object` below; only what is handed to the telemetry callbacks is withheld.
+                let payload = (self.configuration.shouldRecordPayload?(session) ?? false) ? object : nil
                 if error != nil {
                   let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-                  URLSessionLogger.logError(error!, dataOrFile: object, statusCode: status,
+                  URLSessionLogger.logError(error!, dataOrFile: payload, statusCode: status,
                                             instrumentation: self, sessionTaskId: sessionTaskId)
                 } else {
                   if let response {
-                    URLSessionLogger.logResponse(response, dataOrFile: object, instrumentation: self,
+                    URLSessionLogger.logResponse(response, dataOrFile: payload, instrumentation: self,
                                                  sessionTaskId: sessionTaskId)
                   }
                 }
@@ -422,13 +425,16 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
           var completionBlock = completion
           if objc_getAssociatedObject(argument, &idKey) == nil {
             let completionWrapper: (Any?, URLResponse?, Error?) -> Void = { object, response, error in
+              // Payload recording is opt-in and off by default. The caller still receives
+              // `object` below; only what is handed to the telemetry callbacks is withheld.
+              let payload = (self.configuration.shouldRecordPayload?(session) ?? false) ? object : nil
               if error != nil {
                 let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-                URLSessionLogger.logError(error!, dataOrFile: object, statusCode: status,
+                URLSessionLogger.logError(error!, dataOrFile: payload, statusCode: status,
                                           instrumentation: self, sessionTaskId: sessionTaskId)
               } else {
                 if let response {
-                  URLSessionLogger.logResponse(response, dataOrFile: object, instrumentation: self,
+                  URLSessionLogger.logResponse(response, dataOrFile: payload, instrumentation: self,
                                                sessionTaskId: sessionTaskId)
                 }
               }

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -62,8 +62,15 @@ public struct URLSessionInstrumentationConfiguration {
   /// Implement this callback to filter which requests you want to instrument, all by default
   public var shouldInstrument: ((URLRequest) -> (Bool)?)?
 
-  /// Implement this callback if you want the session to record payload data, false by default.
-  /// This callback is only necessary when using session delegate
+  /// Implement this callback if you want the instrumentation to record payload data, false by
+  /// default.
+  ///
+  /// It is the opt-in gate for the payload passed as `dataOrFile` to `receivedResponse` and
+  /// `receivedError`, on the session delegate and completion handler paths alike. Returning `false`,
+  /// or leaving this unimplemented, means those callbacks receive `nil` instead of the body.
+  ///
+  /// This does not affect the data delivered to the caller: a completion handler passed to
+  /// `dataTask(with:completionHandler:)` always receives its own data unchanged.
   public var shouldRecordPayload: ((URLSession) -> (Bool)?)?
 
   /// Implement this callback to filter which requests you want to inject headers to follow the trace,

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -64,6 +64,8 @@ class URLSessionInstrumentationTests: XCTestCase {
     }
   }
 
+  nonisolated(unsafe) static var receivedDataOrFile: Any?
+
   nonisolated(unsafe) static var requestCopy: URLRequest!
   nonisolated(unsafe) static var responseCopy: HTTPURLResponse!
 
@@ -101,8 +103,9 @@ class URLSessionInstrumentationTests: XCTestCase {
                                                                requestCopy = request
                                                                checker.createdRequestCalled = true
                                                              },
-                                                             receivedResponse: { response, _, _ in
+                                                             receivedResponse: { response, dataOrFile, _ in
                                                                responseCopy = response as? HTTPURLResponse
+                                                               receivedDataOrFile = dataOrFile
                                                                checker.receivedResponseCalled = true
                                                              },
                                                              receivedError: { _, _, _, _ in
@@ -158,6 +161,7 @@ class URLSessionInstrumentationTests: XCTestCase {
     sessionDelegate = SessionDelegate(semaphore: URLSessionInstrumentationTests.semaphore)
     URLSessionInstrumentationTests.requestCopy = nil
     URLSessionInstrumentationTests.responseCopy = nil
+    URLSessionInstrumentationTests.receivedDataOrFile = nil
     XCTAssertEqual(0, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
     URLSessionInstrumentationTests.instrumentation.configuration.semanticConvention = .old
   }
@@ -1106,4 +1110,25 @@ class URLSessionInstrumentationTests: XCTestCase {
     // The test passes if tasks completes without crashing.
     wait { task.state == .completed }
   }
+
+  /// `shouldRecordPayload` defaults to off and the session-delegate path honours it, but the
+  /// completion handler path handed the response body to `receivedResponse` regardless. An app that
+  /// never opted in still received response bodies in its telemetry callback.
+  public func testCompletionHandlerHonoursShouldRecordPayload() {
+    let url = URL(string: "http://localhost:33333/success")!
+    nonisolated(unsafe) var callerReceivedBody: Data?
+
+    let task = URLSession.shared.dataTask(with: URLRequest(url: url)) { data, _, _ in
+      callerReceivedBody = data
+      URLSessionInstrumentationTests.semaphore.signal()
+    }
+    task.resume()
+    URLSessionInstrumentationTests.semaphore.wait()
+
+    XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled)
+    XCTAssertNotNil(callerReceivedBody, "the caller's completion handler must still get its data")
+    XCTAssertNil(URLSessionInstrumentationTests.receivedDataOrFile,
+                 "payload recording is disabled, so no body should reach receivedResponse")
+  }
+
 }


### PR DESCRIPTION
## Problem

`shouldRecordPayload` is opt-in and defaults to **off**. The session delegate path respects that — `urlSession(_:dataTask:didReceive:)` and `urlSession(_:dataTask:didReceive:completionHandler:)` both guard on it before accumulating anything.

The completion handler paths do not. Both wrappers in `injectIntoNSURLSessionAsyncDataAndDownloadTaskMethods` pass the response object straight through:

```swift
URLSessionLogger.logResponse(response, dataOrFile: object, ...)
URLSessionLogger.logError(error!, dataOrFile: object, ...)
```

`dataOrFile` is handed to the `receivedResponse` / `receivedError` callbacks. So an application that never enabled payload recording still has response bodies delivered into its telemetry callbacks for every `dataTask(with:completionHandler:)` request — and those callbacks exist to attach information to spans, which is where it would end up.

## Fix

Withhold the payload from the telemetry callbacks unless recording is enabled:

```swift
let payload = (self.configuration.shouldRecordPayload?(session) ?? false) ? object : nil
```

The caller's own completion handler still receives `object` unchanged — only what reaches the instrumentation callbacks is gated. Applied to both wrappers.

## Question for maintainers

The documentation on `shouldRecordPayload` says *"This callback is only necessary when using session delegate"*, so the current behaviour may be intentional rather than an oversight. I think it is worth changing regardless: an option that reads as "payload recording is off by default" not applying to two of the three capture paths is surprising, and it is the kind of surprise that matters because the data involved is response bodies.

That said, this **is** a behaviour change — anyone currently relying on bodies arriving without setting the predicate would stop receiving them. If you would rather keep that and correct the documentation instead, say so and I will turn this into a docs PR.

## Tests

`testCompletionHandlerHonoursShouldRecordPayload` asserts that with recording disabled the caller's completion handler still receives its data while `receivedResponse` receives `nil`. It fails on unmodified `main`, where a `Data` instance arrives despite recording being off.

The test uses the existing `/success` route, whose body is empty — enough to show the path is ungated, since an empty `Data` still arrives where `nil` is expected. Note that no route in `HttpTestServer` returns a non-empty body, which is why payload behaviour has had no coverage until now. Adding one seemed out of scope here, but it is worth doing separately.

Full `URLSessionInstrumentationTests` suite: 58 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
