### PR TITLE
fix(otlp-http): add requeueOnFailure to avoid duplicate Persistence exports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -190,7 +190,10 @@ let package = Package(
     ),
     .testTarget(
       name: "PersistenceExporterTests",
-      dependencies: ["PersistenceExporter"],
+      dependencies: [
+        "PersistenceExporter",
+        "OpenTelemetryProtocolExporterHttp",
+      ],
       path: "Tests/ExportersTests/PersistenceExporter"
     ),
     .testTarget(

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
@@ -19,6 +19,7 @@ public class OtlpHttpExporterBase: @unchecked Sendable {
   let httpClient: HTTPClient
   let envVarHeaders: [(String, String)]?
   let config: OtlpConfiguration
+  let requeueOnFailure: Bool
 
   // MARK: - Init
 
@@ -26,22 +27,26 @@ public class OtlpHttpExporterBase: @unchecked Sendable {
   public init(endpoint: URL,
               config: OtlpConfiguration = OtlpConfiguration(),
               httpClient: HTTPClient = BaseHTTPClient(),
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+              requeueOnFailure: Bool = true) {
     self.envVarHeaders = envVarHeaders
     self.endpoint = endpoint
     self.config = config
     self.httpClient = httpClient
+    self.requeueOnFailure = requeueOnFailure
   }
 
   // Deprecated initializer for backward compatibility
-  @available(*, deprecated, message: "Use init(endpoint:config:httpClient:envVarHeaders:) instead")
+  @available(*, deprecated, message: "Use init(endpoint:config:httpClient:envVarHeaders:requeueOnFailure:) instead")
   public init(endpoint: URL,
               config: OtlpConfiguration = OtlpConfiguration(),
               useSession: URLSession? = nil,
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+              requeueOnFailure: Bool = true) {
     self.envVarHeaders = envVarHeaders
     self.endpoint = endpoint
     self.config = config
+    self.requeueOnFailure = requeueOnFailure
     if let providedSession = useSession {
       self.httpClient = BaseHTTPClient(session: providedSession)
     } else {

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -24,11 +24,13 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
   override public init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
                        config: OtlpConfiguration = OtlpConfiguration(),
                        httpClient: HTTPClient = BaseHTTPClient(),
-                       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+                       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+                       requeueOnFailure: Bool = true) {
     super.init(endpoint: endpoint,
                config: config,
                httpClient: httpClient,
-               envVarHeaders: envVarHeaders)
+               envVarHeaders: envVarHeaders,
+               requeueOnFailure: requeueOnFailure)
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type
@@ -38,13 +40,18 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
   ///    - meterProvider: Injected `StableMeterProvider` for metric
   ///    - httpClient: Custom HTTPClient implementation
   ///    - envVarHeaders: Extra header key-values
+  ///    - requeueOnFailure: Re-append failed batches to the in-memory pending queue
   public convenience init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
                           config: OtlpConfiguration = OtlpConfiguration(),
                           meterProvider: any MeterProvider,
                           httpClient: HTTPClient = BaseHTTPClient(),
-                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
-    self.init(endpoint: endpoint, config: config, httpClient: httpClient,
-              envVarHeaders: envVarHeaders)
+                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+                          requeueOnFailure: Bool = true) {
+    self.init(endpoint: endpoint,
+              config: config,
+              httpClient: httpClient,
+              envVarHeaders: envVarHeaders,
+              requeueOnFailure: requeueOnFailure)
     exporterMetrics = ExporterMetrics(type: "log",
                                       meterProvider: meterProvider,
                                       exporterName: "otlp",
@@ -77,8 +84,10 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
         self?.exporterMetrics?.addSuccess(value: sendingLogRecords.count)
       case let .failure(error):
         self?.exporterMetrics?.addFailed(value: sendingLogRecords.count)
-        self?.exporterLock.withLockVoid {
-          self?.pendingLogRecords.append(contentsOf: sendingLogRecords)
+        if self?.requeueOnFailure == true {
+          self?.exporterLock.withLockVoid {
+            self?.pendingLogRecords.append(contentsOf: sendingLogRecords)
+          }
         }
         OpenTelemetry.instance.feedbackHandler?("\(error)")
       }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -42,12 +42,16 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
                 AggregationTemporality.alwaysCumulative(),
               defaultAggregationSelector: DefaultAggregationSelector = AggregationSelector.instance,
               httpClient: HTTPClient = BaseHTTPClient(),
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+              requeueOnFailure: Bool = true) {
     self.aggregationTemporalitySelector = aggregationTemporalitySelector
     self.defaultAggregationSelector = defaultAggregationSelector
 
-    super.init(endpoint: endpoint, config: config, httpClient: httpClient,
-               envVarHeaders: envVarHeaders)
+    super.init(endpoint: endpoint,
+               config: config,
+               httpClient: httpClient,
+               envVarHeaders: envVarHeaders,
+               requeueOnFailure: requeueOnFailure)
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type
@@ -59,6 +63,7 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
   ///    - defaultAggregationSelector: default aggregator
   ///    - httpClient: Custom HTTPClient implementation
   ///    - envVarHeaders: Extra header key-values
+  ///    - requeueOnFailure: Re-append failed batches to the in-memory pending queue
   public convenience init(endpoint: URL,
                           config: OtlpConfiguration = OtlpConfiguration(),
                           meterProvider: any MeterProvider,
@@ -67,13 +72,15 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
                           defaultAggregationSelector: DefaultAggregationSelector = AggregationSelector
                             .instance,
                           httpClient: HTTPClient = BaseHTTPClient(),
-                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+                          requeueOnFailure: Bool = true) {
     self.init(endpoint: endpoint,
               config: config,
               aggregationTemporalitySelector: aggregationTemporalitySelector,
               defaultAggregationSelector: defaultAggregationSelector,
               httpClient: httpClient,
-              envVarHeaders: envVarHeaders)
+              envVarHeaders: envVarHeaders,
+              requeueOnFailure: requeueOnFailure)
     exporterMetrics = ExporterMetrics(type: "metric",
                                       meterProvider: meterProvider,
                                       exporterName: "otlp",
@@ -105,8 +112,10 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
         self?.exporterMetrics?.addSuccess(value: sendingMetrics.count)
       case let .failure(error):
         self?.exporterMetrics?.addFailed(value: sendingMetrics.count)
-        self?.exporterLock.withLockVoid {
-          self?.pendingMetrics.append(contentsOf: sendingMetrics)
+        if self?.requeueOnFailure == true {
+          self?.exporterLock.withLockVoid {
+            self?.pendingMetrics.append(contentsOf: sendingMetrics)
+          }
         }
         OpenTelemetry.instance.feedbackHandler?("\(error)")
       }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
@@ -25,11 +25,13 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
   override public init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
                        config: OtlpConfiguration = OtlpConfiguration(),
                        httpClient: HTTPClient = BaseHTTPClient(),
-                       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
+                       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+                       requeueOnFailure: Bool = true) {
     super.init(endpoint: endpoint,
                config: config,
                httpClient: httpClient,
-               envVarHeaders: envVarHeaders)
+               envVarHeaders: envVarHeaders,
+               requeueOnFailure: requeueOnFailure)
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type
@@ -39,13 +41,18 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
   ///    - meterProvider: Injected `StableMeterProvider` for metric
   ///    - httpClient: Custom HTTPClient implementation
   ///    - envVarHeaders: Extra header key-values
+  ///    - requeueOnFailure: Re-append failed batches to the in-memory pending queue
   public convenience init(endpoint: URL,
                           config: OtlpConfiguration,
                           meterProvider: any MeterProvider,
                           httpClient: HTTPClient = BaseHTTPClient(),
-                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes) {
-    self.init(endpoint: endpoint, config: config, httpClient: httpClient,
-              envVarHeaders: envVarHeaders)
+                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+                          requeueOnFailure: Bool = true) {
+    self.init(endpoint: endpoint,
+              config: config,
+              httpClient: httpClient,
+              envVarHeaders: envVarHeaders,
+              requeueOnFailure: requeueOnFailure)
     exporterMetrics = ExporterMetrics(type: "span",
                                       meterProvider: meterProvider,
                                       exporterName: "otlp",
@@ -82,8 +89,10 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
         self?.exporterMetrics?.addSuccess(value: sendingSpans.count)
       case let .failure(error):
         self?.exporterMetrics?.addFailed(value: sendingSpans.count)
-        self?.exporterLock.withLockVoid {
-          self?.pendingSpans.append(contentsOf: sendingSpans)
+        if self?.requeueOnFailure == true {
+          self?.exporterLock.withLockVoid {
+            self?.pendingSpans.append(contentsOf: sendingSpans)
+          }
         }
         OpenTelemetry.instance.feedbackHandler?("\(error)")
         resultValue = .failure

--- a/Sources/Exporters/Persistence/README.md
+++ b/Sources/Exporters/Persistence/README.md
@@ -22,9 +22,20 @@ let persistenceMetricExporter = try PersistenceMetricExporterDecorator(
 
 An example of decorating a `SpanExporter`:
 
+When the decorated exporter is an OTLP HTTP exporter, set `requeueOnFailure: false` so
+Persistence owns disk retry and the HTTP exporter does not also hold a copy in its
+in-memory pending queue (which would duplicate spans on the next export):
+
 ```swift
-let spanExporter = ... // create some SpanExporter
+let otlpExporter = OtlpHttpTraceExporter(
+  config: OtlpConfiguration(),
+  requeueOnFailure: false)
 let persistenceTraceExporter = try PersistenceSpanExporterDecorator(
-  spanExporter: spanExporter,
+  spanExporter: otlpExporter,
   storageURL: tracesSubdirectoryURL)
 ```
+
+The same `requeueOnFailure` flag exists on `OtlpHttpLogExporter` and
+`OtlpHttpMetricExporter` and prevents in-memory duplication when wrapped by
+Persistence. End-to-end Persistence retry for logs and metrics still requires
+separate failure-signaling work in those exporters.

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -123,6 +123,15 @@ final class OtlpHttpLogExporterCoverageTests: XCTestCase {
     XCTAssertEqual(client.sentRequests.count, 1)
   }
 
+  func testExportFailureWithRequeueDisabledLeavesPendingEmpty() {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpLogExporter(httpClient: client, requeueOnFailure: false)
+
+    _ = exporter.export(logRecords: [sampleLogRecord()])
+    XCTAssertEqual(exporter.pendingLogRecords.count, 0)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
   func testFlushWithPendingLogRecordsSuccess() {
     let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError()), .success])
     let exporter = OtlpHttpLogExporter(httpClient: client)
@@ -201,6 +210,15 @@ final class OtlpHttpTraceExporterCoverageTests: XCTestCase {
     let exporter = OtlpHttpTraceExporter(httpClient: client)
     let result = exporter.export(spans: [sampleSpanData()])
     XCTAssertEqual(result, .failure)
+  }
+
+  func testExportFailureWithRequeueDisabledLeavesPendingEmpty() {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpTraceExporter(httpClient: client, requeueOnFailure: false)
+    let result = exporter.export(spans: [sampleSpanData()])
+    XCTAssertEqual(result, .failure)
+    XCTAssertEqual(exporter.pendingSpans.count, 0)
+    XCTAssertEqual(client.sentRequests.count, 1)
   }
 
   func testFlushWithPendingSpans() {
@@ -297,6 +315,17 @@ final class OtlpHttpExporterFlushTimeoutTests: XCTestCase {
     let start = Date()
     XCTAssertEqual(exporter.flush(), .failure)
     XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+  }
+
+  func testExportFailureWithRequeueDisabledLeavesPendingEmpty() {
+    let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
+    let exporter = OtlpHttpMetricExporter(
+      endpoint: URL(string: "http://localhost:4318/v1/metrics")!,
+      httpClient: client,
+      requeueOnFailure: false)
+    _ = exporter.export(metrics: [.empty])
+    XCTAssertEqual(exporter.pendingMetrics.count, 0)
+    XCTAssertEqual(client.sentRequests.count, 1)
   }
 }
 

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceSpanExporterStackedWithOtlpHttpTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceSpanExporterStackedWithOtlpHttpTests.swift
@@ -1,0 +1,152 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+import OpenTelemetryApi
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetryProtocolExporterHttp
+import OpenTelemetrySdk
+@testable import PersistenceExporter
+import SwiftProtobuf
+import XCTest
+
+/// When Persistence wraps an OTLP HTTP trace exporter, both layers used to retry
+/// the same failed batch. With `requeueOnFailure: false`, the exporter leaves its
+/// pending queue empty so Persistence can retry from disk without duplicating spans.
+final class PersistenceSpanExporterStackedWithOtlpHttpTests: XCTestCase {
+  @UniqueTemporaryDirectory private var temporaryDirectory: Directory
+
+  private final class FailOnceHTTPClient: HTTPClient, @unchecked Sendable {
+    struct SendFailure: Error {}
+
+    private let lock = NSLock()
+    private var _sentBodies: [Data] = []
+    private let firstRequestSent: XCTestExpectation
+    private let secondRequestSent: XCTestExpectation
+
+    var sentBodies: [Data] {
+      lock.lock()
+      defer { lock.unlock() }
+      return _sentBodies
+    }
+
+    init(firstRequestSent: XCTestExpectation, secondRequestSent: XCTestExpectation) {
+      self.firstRequestSent = firstRequestSent
+      self.secondRequestSent = secondRequestSent
+    }
+
+    func send(request: URLRequest,
+              completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+      lock.lock()
+      _sentBodies.append(request.httpBody ?? Data())
+      let requestCount = _sentBodies.count
+      lock.unlock()
+
+      // First request fails; later requests succeed (Persistence retry).
+      if requestCount == 1 {
+        firstRequestSent.fulfill()
+        completion(.failure(SendFailure()))
+      } else {
+        secondRequestSent.fulfill()
+        completion(.success(HTTPURLResponse(url: request.url!,
+                                            statusCode: 200,
+                                            httpVersion: "HTTP/1.1",
+                                            headerFields: nil)!))
+      }
+    }
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+      try await withCheckedThrowingContinuation { continuation in
+        send(request: request) { result in
+          continuation.resume(with: result)
+        }
+      }
+    }
+  }
+
+  override func setUp() {
+    super.setUp()
+    temporaryDirectory.create()
+  }
+
+  override func tearDown() {
+    temporaryDirectory.delete()
+    super.tearDown()
+  }
+
+  func testWhenExportFails_thenTheRetriedRequestCarriesOneCopyOfTheSpan() throws {
+    let firstRequestSent = expectation(description: "first export attempt sent")
+    let secondRequestSent = expectation(description: "second export attempt sent")
+    let httpClient = FailOnceHTTPClient(firstRequestSent: firstRequestSent,
+                                        secondRequestSent: secondRequestSent)
+
+    let otlpExporter = OtlpHttpTraceExporter(config: OtlpConfiguration(compression: .none),
+                                             httpClient: httpClient,
+                                             envVarHeaders: nil,
+                                             requeueOnFailure: false)
+
+    let persistenceExporter = try PersistenceSpanExporterDecorator(
+      spanExporter: otlpExporter,
+      storageURL: temporaryDirectory.url,
+      exportCondition: { true },
+      performancePreset: PersistencePerformancePreset.mockWith(
+        storagePerformance: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,
+        synchronousWrite: true,
+        exportPerformance: ExportPerformanceMock.veryQuick))
+
+    let tracerProviderSDK = TracerProviderSdk()
+    OpenTelemetry.registerTracerProvider(tracerProvider: tracerProviderSDK)
+    let tracer = tracerProviderSDK.get(instrumentationName: "StackedOtlpHttpExporter") as! TracerSdk
+
+    let spanProcessor = SimpleSpanProcessor(spanExporter: persistenceExporter)
+    tracerProviderSDK.addSpanProcessor(spanProcessor)
+
+    let span = tracer.spanBuilder(spanName: "SimpleSpan").setSpanKind(spanKind: .client).startSpan()
+    let spanContext = span.context
+    span.end() // only writes to disk; the worker exports asynchronously.
+    spanProcessor.shutdown() // flushes remaining disk batches so the failed span is retried synchronously.
+
+    wait(for: [firstRequestSent, secondRequestSent], timeout: 10)
+
+    let bodies = httpClient.sentBodies
+    XCTAssertEqual(bodies.count, 2, "Expected the failed attempt and exactly one retry")
+
+    let firstSpan = try singleSpan(in: bodies[0])
+    let secondSpan = try singleSpan(in: bodies[1])
+    XCTAssertEqual(firstSpan, secondSpan,
+                   "The retried request must carry the same span, not a duplicate copy")
+    assertSpanIdentity(firstSpan, matches: spanContext, name: "SimpleSpan")
+  }
+
+  private func singleSpan(in body: Data) throws -> Opentelemetry_Proto_Trace_V1_Span {
+    let request = try Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest(serializedBytes: body)
+    let spans = request.resourceSpans.flatMap(\.scopeSpans).flatMap(\.spans)
+    guard spans.count == 1, let span = spans.first else {
+      throw TestError.unexpectedSpanCount(spans.count)
+    }
+    return span
+  }
+
+  private func assertSpanIdentity(_ protoSpan: Opentelemetry_Proto_Trace_V1_Span,
+                                  matches context: SpanContext,
+                                  name: String,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line) {
+    var expectedTraceID = Data(count: TraceId.size)
+    context.traceId.copyBytesTo(dest: &expectedTraceID, destOffset: 0)
+    var expectedSpanID = Data(count: SpanId.size)
+    context.spanId.copyBytesTo(dest: &expectedSpanID, destOffset: 0)
+    XCTAssertEqual(protoSpan.traceID, expectedTraceID, file: file, line: line)
+    XCTAssertEqual(protoSpan.spanID, expectedSpanID, file: file, line: line)
+    XCTAssertEqual(protoSpan.name, name, file: file, line: line)
+  }
+
+  private enum TestError: Error {
+    case unexpectedSpanCount(Int)
+  }
+}


### PR DESCRIPTION
Fixes #1147

## Summary

When `PersistenceSpanExporterDecorator` wraps an OTLP HTTP exporter, a failed upload was retried twice: Persistence kept the batch on disk while the HTTP exporter also re-appended it to the in-memory pending queue. The next export merged both copies and sent duplicate spans.

This adds `requeueOnFailure: Bool = true` on `OtlpHttpExporterBase` (trace, log, and metric HTTP exporters). Set `requeueOnFailure: false` when wrapping with Persistence so disk retry owns failed batches.

## Test plan

- [x] `swift build --build-tests`
- [x] `swift test --filter 'OtlpHttpLogExporterCoverageTests|OtlpHttpTraceExporterCoverageTests|OtlpHttpExporterFlushTimeoutTests'`
- [x] `swift test --filter PersistenceSpanExporterStackedWithOtlpHttpTests`

<details>
<summary>Known limitations</summary>

Log and metric HTTP exporters still return `.success` before the HTTP callback completes. With `requeueOnFailure: false`, in-memory duplication is prevented, but Persistence disk retry for logs/metrics still needs separate failure-signaling work (#1146). Trace is correct end-to-end.
</details>