### PR TITLE
fix(URLSession): end the span for tasks nothing else reports

### DIFF
--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -25,6 +25,7 @@ struct NetworkRequestState {
 }
 
 nonisolated(unsafe) private var idKey: Void?
+nonisolated(unsafe) private var completionHandlerKey: Void?
 
 public final class URLSessionInstrumentation: @unchecked Sendable {
   private var requestMap = [String: NetworkRequestState]()
@@ -133,6 +134,7 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
     injectIntoNSURLSessionAsyncDataAndDownloadTaskMethods()
     injectIntoNSURLSessionAsyncUploadTaskMethods()
     injectIntoNSURLSessionTaskResume()
+    injectIntoNSURLSessionTaskSetState()
   }
 
   private func injectIntoDelegateClass(cls: AnyClass) {
@@ -387,6 +389,9 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
             }
           }
           self.setIdKey(value: sessionTaskId, for: task)
+          if completionBlock != nil {
+            self.markHasCompletionHandler(task)
+          }
           return task
         }
       let swizzledIMP = imp_implementationWithBlock(
@@ -447,6 +452,9 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
                            completionBlock)
 
           self.setIdKey(value: sessionTaskId, for: task)
+          if completionBlock != nil {
+            self.markHasCompletionHandler(task)
+          }
           return task
         }
       let swizzledIMP = imp_implementationWithBlock(
@@ -856,6 +864,75 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
       objc_setAssociatedObject(task, &idKey, id, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
     return id!
+  }
+
+  /// Marks a task whose completion handler reports the response itself, so the setState fallback
+  /// does not report it a second time with less data than the handler has.
+  private func markHasCompletionHandler(_ task: URLSessionTask) {
+    objc_setAssociatedObject(task, &completionHandlerKey, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+  }
+
+  /// Reports completion for tasks that nothing else reports.
+  ///
+  /// A task with no session delegate and no completion handler has its span started by the factory
+  /// swizzle and then never ended, because there is nothing left to observe its completion. Third
+  /// party networking layers hit the same gap. `setState:` is the one place every task passes
+  /// through on its way to `.completed`.
+  private func injectIntoNSURLSessionTaskSetState() {
+    typealias SetStateIMP = @convention(c) (AnyObject, Selector, URLSessionTask.State) -> Void
+    let selector = NSSelectorFromString("setState:")
+
+    var classesToSwizzle = [AnyClass]()
+    if class_getInstanceMethod(URLSessionTask.self, selector) != nil {
+      classesToSwizzle.append(URLSessionTask.self)
+    }
+    if let cfTask = NSClassFromString("__NSCFURLSessionTask"),
+       class_getInstanceMethod(cfTask, selector) != nil {
+      classesToSwizzle.append(cfTask)
+    }
+
+    classesToSwizzle.forEach { cls in
+      guard let method = class_getInstanceMethod(cls, selector) else {
+        return
+      }
+      let originalIMP = method_getImplementation(method)
+
+      let block: @convention(block) (AnyObject, URLSessionTask.State) -> Void = { anyTask, state in
+        unsafeBitCast(originalIMP, to: SetStateIMP.self)(anyTask, selector, state)
+
+        guard state == .completed, let task = anyTask as? URLSessionTask else {
+          return
+        }
+        self.reportCompletionIfUnreported(task)
+      }
+      let swizzledIMP = imp_implementationWithBlock(
+        unsafeBitCast(block, to: AnyObject.self))
+      method_setImplementation(method, swizzledIMP)
+    }
+  }
+
+  /// Ends the task's span if it is still running. A task already reported by a delegate or a
+  /// completion handler has had its span removed from `runningSpans`, so logging here is a no-op.
+  private func reportCompletionIfUnreported(_ task: URLSessionTask) {
+    guard let taskId = objc_getAssociatedObject(task, &idKey) as? String,
+          objc_getAssociatedObject(task, &completionHandlerKey) == nil else {
+      return
+    }
+
+    var requestState: NetworkRequestState?
+    queue.sync {
+      requestState = requestMap[taskId]
+      requestMap[taskId] = nil
+    }
+
+    if let error = task.error {
+      let status = (task.response as? HTTPURLResponse)?.statusCode ?? 0
+      URLSessionLogger.logError(error, dataOrFile: requestState?.dataProcessed, statusCode: status,
+                                instrumentation: self, sessionTaskId: taskId)
+    } else if let response = task.response {
+      URLSessionLogger.logResponse(response, dataOrFile: requestState?.dataProcessed,
+                                   instrumentation: self, sessionTaskId: taskId)
+    }
   }
 
   private func setIdKey(value: String, for task: URLSessionTask) {

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -1106,4 +1106,18 @@ class URLSessionInstrumentationTests: XCTestCase {
     // The test passes if tasks completes without crashing.
     wait { task.state == .completed }
   }
+
+  /// A task with no session delegate and no completion handler has its span started by the factory
+  /// swizzle, and before the setState fallback there was nothing left to end it: the span stayed in
+  /// runningSpans for the lifetime of the process.
+  public func testSpanIsEndedWithoutADelegateOrCompletionHandler() {
+    let session = URLSession(configuration: .ephemeral)
+    let task = session.dataTask(with: URLRequest(url: URL(string: "http://localhost:33333/success")!))
+    task.resume()
+    wait(timeout: 5) { task.state == .completed }
+
+    let leaked = URLSessionInstrumentationTests.instrumentation.startedRequestSpans
+    XCTAssertTrue(leaked.isEmpty, "nothing ended the span: \(leaked.count) still running")
+  }
+
 }


### PR DESCRIPTION
We hit this in production and have been carrying a fix for it in our SDK, so I'm upstreaming it.

If a task has no session delegate and no completion handler, the factory swizzle starts its span and then nothing ever ends it. There's nothing left to observe the completion, so the span just sits in `runningSpans` for the rest of the process. Same thing happens with networking layers that manage their own tasks.

Easy to see on `main`:

```swift
let session = URLSession(configuration: .ephemeral)
let task = session.dataTask(with: request)   // no completion handler, no delegate
task.resume()
// after the task completes: startedRequestSpans.count == 1
```

`setState:` is the one place every task goes through on its way to `.completed`, so I swizzle it and end the span there if it's still running. If a delegate or a completion handler already reported the task, its span is gone from `runningSpans` and this is a no-op.

One detail worth calling out: tasks created with a completion handler get marked and skipped here. That handler reports the response itself and it has the body, so letting the fallback get there first would mean reporting the same request with less data.

The existing tests couldn't catch the leak because `tearDown` clears `runningSpans` before it asserts it's empty. The new test looks right after the task completes instead. It fails on `main` with `1 still running` and passes with this.

Full URLSession suite is green, and the whole package suite (597 tests) too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
