### PR TITLE
feat(URLSession): allow payload recording to be decided per request

### DIFF
--- a/Sources/Instrumentation/URLSession/README.md
+++ b/Sources/Instrumentation/URLSession/README.md
@@ -12,7 +12,9 @@ This behaviour can be modified or augmented by using the optional callbacks defi
 
 `shouldInstrument: ((URLRequest) -> (Bool)?)?` :  Filter which requests you want to instrument, all by default
 
-`shouldRecordPayload: ((URLSession) -> (Bool)?)?`: Implement if you want the session to record payload data, false by default.
+`shouldRecordPayload: ((URLSession) -> (Bool)?)?`: Implement if you want the session to record payload data, false by default. It gates the payload passed to `receivedResponse` and `receivedError` on every path, whether the request uses the session delegate, a completion handler or async/await.
+
+`shouldRecordPayloadForRequest: ((URLRequest) -> (Bool)?)?`: Decide payload recording per request rather than per session, which is useful when one session serves endpoints that should be treated differently. Asked first, falling back to `shouldRecordPayload` when it is not implemented or returns nil.
 
 `shouldInjectTracingHeaders: ((URLRequest) -> (Bool)?)?`: Allows filtering which requests you want to inject headers to follow the trace, true by default. You must also return true if you want to inject custom headers.
 

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -353,13 +353,16 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
           if completionBlock != nil {
             if objc_getAssociatedObject(argument, &idKey) == nil {
               let completionWrapper: (Any?, URLResponse?, Error?) -> Void = { object, response, error in
+                // Payload recording is opt-in and off by default. The caller still receives
+                // `object` below; only what is handed to the telemetry callbacks is withheld.
+                let payload = (self.configuration.shouldRecordPayload?(session) ?? false) ? object : nil
                 if error != nil {
                   let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-                  URLSessionLogger.logError(error!, dataOrFile: object, statusCode: status,
+                  URLSessionLogger.logError(error!, dataOrFile: payload, statusCode: status,
                                             instrumentation: self, sessionTaskId: sessionTaskId)
                 } else {
                   if let response {
-                    URLSessionLogger.logResponse(response, dataOrFile: object, instrumentation: self,
+                    URLSessionLogger.logResponse(response, dataOrFile: payload, instrumentation: self,
                                                  sessionTaskId: sessionTaskId)
                   }
                 }
@@ -422,13 +425,16 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
           var completionBlock = completion
           if objc_getAssociatedObject(argument, &idKey) == nil {
             let completionWrapper: (Any?, URLResponse?, Error?) -> Void = { object, response, error in
+              // Payload recording is opt-in and off by default. The caller still receives
+              // `object` below; only what is handed to the telemetry callbacks is withheld.
+              let payload = (self.configuration.shouldRecordPayload?(session) ?? false) ? object : nil
               if error != nil {
                 let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-                URLSessionLogger.logError(error!, dataOrFile: object, statusCode: status,
+                URLSessionLogger.logError(error!, dataOrFile: payload, statusCode: status,
                                           instrumentation: self, sessionTaskId: sessionTaskId)
               } else {
                 if let response {
-                  URLSessionLogger.logResponse(response, dataOrFile: object, instrumentation: self,
+                  URLSessionLogger.logResponse(response, dataOrFile: payload, instrumentation: self,
                                                sessionTaskId: sessionTaskId)
                 }
               }

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -652,7 +652,7 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
 
   // URLSessionTask methods
   private func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-    guard configuration.shouldRecordPayload?(session) ?? false else { return }
+    guard shouldRecordPayload(for: session, taskId: objc_getAssociatedObject(dataTask, &idKey) as? String) else { return }
     guard let taskId = objc_getAssociatedObject(dataTask, &idKey) as? String
     else {
       return
@@ -672,7 +672,7 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
   private func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
                           didReceive response: URLResponse,
                           completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-    guard configuration.shouldRecordPayload?(session) ?? false else { return }
+    guard shouldRecordPayload(for: session, taskId: objc_getAssociatedObject(dataTask, &idKey) as? String) else { return }
     guard let taskId = objc_getAssociatedObject(dataTask, &idKey) as? String
     else {
       return
@@ -856,6 +856,19 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
       objc_setAssociatedObject(task, &idKey, id, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
     return id!
+  }
+
+  /// Whether the payload should be recorded, asking per request first and falling back to the
+  /// per-session callback.
+  private func shouldRecordPayload(for session: URLSession, taskId: String?) -> Bool {
+    let config = configuration
+    if let perRequest = config.shouldRecordPayloadForRequest,
+       let taskId,
+       let request = queue.sync(execute: { requestMap[taskId]?.request }),
+       let answer = perRequest(request) {
+      return answer
+    }
+    return config.shouldRecordPayload?(session) ?? false
   }
 
   private func setIdKey(value: String, for task: URLSessionTask) {

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -355,7 +355,7 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
               let completionWrapper: (Any?, URLResponse?, Error?) -> Void = { object, response, error in
                 // Payload recording is opt-in and off by default. The caller still receives
                 // `object` below; only what is handed to the telemetry callbacks is withheld.
-                let payload = (self.configuration.shouldRecordPayload?(session) ?? false) ? object : nil
+                let payload = self.shouldRecordPayload(for: session, taskId: sessionTaskId) ? object : nil
                 if error != nil {
                   let status = (response as? HTTPURLResponse)?.statusCode ?? 0
                   URLSessionLogger.logError(error!, dataOrFile: payload, statusCode: status,
@@ -427,7 +427,7 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
             let completionWrapper: (Any?, URLResponse?, Error?) -> Void = { object, response, error in
               // Payload recording is opt-in and off by default. The caller still receives
               // `object` below; only what is handed to the telemetry callbacks is withheld.
-              let payload = (self.configuration.shouldRecordPayload?(session) ?? false) ? object : nil
+              let payload = self.shouldRecordPayload(for: session, taskId: sessionTaskId) ? object : nil
               if error != nil {
                 let status = (response as? HTTPURLResponse)?.statusCode ?? 0
                 URLSessionLogger.logError(error!, dataOrFile: payload, statusCode: status,

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -64,8 +64,15 @@ public struct URLSessionInstrumentationConfiguration {
   /// Implement this callback to filter which requests you want to instrument, all by default
   public var shouldInstrument: ((URLRequest) -> (Bool)?)?
 
-  /// Implement this callback if you want the session to record payload data, false by default.
-  /// This callback is only necessary when using session delegate
+  /// Implement this callback if you want the instrumentation to record payload data, false by
+  /// default.
+  ///
+  /// It is the opt-in gate for the payload passed as `dataOrFile` to `receivedResponse` and
+  /// `receivedError`, on the session delegate and completion handler paths alike. Returning `false`,
+  /// or leaving this unimplemented, means those callbacks receive `nil` instead of the body.
+  ///
+  /// This does not affect the data delivered to the caller: a completion handler passed to
+  /// `dataTask(with:completionHandler:)` always receives its own data unchanged.
   public var shouldRecordPayload: ((URLSession) -> (Bool)?)?
 
   /// Implement this callback to decide payload recording per request rather than per session.

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -25,6 +25,7 @@ public enum HTTPSemanticConvention {
 
 public struct URLSessionInstrumentationConfiguration {
   public init(shouldRecordPayload: ((URLSession) -> (Bool)?)? = nil,
+              shouldRecordPayloadForRequest: ((URLRequest) -> (Bool)?)? = nil,
               shouldInstrument: ((URLRequest) -> (Bool)?)? = nil,
               nameSpan: ((URLRequest) -> (String)?)? = nil,
               spanCustomization: ((URLRequest, SpanBuilder) -> Void)? = nil,
@@ -39,6 +40,7 @@ public struct URLSessionInstrumentationConfiguration {
               ignoredClassPrefixes: [String]? = nil,
               semanticConvention: HTTPSemanticConvention = .old) {
     self.shouldRecordPayload = shouldRecordPayload
+    self.shouldRecordPayloadForRequest = shouldRecordPayloadForRequest
     self.shouldInstrument = shouldInstrument
     self.shouldInjectTracingHeaders = shouldInjectTracingHeaders
     self.injectCustomHeaders = injectCustomHeaders
@@ -65,6 +67,13 @@ public struct URLSessionInstrumentationConfiguration {
   /// Implement this callback if you want the session to record payload data, false by default.
   /// This callback is only necessary when using session delegate
   public var shouldRecordPayload: ((URLSession) -> (Bool)?)?
+
+  /// Implement this callback to decide payload recording per request rather than per session.
+  ///
+  /// A session is usually shared across every call an app makes, so `shouldRecordPayload` can only
+  /// answer for all of them at once. This is consulted first, and `shouldRecordPayload` is used when
+  /// it is not implemented or returns nil, so existing behaviour is unchanged.
+  public var shouldRecordPayloadForRequest: ((URLRequest) -> (Bool)?)?
 
   /// Implement this callback to filter which requests you want to inject headers to follow the trace,
   /// also must implement it if you want to inject custom headers

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -103,6 +103,8 @@ class URLSessionInstrumentationTests: XCTestCase {
     }
   }
 
+  nonisolated(unsafe) static var receivedDataOrFile: Any?
+
   nonisolated(unsafe) static var requestCopy: URLRequest!
   nonisolated(unsafe) static var responseCopy: HTTPURLResponse!
 
@@ -140,8 +142,9 @@ class URLSessionInstrumentationTests: XCTestCase {
                                                                requestCopy = request
                                                                checker.createdRequestCalled = true
                                                              },
-                                                             receivedResponse: { response, _, _ in
+                                                             receivedResponse: { response, dataOrFile, _ in
                                                                responseCopy = response as? HTTPURLResponse
+                                                               receivedDataOrFile = dataOrFile
                                                                checker.receivedResponseCalled = true
                                                              },
                                                              receivedError: { _, _, _, _ in
@@ -197,6 +200,7 @@ class URLSessionInstrumentationTests: XCTestCase {
     sessionDelegate = SessionDelegate(semaphore: URLSessionInstrumentationTests.semaphore)
     URLSessionInstrumentationTests.requestCopy = nil
     URLSessionInstrumentationTests.responseCopy = nil
+    URLSessionInstrumentationTests.receivedDataOrFile = nil
     XCTAssertEqual(0, URLSessionInstrumentationTests.instrumentation.startedRequestSpans.count)
     URLSessionInstrumentationTests.instrumentation.configuration.semanticConvention = .old
   }
@@ -1176,6 +1180,26 @@ class URLSessionInstrumentationTests: XCTestCase {
 
     let observed = askedLock.withLock { askedFor }
     XCTAssertEqual(observed.first, url, "the callback should be asked about the request being sent")
+  }
+
+  /// `shouldRecordPayload` defaults to off and the session-delegate path honours it, but the
+  /// completion handler path handed the response body to `receivedResponse` regardless. An app that
+  /// never opted in still received response bodies in its telemetry callback.
+  public func testCompletionHandlerHonoursShouldRecordPayload() {
+    let url = URL(string: "http://localhost:33333/success")!
+    nonisolated(unsafe) var callerReceivedBody: Data?
+
+    let task = URLSession.shared.dataTask(with: URLRequest(url: url)) { data, _, _ in
+      callerReceivedBody = data
+      URLSessionInstrumentationTests.semaphore.signal()
+    }
+    task.resume()
+    URLSessionInstrumentationTests.semaphore.wait()
+
+    XCTAssertTrue(URLSessionInstrumentationTests.checker.receivedResponseCalled)
+    XCTAssertNotNil(callerReceivedBody, "the caller's completion handler must still get its data")
+    XCTAssertNil(URLSessionInstrumentationTests.receivedDataOrFile,
+                 "payload recording is disabled, so no body should reach receivedResponse")
   }
 
 }

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -9,6 +9,30 @@
 import XCTest
 import SharedTestUtils
 
+/// Serves a fixed response body for one sentinel host, so tests can exercise the payload path.
+/// Scoped to that host so registering it cannot affect any other request in the process.
+final class PayloadStubURLProtocol: URLProtocol {
+  static let host = "payload.stub"
+  nonisolated(unsafe) static var body = Data("{\"message\":\"hello\"}".utf8)
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    request.url?.host == host
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let url = request.url ?? URL(string: "http://\(Self.host)/")!
+    let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil,
+                                   headerFields: ["Content-Type": "application/json"])!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: Self.body)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
 class URLSessionInstrumentationTests: XCTestCase {
   class Check {
     public var shouldRecordPayloadCalled: Bool = false
@@ -31,6 +55,21 @@ class URLSessionInstrumentationTests: XCTestCase {
     func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
       semaphore.signal()
     }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+      semaphore.signal()
+    }
+  }
+
+  /// Implements didReceive, so the instrumentation's payload path runs for this session.
+  final class DataReceivingDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate, @unchecked Sendable {
+    let semaphore: DispatchSemaphore
+
+    init(semaphore: DispatchSemaphore) {
+      self.semaphore = semaphore
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {}
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
       semaphore.signal()
@@ -1106,4 +1145,37 @@ class URLSessionInstrumentationTests: XCTestCase {
     // The test passes if tasks completes without crashing.
     wait { task.state == .completed }
   }
+
+  /// The per-request payload callback is asked with the request it is deciding about, so an app can
+  /// record payloads for some endpoints without turning it on for the whole session.
+  public func testPerRequestPayloadCallbackIsAskedWithTheRequest() {
+    URLProtocol.registerClass(PayloadStubURLProtocol.self)
+    defer { URLProtocol.unregisterClass(PayloadStubURLProtocol.self) }
+
+    let url = URL(string: "http://\(PayloadStubURLProtocol.host)/body")!
+    nonisolated(unsafe) var askedFor = [URL]()
+    let askedLock = NSLock()
+
+    URLSessionInstrumentationTests.instrumentation.configuration.shouldRecordPayloadForRequest = { request in
+      if let requestURL = request.url {
+        askedLock.withLock { askedFor.append(requestURL) }
+      }
+      return true
+    }
+    defer {
+      URLSessionInstrumentationTests.instrumentation.configuration.shouldRecordPayloadForRequest = nil
+    }
+
+    let delegate = DataReceivingDelegate(semaphore: URLSessionInstrumentationTests.semaphore)
+    let configuration = URLSessionConfiguration.default
+    configuration.protocolClasses = [PayloadStubURLProtocol.self]
+    let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+    let task = session.dataTask(with: URLRequest(url: url))
+    task.resume()
+    URLSessionInstrumentationTests.semaphore.wait()
+
+    let observed = askedLock.withLock { askedFor }
+    XCTAssertEqual(observed.first, url, "the callback should be asked about the request being sent")
+  }
+
 }

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationTests.swift
@@ -1202,4 +1202,39 @@ class URLSessionInstrumentationTests: XCTestCase {
                  "payload recording is disabled, so no body should reach receivedResponse")
   }
 
+
+  /// The completion handler paths go through the same gate as the session delegate path, so the
+  /// per-request callback decides for them too rather than being silently ignored.
+  public func testCompletionHandlerHonoursPerRequestPayloadCallback() {
+    let url = URL(string: "http://\(PayloadStubURLProtocol.host)/body")!
+    nonisolated(unsafe) var askedFor = [URL]()
+    let askedLock = NSLock()
+
+    URLSessionInstrumentationTests.instrumentation.configuration.shouldRecordPayloadForRequest = { request in
+      if let requestURL = request.url {
+        askedLock.withLock { askedFor.append(requestURL) }
+      }
+      return true
+    }
+    defer {
+      URLSessionInstrumentationTests.instrumentation.configuration.shouldRecordPayloadForRequest = nil
+    }
+
+    let configuration = URLSessionConfiguration.default
+    configuration.protocolClasses = [PayloadStubURLProtocol.self]
+    let session = URLSession(configuration: configuration)
+
+    let task = session.dataTask(with: URLRequest(url: url)) { _, _, _ in
+      URLSessionInstrumentationTests.semaphore.signal()
+    }
+    task.resume()
+    URLSessionInstrumentationTests.semaphore.wait()
+
+    XCTAssertEqual(askedLock.withLock { askedFor }.first, url,
+                   "the per-request callback should decide for completion handler tasks too")
+    XCTAssertEqual((URLSessionInstrumentationTests.receivedDataOrFile as? Data),
+                   PayloadStubURLProtocol.body,
+                   "recording was allowed for this request, so the body should reach receivedResponse")
+  }
+
 }


### PR DESCRIPTION
Last of the batch from our SDK.

`shouldRecordPayload` asks about the *session*. In our app, and I'd guess in most, one session is shared across everything, so that callback can only answer for all requests at once. We want bodies from a couple of endpoints and definitely not from the rest, and there's no way to say that today — it's all or nothing.

So this adds `shouldRecordPayloadForRequest`, which gets the request instead of the session:

```swift
shouldRecordPayloadForRequest: { request in
    request.url?.path.hasPrefix("/api/orders") == true
}
```

It's asked first, and falls back to `shouldRecordPayload` when it isn't implemented or returns nil, so nothing changes for anyone already using the session-level one.

Two notes:

- This sits next to #1163, which makes the completion handler paths honour `shouldRecordPayload` at all. If you'd rather land that one first and have me rebase this on top, that's fine by me.
- The test needed a response with an actual body, and no route in `HttpTestServer` returns one, so I added a small `URLProtocol` stub scoped to a single sentinel host (`payload.stub`). It only claims requests for that host, so registering it can't affect anything else in the suite. Happy to move it somewhere more general if you'd prefer it reusable.

Test asserts the callback is asked with the request that's being sent, and fails if the per-request lookup is skipped. URLSession suite green, full package suite green (597 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
