### PR TITLE
refactor(otlp-http): compose generic OtlpHttpExporterBase over inheritance

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
@@ -111,7 +111,7 @@ final class OtlpHttpExporterBase<Signal>: @unchecked Sendable {
             compressedData = data
             request.setValue("deflate", forHTTPHeaderField: "Content-Encoding")
           }
-        
+
         case .none:
           break
         }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
@@ -11,7 +11,7 @@ import FoundationNetworking
 #endif
 import OpenTelemetryApi
 
-final class OtlpHttpExporterBase<Signal>: @unchecked Sendable {
+final class OtlpHttpExporterBase<Signal: Sendable>: @unchecked Sendable {
   let endpoint: URL
   let httpClient: HTTPClient
   let envVarHeaders: [(String, String)]?
@@ -19,7 +19,7 @@ final class OtlpHttpExporterBase<Signal>: @unchecked Sendable {
   let requeueOnFailure: Bool
 
   private let lock = Lock()
-  var pendingSignals: [Signal] = []
+  private var pendingSignals: [Signal] = []
 
   // MARK: - Init
 

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
@@ -98,24 +98,24 @@ final class OtlpHttpExporterBase<Signal>: @unchecked Sendable {
 
       var compressedData = rawData
 
-#if canImport(Compression)
-      switch config.compression {
-      case .gzip:
-        if let data = rawData.gzip() {
-          compressedData = data
-          request.setValue("gzip", forHTTPHeaderField: "Content-Encoding")
-        }
+      #if canImport(Compression)
+        switch config.compression {
+        case .gzip:
+          if let data = rawData.gzip() {
+            compressedData = data
+            request.setValue("gzip", forHTTPHeaderField: "Content-Encoding")
+          }
 
-      case .deflate:
-        if let data = rawData.deflate() {
-          compressedData = data
-          request.setValue("deflate", forHTTPHeaderField: "Content-Encoding")
-        }
+        case .deflate:
+          if let data = rawData.deflate() {
+            compressedData = data
+            request.setValue("deflate", forHTTPHeaderField: "Content-Encoding")
+          }
         
-      case .none:
-        break
-      }
-#endif
+        case .none:
+          break
+        }
+      #endif
 
       // Apply final data. Could be compressed or raw
       // but it doesn't matter here

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
@@ -7,28 +7,28 @@ import Foundation
 import OpenTelemetryProtocolExporterCommon
 import SwiftProtobuf
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+import FoundationNetworking
 #endif
 import OpenTelemetryApi
 
-@available(*, deprecated, renamed: "OtlpHttpExporterBase")
-public typealias StableOtlpHTTPExporterBase = OtlpHttpExporterBase
-
-public class OtlpHttpExporterBase: @unchecked Sendable {
+final class OtlpHttpExporterBase<Signal>: @unchecked Sendable {
   let endpoint: URL
   let httpClient: HTTPClient
   let envVarHeaders: [(String, String)]?
   let config: OtlpConfiguration
   let requeueOnFailure: Bool
 
+  private let lock = Lock()
+  var pendingSignals: [Signal] = []
+
   // MARK: - Init
 
   // New initializer with HTTPClient support
-  public init(endpoint: URL,
-              config: OtlpConfiguration = OtlpConfiguration(),
-              httpClient: HTTPClient = BaseHTTPClient(),
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
-              requeueOnFailure: Bool = true) {
+  init(endpoint: URL,
+       config: OtlpConfiguration = OtlpConfiguration(),
+       httpClient: HTTPClient = BaseHTTPClient(),
+       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+       requeueOnFailure: Bool = true) {
     self.envVarHeaders = envVarHeaders
     self.endpoint = endpoint
     self.config = config
@@ -38,11 +38,11 @@ public class OtlpHttpExporterBase: @unchecked Sendable {
 
   // Deprecated initializer for backward compatibility
   @available(*, deprecated, message: "Use init(endpoint:config:httpClient:envVarHeaders:requeueOnFailure:) instead")
-  public init(endpoint: URL,
-              config: OtlpConfiguration = OtlpConfiguration(),
-              useSession: URLSession? = nil,
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
-              requeueOnFailure: Bool = true) {
+  init(endpoint: URL,
+       config: OtlpConfiguration = OtlpConfiguration(),
+       useSession: URLSession? = nil,
+       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+       requeueOnFailure: Bool = true) {
     self.envVarHeaders = envVarHeaders
     self.endpoint = endpoint
     self.config = config
@@ -54,7 +54,34 @@ public class OtlpHttpExporterBase: @unchecked Sendable {
     }
   }
 
-  public func createRequest(body: Message, endpoint: URL) -> URLRequest {
+  func drainPending(adding signals: [Signal]) -> [Signal] {
+    lock.withLock {
+      pendingSignals.append(contentsOf: signals)
+      let sending = pendingSignals
+      pendingSignals = []
+      return sending
+    }
+  }
+
+  func requeue(_ signals: [Signal]) {
+    guard requeueOnFailure else { return }
+    lock.withLockVoid {
+      pendingSignals.append(contentsOf: signals)
+    }
+  }
+
+  func snapshotPending() -> [Signal] {
+    lock.withLock { pendingSignals }
+  }
+
+  func dropFlushed(count sentCount: Int) {
+    lock.withLockVoid {
+      let n = min(sentCount, pendingSignals.count)
+      pendingSignals.removeFirst(n)
+    }
+  }
+
+  func createRequest(body: Message, endpoint: URL) -> URLRequest {
     var request = URLRequest(url: endpoint)
 
     if let headers = envVarHeaders ?? config.headersForExport() {
@@ -71,24 +98,24 @@ public class OtlpHttpExporterBase: @unchecked Sendable {
 
       var compressedData = rawData
 
-      #if canImport(Compression)
-        switch config.compression {
-        case .gzip:
-          if let data = rawData.gzip() {
-            compressedData = data
-            request.setValue("gzip", forHTTPHeaderField: "Content-Encoding")
-          }
-
-        case .deflate:
-          if let data = rawData.deflate() {
-            compressedData = data
-            request.setValue("deflate", forHTTPHeaderField: "Content-Encoding")
-          }
-
-        case .none:
-          break
+#if canImport(Compression)
+      switch config.compression {
+      case .gzip:
+        if let data = rawData.gzip() {
+          compressedData = data
+          request.setValue("gzip", forHTTPHeaderField: "Content-Encoding")
         }
-      #endif
+
+      case .deflate:
+        if let data = rawData.deflate() {
+          compressedData = data
+          request.setValue("deflate", forHTTPHeaderField: "Content-Encoding")
+        }
+        
+      case .none:
+        break
+      }
+#endif
 
       // Apply final data. Could be compressed or raw
       // but it doesn't matter here
@@ -98,6 +125,4 @@ public class OtlpHttpExporterBase: @unchecked Sendable {
     }
     return request
   }
-
-  public func shutdown(explicitTimeout: TimeInterval? = nil) {}
 }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -24,6 +24,13 @@ public final class OtlpHttpLogExporter: LogRecordExporter, @unchecked Sendable {
     self.base = base
   }
 
+  /// A `convenience` constructor to configure the OTLP HTTP log exporter
+  /// - Parameters:
+  ///    - endpoint: Exporter endpoint injected as dependency
+  ///    - config: Exporter configuration including type of exporter
+  ///    - httpClient: Custom HTTPClient implementation
+  ///    - envVarHeaders: Extra header key-values
+  ///    - requeueOnFailure: Re-append failed batches to the in-memory pending queue
   public convenience init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
                           config: OtlpConfiguration = OtlpConfiguration(),
                           httpClient: HTTPClient = BaseHTTPClient(),

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -16,21 +16,24 @@ public func defaultOltpHttpLoggingEndpoint() -> URL {
   URL(string: "http://localhost:4318/v1/logs")!
 }
 
-public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unchecked Sendable {
-  var pendingLogRecords: [ReadableLogRecord] = []
-  private let exporterLock = Lock()
+public final class OtlpHttpLogExporter: LogRecordExporter, @unchecked Sendable {
+  var pendingLogRecords: [ReadableLogRecord] {
+    base.snapshotPending()
+  }
+
+  private let base: OtlpHttpExporterBase<ReadableLogRecord>
   private var exporterMetrics: ExporterMetrics?
 
-  override public init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
-                       config: OtlpConfiguration = OtlpConfiguration(),
-                       httpClient: HTTPClient = BaseHTTPClient(),
-                       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
-                       requeueOnFailure: Bool = true) {
-    super.init(endpoint: endpoint,
-               config: config,
-               httpClient: httpClient,
-               envVarHeaders: envVarHeaders,
-               requeueOnFailure: requeueOnFailure)
+  public init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
+              config: OtlpConfiguration = OtlpConfiguration(),
+              httpClient: HTTPClient = BaseHTTPClient(),
+              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+              requeueOnFailure: Bool = true) {
+    base = OtlpHttpExporterBase(endpoint: endpoint,
+                                config: config,
+                                httpClient: httpClient,
+                                envVarHeaders: envVarHeaders,
+                                requeueOnFailure: requeueOnFailure)
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type
@@ -62,12 +65,7 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
 
   public func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord],
                      explicitTimeout: TimeInterval? = nil) -> OpenTelemetrySdk.ExportResult {
-    var sendingLogRecords: [ReadableLogRecord] = []
-    exporterLock.withLockVoid {
-      pendingLogRecords.append(contentsOf: logRecords)
-      sendingLogRecords = pendingLogRecords
-      pendingLogRecords = []
-    }
+    let sendingLogRecords = base.drainPending(adding: logRecords)
 
     let body =
       Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest.with { request in
@@ -75,20 +73,16 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
           logRecordList: sendingLogRecords)
       }
 
-    var request = createRequest(body: body, endpoint: endpoint)
+    var request = base.createRequest(body: body, endpoint: base.endpoint)
     exporterMetrics?.addSeen(value: sendingLogRecords.count)
-    request.timeoutInterval = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
-    httpClient.send(request: request) { [weak self] result in
+    request.timeoutInterval = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, base.config.timeout)
+    base.httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success:
         self?.exporterMetrics?.addSuccess(value: sendingLogRecords.count)
       case let .failure(error):
         self?.exporterMetrics?.addFailed(value: sendingLogRecords.count)
-        if self?.requeueOnFailure == true {
-          self?.exporterLock.withLockVoid {
-            self?.pendingLogRecords.append(contentsOf: sendingLogRecords)
-          }
-        }
+        self?.base.requeue(sendingLogRecords)
         OpenTelemetry.instance.feedbackHandler?("\(error)")
       }
     }
@@ -102,10 +96,7 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
 
   public func flush(explicitTimeout: TimeInterval? = nil) -> ExportResult {
     var exporterResult: ExportResult = .success
-    var pendingLogRecords: [ReadableLogRecord] = []
-    exporterLock.withLockVoid {
-      pendingLogRecords = self.pendingLogRecords
-    }
+    let pendingLogRecords = base.snapshotPending()
 
     if !pendingLogRecords.isEmpty {
       let sentCount = pendingLogRecords.count
@@ -115,21 +106,14 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
             logRecordList: pendingLogRecords)
         }
       let semaphore = DispatchSemaphore(value: 0)
-      var request = createRequest(body: body, endpoint: endpoint)
-      let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+      var request = base.createRequest(body: body, endpoint: base.endpoint)
+      let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, base.config.timeout)
       request.timeoutInterval = timeout
-      httpClient.send(request: request) { [weak self] result in
+      base.httpClient.send(request: request) { [weak self] result in
         switch result {
         case .success:
           self?.exporterMetrics?.addSuccess(value: sentCount)
-          // Drop the records we successfully flushed from the pending queue.
-          // Remove only the `sentCount` oldest entries so any records that
-          // `export()` appended concurrently are preserved for the next flush.
-          self?.exporterLock.withLockVoid {
-            guard let self else { return }
-            let n = min(sentCount, self.pendingLogRecords.count)
-            self.pendingLogRecords.removeFirst(n)
-          }
+          self?.base.dropFlushed(count: sentCount)
           exporterResult = ExportResult.success
         case let .failure(error):
           self?.exporterMetrics?.addFailed(value: sentCount)
@@ -148,4 +132,6 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
 
     return exporterResult
   }
+
+  public func shutdown(explicitTimeout: TimeInterval? = nil) {}
 }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -17,23 +17,23 @@ public func defaultOltpHttpLoggingEndpoint() -> URL {
 }
 
 public final class OtlpHttpLogExporter: LogRecordExporter, @unchecked Sendable {
-  var pendingLogRecords: [ReadableLogRecord] {
-    base.snapshotPending()
-  }
-
   private let base: OtlpHttpExporterBase<ReadableLogRecord>
   private var exporterMetrics: ExporterMetrics?
 
-  public init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
-              config: OtlpConfiguration = OtlpConfiguration(),
-              httpClient: HTTPClient = BaseHTTPClient(),
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
-              requeueOnFailure: Bool = true) {
-    base = OtlpHttpExporterBase(endpoint: endpoint,
-                                config: config,
-                                httpClient: httpClient,
-                                envVarHeaders: envVarHeaders,
-                                requeueOnFailure: requeueOnFailure)
+  init(base: OtlpHttpExporterBase<ReadableLogRecord>) {
+    self.base = base
+  }
+
+  public convenience init(endpoint: URL = defaultOltpHttpLoggingEndpoint(),
+                          config: OtlpConfiguration = OtlpConfiguration(),
+                          httpClient: HTTPClient = BaseHTTPClient(),
+                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+                          requeueOnFailure: Bool = true) {
+    self.init(base: OtlpHttpExporterBase(endpoint: endpoint,
+                                         config: config,
+                                         httpClient: httpClient,
+                                         envVarHeaders: envVarHeaders,
+                                         requeueOnFailure: requeueOnFailure))
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -31,29 +31,34 @@ public final class OtlpHttpMetricExporter: MetricExporter, @unchecked Sendable {
   var aggregationTemporalitySelector: AggregationTemporalitySelector
   var defaultAggregationSelector: DefaultAggregationSelector
 
-  var pendingMetrics: [MetricData] {
-    base.snapshotPending()
-  }
-
   private let base: OtlpHttpExporterBase<MetricData>
   private var exporterMetrics: ExporterMetrics?
 
   // MARK: - Init
 
-  public init(endpoint: URL, config: OtlpConfiguration = OtlpConfiguration(),
-              aggregationTemporalitySelector: AggregationTemporalitySelector =
-                AggregationTemporality.alwaysCumulative(),
-              defaultAggregationSelector: DefaultAggregationSelector = AggregationSelector.instance,
-              httpClient: HTTPClient = BaseHTTPClient(),
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
-              requeueOnFailure: Bool = true) {
+  init(base: OtlpHttpExporterBase<MetricData>,
+       aggregationTemporalitySelector: AggregationTemporalitySelector,
+       defaultAggregationSelector: DefaultAggregationSelector) {
+    self.base = base
     self.aggregationTemporalitySelector = aggregationTemporalitySelector
     self.defaultAggregationSelector = defaultAggregationSelector
-    base = OtlpHttpExporterBase(endpoint: endpoint,
-                                config: config,
-                                httpClient: httpClient,
-                                envVarHeaders: envVarHeaders,
-                                requeueOnFailure: requeueOnFailure)
+  }
+
+  public convenience init(endpoint: URL,
+                          config: OtlpConfiguration = OtlpConfiguration(),
+                          aggregationTemporalitySelector: AggregationTemporalitySelector =
+                          AggregationTemporality.alwaysCumulative(),
+                          defaultAggregationSelector: DefaultAggregationSelector = AggregationSelector.instance,
+                          httpClient: HTTPClient = BaseHTTPClient(),
+                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+                          requeueOnFailure: Bool = true) {
+    self.init(base: OtlpHttpExporterBase(endpoint: endpoint,
+                                         config: config,
+                                         httpClient: httpClient,
+                                         envVarHeaders: envVarHeaders,
+                                         requeueOnFailure: requeueOnFailure),
+              aggregationTemporalitySelector: aggregationTemporalitySelector,
+              defaultAggregationSelector: defaultAggregationSelector)
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -44,6 +44,15 @@ public final class OtlpHttpMetricExporter: MetricExporter, @unchecked Sendable {
     self.defaultAggregationSelector = defaultAggregationSelector
   }
 
+  /// A `convenience` constructor to configure the OTLP HTTP metric exporter
+  /// - Parameters:
+  ///    - endpoint: Exporter endpoint injected as dependency
+  ///    - config: Exporter configuration including type of exporter
+  ///    - aggregationTemporalitySelector: aggregator
+  ///    - defaultAggregationSelector: default aggregator
+  ///    - httpClient: Custom HTTPClient implementation
+  ///    - envVarHeaders: Extra header key-values
+  ///    - requeueOnFailure: Re-append failed batches to the in-memory pending queue
   public convenience init(endpoint: URL,
                           config: OtlpConfiguration = OtlpConfiguration(),
                           aggregationTemporalitySelector: AggregationTemporalitySelector =

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -27,12 +27,15 @@ public typealias StableOtlpHTTPMetricExporter = OtlpHttpMetricExporter
 @available(*, deprecated, renamed: "OtlpHttpMetricExporter")
 public typealias OtlpHTTPMetricExporter = OtlpHttpMetricExporter
 
-public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unchecked Sendable {
+public final class OtlpHttpMetricExporter: MetricExporter, @unchecked Sendable {
   var aggregationTemporalitySelector: AggregationTemporalitySelector
   var defaultAggregationSelector: DefaultAggregationSelector
 
-  var pendingMetrics: [MetricData] = []
-  private let exporterLock = Lock()
+  var pendingMetrics: [MetricData] {
+    base.snapshotPending()
+  }
+
+  private let base: OtlpHttpExporterBase<MetricData>
   private var exporterMetrics: ExporterMetrics?
 
   // MARK: - Init
@@ -46,12 +49,11 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
               requeueOnFailure: Bool = true) {
     self.aggregationTemporalitySelector = aggregationTemporalitySelector
     self.defaultAggregationSelector = defaultAggregationSelector
-
-    super.init(endpoint: endpoint,
-               config: config,
-               httpClient: httpClient,
-               envVarHeaders: envVarHeaders,
-               requeueOnFailure: requeueOnFailure)
+    base = OtlpHttpExporterBase(endpoint: endpoint,
+                                config: config,
+                                httpClient: httpClient,
+                                envVarHeaders: envVarHeaders,
+                                requeueOnFailure: requeueOnFailure)
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type
@@ -92,31 +94,22 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
   // MARK: - StableMetricsExporter
 
   public func export(metrics: [MetricData]) -> ExportResult {
-    var sendingMetrics: [MetricData] = []
-    exporterLock.withLockVoid {
-      pendingMetrics.append(contentsOf: metrics)
-      sendingMetrics = pendingMetrics
-      pendingMetrics = []
-    }
+    let sendingMetrics = base.drainPending(adding: metrics)
     let body =
       Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest.with {
         $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(
           metricData: sendingMetrics)
       }
     exporterMetrics?.addSeen(value: sendingMetrics.count)
-    var request = createRequest(body: body, endpoint: endpoint)
-    request.timeoutInterval = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
-    httpClient.send(request: request) { [weak self] result in
+    var request = base.createRequest(body: body, endpoint: base.endpoint)
+    request.timeoutInterval = min(TimeInterval.greatestFiniteMagnitude, base.config.timeout)
+    base.httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success:
         self?.exporterMetrics?.addSuccess(value: sendingMetrics.count)
       case let .failure(error):
         self?.exporterMetrics?.addFailed(value: sendingMetrics.count)
-        if self?.requeueOnFailure == true {
-          self?.exporterLock.withLockVoid {
-            self?.pendingMetrics.append(contentsOf: sendingMetrics)
-          }
-        }
+        self?.base.requeue(sendingMetrics)
         OpenTelemetry.instance.feedbackHandler?("\(error)")
       }
     }
@@ -126,10 +119,7 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
 
   public func flush() -> ExportResult {
     var exporterResult: ExportResult = .success
-    var pendingMetrics: [MetricData] = []
-    exporterLock.withLockVoid {
-      pendingMetrics = self.pendingMetrics
-    }
+    let pendingMetrics = base.snapshotPending()
     if !pendingMetrics.isEmpty {
       let sentCount = pendingMetrics.count
       let body =
@@ -139,19 +129,14 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
               metricData: pendingMetrics)
           }
       let semaphore = DispatchSemaphore(value: 0)
-      var request = createRequest(body: body, endpoint: endpoint)
-      let timeout = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+      var request = base.createRequest(body: body, endpoint: base.endpoint)
+      let timeout = min(TimeInterval.greatestFiniteMagnitude, base.config.timeout)
       request.timeoutInterval = timeout
-      httpClient.send(request: request) { [weak self] result in
+      base.httpClient.send(request: request) { [weak self] result in
         switch result {
         case .success:
           self?.exporterMetrics?.addSuccess(value: sentCount)
-          // Drop the records we successfully flushed from the pending queue.
-          self?.exporterLock.withLockVoid {
-            guard let self else { return }
-            let n = min(sentCount, self.pendingMetrics.count)
-            self.pendingMetrics.removeFirst(n)
-          }
+          self?.base.dropFlushed(count: sentCount)
         case let .failure(error):
           self?.exporterMetrics?.addFailed(value: sentCount)
           OpenTelemetry.instance.feedbackHandler?("\(error)")

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
@@ -16,22 +16,24 @@ public func defaultOltpHttpTracesEndpoint() -> URL {
   URL(string: "http://localhost:4318/v1/traces")!
 }
 
-public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @unchecked Sendable {
-  var pendingSpans: [SpanData] = []
+public final class OtlpHttpTraceExporter: SpanExporter, @unchecked Sendable {
+  var pendingSpans: [SpanData] {
+    base.snapshotPending()
+  }
 
-  private let exporterLock = Lock()
+  private let base: OtlpHttpExporterBase<SpanData>
   private var exporterMetrics: ExporterMetrics?
 
-  override public init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
-                       config: OtlpConfiguration = OtlpConfiguration(),
-                       httpClient: HTTPClient = BaseHTTPClient(),
-                       envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
-                       requeueOnFailure: Bool = true) {
-    super.init(endpoint: endpoint,
-               config: config,
-               httpClient: httpClient,
-               envVarHeaders: envVarHeaders,
-               requeueOnFailure: requeueOnFailure)
+  public init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
+              config: OtlpConfiguration = OtlpConfiguration(),
+              httpClient: HTTPClient = BaseHTTPClient(),
+              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+              requeueOnFailure: Bool = true) {
+    base = OtlpHttpExporterBase(endpoint: endpoint,
+                                config: config,
+                                httpClient: httpClient,
+                                envVarHeaders: envVarHeaders,
+                                requeueOnFailure: requeueOnFailure)
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type
@@ -64,12 +66,7 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
   public func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil)
     -> SpanExporterResultCode {
     var resultValue: SpanExporterResultCode = .success
-    var sendingSpans: [SpanData] = []
-    exporterLock.withLockVoid {
-      pendingSpans.append(contentsOf: spans)
-      sendingSpans = pendingSpans
-      pendingSpans = []
-    }
+    let sendingSpans = base.drainPending(adding: spans)
 
     let body =
       Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest.with {
@@ -77,23 +74,19 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
           spanDataList: sendingSpans)
       }
     let semaphore = DispatchSemaphore(value: 0)
-    var request = createRequest(body: body, endpoint: endpoint)
+    var request = base.createRequest(body: body, endpoint: base.endpoint)
 
-    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, base.config.timeout)
     request.timeoutInterval = timeout
 
     exporterMetrics?.addSeen(value: sendingSpans.count)
-    httpClient.send(request: request) { [weak self] result in
+    base.httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success:
         self?.exporterMetrics?.addSuccess(value: sendingSpans.count)
       case let .failure(error):
         self?.exporterMetrics?.addFailed(value: sendingSpans.count)
-        if self?.requeueOnFailure == true {
-          self?.exporterLock.withLockVoid {
-            self?.pendingSpans.append(contentsOf: sendingSpans)
-          }
-        }
+        self?.base.requeue(sendingSpans)
         OpenTelemetry.instance.feedbackHandler?("\(error)")
         resultValue = .failure
       }
@@ -111,10 +104,7 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
   public func flush(explicitTimeout: TimeInterval? = nil)
     -> SpanExporterResultCode {
     var resultValue: SpanExporterResultCode = .success
-    var pendingSpans: [SpanData] = []
-    exporterLock.withLockVoid {
-      pendingSpans = self.pendingSpans
-    }
+    let pendingSpans = base.snapshotPending()
     if !pendingSpans.isEmpty {
       let sentCount = pendingSpans.count
       let body =
@@ -123,20 +113,15 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
             spanDataList: pendingSpans)
         }
       let semaphore = DispatchSemaphore(value: 0)
-      var request = createRequest(body: body, endpoint: endpoint)
-      let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+      var request = base.createRequest(body: body, endpoint: base.endpoint)
+      let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, base.config.timeout)
       request.timeoutInterval = timeout
 
-      httpClient.send(request: request) { [weak self] result in
+      base.httpClient.send(request: request) { [weak self] result in
         switch result {
         case .success:
           self?.exporterMetrics?.addSuccess(value: sentCount)
-          // Drop the records we successfully flushed from the pending queue.
-          self?.exporterLock.withLockVoid {
-            guard let self else { return }
-            let n = min(sentCount, self.pendingSpans.count)
-            self.pendingSpans.removeFirst(n)
-          }
+          self?.base.dropFlushed(count: sentCount)
         case let .failure(error):
           self?.exporterMetrics?.addFailed(value: sentCount)
           OpenTelemetry.instance.feedbackHandler?("\(error)")
@@ -153,4 +138,6 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter, @uncheck
     }
     return resultValue
   }
+
+  public func shutdown(explicitTimeout: TimeInterval? = nil) {}
 }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
@@ -17,23 +17,23 @@ public func defaultOltpHttpTracesEndpoint() -> URL {
 }
 
 public final class OtlpHttpTraceExporter: SpanExporter, @unchecked Sendable {
-  var pendingSpans: [SpanData] {
-    base.snapshotPending()
-  }
-
   private let base: OtlpHttpExporterBase<SpanData>
   private var exporterMetrics: ExporterMetrics?
 
-  public init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
+  init(base: OtlpHttpExporterBase<SpanData>) {
+    self.base = base
+  }
+
+  public convenience init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
               config: OtlpConfiguration = OtlpConfiguration(),
               httpClient: HTTPClient = BaseHTTPClient(),
               envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
               requeueOnFailure: Bool = true) {
-    base = OtlpHttpExporterBase(endpoint: endpoint,
-                                config: config,
-                                httpClient: httpClient,
-                                envVarHeaders: envVarHeaders,
-                                requeueOnFailure: requeueOnFailure)
+    self.init(base: OtlpHttpExporterBase(endpoint: endpoint,
+                                         config: config,
+                                         httpClient: httpClient,
+                                         envVarHeaders: envVarHeaders,
+                                         requeueOnFailure: requeueOnFailure))
   }
 
   /// A `convenience` constructor to provide support for exporter metric using`StableMeterProvider` type

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
@@ -24,11 +24,18 @@ public final class OtlpHttpTraceExporter: SpanExporter, @unchecked Sendable {
     self.base = base
   }
 
+  /// A `convenience` constructor to configure the OTLP HTTP trace exporter
+  /// - Parameters:
+  ///    - endpoint: Exporter endpoint injected as dependency
+  ///    - config: Exporter configuration including type of exporter
+  ///    - httpClient: Custom HTTPClient implementation
+  ///    - envVarHeaders: Extra header key-values
+  ///    - requeueOnFailure: Re-append failed batches to the in-memory pending queue
   public convenience init(endpoint: URL = defaultOltpHttpTracesEndpoint(),
-              config: OtlpConfiguration = OtlpConfiguration(),
-              httpClient: HTTPClient = BaseHTTPClient(),
-              envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
-              requeueOnFailure: Bool = true) {
+                          config: OtlpConfiguration = OtlpConfiguration(),
+                          httpClient: HTTPClient = BaseHTTPClient(),
+                          envVarHeaders: [(String, String)]? = EnvVarHeaders.attributes,
+                          requeueOnFailure: Bool = true) {
     self.init(base: OtlpHttpExporterBase(endpoint: endpoint,
                                          config: config,
                                          httpClient: httpClient,

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHTTPExporterBaseTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHTTPExporterBaseTests.swift
@@ -16,7 +16,7 @@
   import XCTest
 
   class OtlpHttpExporterBaseTests: XCTestCase {
-    var exporter: OtlpHttpExporterBase!
+    var exporter: OtlpHttpExporterBase<SpanData>!
     var spans: [SpanData] = []
 
     override func setUp() {
@@ -33,7 +33,7 @@
     func testCreateRequestWithGzipCompression() {
       let config = OtlpConfiguration(compression: .gzip)
 
-      exporter = OtlpHttpExporterBase(
+      exporter = OtlpHttpExporterBase<SpanData>(
         endpoint: URL(
           string: "http://example.com"
         )!,
@@ -60,7 +60,7 @@
     func testCreateRequestWithDeflateCompression() {
       let config = OtlpConfiguration(compression: .deflate)
 
-      exporter = OtlpHttpExporterBase(
+      exporter = OtlpHttpExporterBase<SpanData>(
         endpoint: URL(
           string: "http://example.com"
         )!,
@@ -87,7 +87,7 @@
     func testCreateRequestWithNoCompression() {
       let config = OtlpConfiguration(compression: .none)
 
-      exporter = OtlpHttpExporterBase(
+      exporter = OtlpHttpExporterBase<SpanData>(
         endpoint: URL(
           string: "http://example.com"
         )!,

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
@@ -144,4 +144,79 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
       envVarHeaders: nil)
     XCTAssertNotNil(exporter)
   }
+
+  private func makePendingQueueBase(requeueOnFailure: Bool = true) -> OtlpHttpExporterBase<String> {
+    OtlpHttpExporterBase<String>(endpoint: URL(string: "http://example.com")!,
+                                 httpClient: BaseHTTPClient(),
+                                 envVarHeaders: nil,
+                                 requeueOnFailure: requeueOnFailure)
+  }
+
+  func testSnapshotPendingStartsEmpty() {
+    XCTAssertEqual(makePendingQueueBase().snapshotPending(), [])
+  }
+
+  func testDrainPendingReturnsAddedSignalsAndClearsPending() {
+    let base = makePendingQueueBase()
+    XCTAssertEqual(base.drainPending(adding: ["a", "b"]), ["a", "b"])
+    XCTAssertEqual(base.snapshotPending(), [])
+  }
+
+  func testDrainPendingIncludesPreviouslyRequeuedSignals() {
+    let base = makePendingQueueBase()
+    base.requeue(["prev"])
+    XCTAssertEqual(base.drainPending(adding: ["new"]), ["prev", "new"])
+    XCTAssertEqual(base.snapshotPending(), [])
+  }
+
+  func testRequeueAppendsSignalsToPending() {
+    let base = makePendingQueueBase()
+    base.requeue(["a"])
+    base.requeue(["b", "c"])
+    XCTAssertEqual(base.snapshotPending(), ["a", "b", "c"])
+  }
+
+  func testRequeueIsNoOpWhenDisabled() {
+    let base = makePendingQueueBase(requeueOnFailure: false)
+    base.requeue(["a"])
+    XCTAssertEqual(base.snapshotPending(), [])
+  }
+
+  func testDropFlushedRemovesSentCountFromPending() {
+    let base = makePendingQueueBase()
+    base.requeue(["a", "b", "c"])
+    base.dropFlushed(count: 2)
+    XCTAssertEqual(base.snapshotPending(), ["c"])
+  }
+
+  func testDropFlushedDoesNotRemoveMoreThanPending() {
+    let base = makePendingQueueBase()
+    base.requeue(["a"])
+    base.dropFlushed(count: 5)
+    XCTAssertEqual(base.snapshotPending(), [])
+  }
+
+  func testDropFlushedOnEmptyPendingIsNoOp() {
+    let base = makePendingQueueBase()
+    base.dropFlushed(count: 1)
+    XCTAssertEqual(base.snapshotPending(), [])
+  }
+
+  func testPendingQueueOperationsAreThreadSafe() {
+    let base = makePendingQueueBase()
+    let iterations = 100
+    let group = DispatchGroup()
+
+    for i in 0 ..< iterations {
+      group.enter()
+      DispatchQueue.global().async {
+        base.requeue(["\(i)"])
+        _ = base.snapshotPending()
+        group.leave()
+      }
+    }
+
+    group.wait()
+    XCTAssertEqual(base.snapshotPending().count, iterations)
+  }
 }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExporterBaseCoverageTests.swift
@@ -22,7 +22,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
   }
 
   func testEnvVarHeadersAppliedOnRequest() {
-    let exporter = OtlpHttpExporterBase(
+    let exporter = OtlpHttpExporterBase<SpanData>(
       endpoint: URL(string: "http://example.com")!,
       config: OtlpConfiguration(compression: .none),
       httpClient: BaseHTTPClient(),
@@ -32,7 +32,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
   }
 
   func testConfigHeadersAppliedWhenEnvVarHeadersNil() {
-    let exporter = OtlpHttpExporterBase(
+    let exporter = OtlpHttpExporterBase<SpanData>(
       endpoint: URL(string: "http://example.com")!,
       config: OtlpConfiguration(headers: [("X-Cfg-Header", "cfg-value")]),
       httpClient: BaseHTTPClient(),
@@ -43,7 +43,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
 
   func testHeadersProviderIsEvaluatedForEveryRequest() throws {
     let provider = MutableHeadersProvider([("Authorization", "Bearer first")])
-    let exporter = try OtlpHttpExporterBase(
+    let exporter = try OtlpHttpExporterBase<SpanData>(
       endpoint: XCTUnwrap(URL(string: "http://example.com")),
       config: OtlpConfiguration(
         headers: [
@@ -75,7 +75,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
 
   func testEnvVarHeadersTakePrecedenceOverHeadersProvider() throws {
     let provider = MutableHeadersProvider([("Authorization", "Bearer provider")])
-    let exporter = try OtlpHttpExporterBase(
+    let exporter = try OtlpHttpExporterBase<SpanData>(
       endpoint: XCTUnwrap(URL(string: "http://example.com")),
       config: OtlpConfiguration(headersProvider: provider.currentHeaders),
       httpClient: BaseHTTPClient(),
@@ -93,7 +93,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
 
   func testNilHeadersProviderRetainsStaticHeaders() throws {
     let provider = MutableHeadersProvider(nil)
-    let exporter = try OtlpHttpExporterBase(
+    let exporter = try OtlpHttpExporterBase<SpanData>(
       endpoint: XCTUnwrap(URL(string: "http://example.com")),
       config: OtlpConfiguration(
         headers: [("Authorization", "Bearer static")],
@@ -113,7 +113,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
   }
 
   func testContentTypeAndUserAgentSet() {
-    let exporter = OtlpHttpExporterBase(
+    let exporter = OtlpHttpExporterBase<SpanData>(
       endpoint: URL(string: "http://example.com")!,
       config: OtlpConfiguration(compression: .none),
       httpClient: BaseHTTPClient(),
@@ -127,7 +127,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
   @available(*, deprecated)
   func testDeprecatedInitWithURLSession() {
     let session = URLSession(configuration: .ephemeral)
-    let exporter = OtlpHttpExporterBase(
+    let exporter = OtlpHttpExporterBase<SpanData>(
       endpoint: URL(string: "http://example.com")!,
       config: OtlpConfiguration(),
       useSession: session,
@@ -137,7 +137,7 @@ final class OtlpHttpExporterBaseCoverageTests: XCTestCase {
 
   @available(*, deprecated)
   func testDeprecatedInitWithNilURLSessionUsesDefault() {
-    let exporter = OtlpHttpExporterBase(
+    let exporter = OtlpHttpExporterBase<SpanData>(
       endpoint: URL(string: "http://example.com")!,
       config: OtlpConfiguration(),
       useSession: nil,

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -112,39 +112,46 @@ private func sampleSpanData() -> SpanData {
 final class OtlpHttpLogExporterCoverageTests: XCTestCase {
   func testExportFailurePutsRecordsBackInPending() {
     let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
-    let exporter = OtlpHttpLogExporter(httpClient: client)
+    let base = OtlpHttpExporterBase<ReadableLogRecord>(endpoint: defaultOltpHttpLoggingEndpoint(),
+                                                       httpClient: client)
+    let exporter = OtlpHttpLogExporter(base: base)
 
     let rec = sampleLogRecord()
     let result = exporter.export(logRecords: [rec])
     XCTAssertEqual(result, .success)
 
-    // Failure path should put the record back into pendingLogRecords.
-    XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+    // Failure path should put the record back into the pending queue.
+    XCTAssertEqual(base.snapshotPending().count, 1)
     XCTAssertEqual(client.sentRequests.count, 1)
   }
 
   func testExportFailureWithRequeueDisabledLeavesPendingEmpty() {
     let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
-    let exporter = OtlpHttpLogExporter(httpClient: client, requeueOnFailure: false)
+    let base = OtlpHttpExporterBase<ReadableLogRecord>(endpoint: defaultOltpHttpLoggingEndpoint(),
+                                                       httpClient: client,
+                                                       requeueOnFailure: false)
+    let exporter = OtlpHttpLogExporter(base: base)
 
     _ = exporter.export(logRecords: [sampleLogRecord()])
-    XCTAssertEqual(exporter.pendingLogRecords.count, 0)
+    XCTAssertEqual(base.snapshotPending().count, 0)
     XCTAssertEqual(client.sentRequests.count, 1)
   }
 
   func testFlushWithPendingLogRecordsSuccess() {
     let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError()), .success])
-    let exporter = OtlpHttpLogExporter(httpClient: client)
+    let base = OtlpHttpExporterBase<ReadableLogRecord>(endpoint: defaultOltpHttpLoggingEndpoint(),
+                                                       httpClient: client)
+    let exporter = OtlpHttpLogExporter(base: base)
 
     _ = exporter.export(logRecords: [sampleLogRecord()])
-    XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+    XCTAssertEqual(base.snapshotPending().count, 1)
 
     let flushResult = exporter.flush()
     XCTAssertEqual(flushResult, .success)
     XCTAssertEqual(client.sentRequests.count, 2)
     // flush() must drop successfully-flushed records; otherwise every
     // subsequent flush re-sends them.
-    XCTAssertEqual(exporter.pendingLogRecords.count, 0)
+    XCTAssertEqual(base.snapshotPending().count, 0)
   }
 
   func testFlushWithNoPendingReturnsSuccess() {
@@ -228,21 +235,26 @@ final class OtlpHttpTraceExporterCoverageTests: XCTestCase {
 
   func testExportFailureWithRequeueDisabledLeavesPendingEmpty() {
     let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
-    let exporter = OtlpHttpTraceExporter(httpClient: client, requeueOnFailure: false)
+    let base = OtlpHttpExporterBase<SpanData>(endpoint: defaultOltpHttpTracesEndpoint(),
+                                              httpClient: client,
+                                              requeueOnFailure: false)
+    let exporter = OtlpHttpTraceExporter(base: base)
     let result = exporter.export(spans: [sampleSpanData()])
     XCTAssertEqual(result, .failure)
-    XCTAssertEqual(exporter.pendingSpans.count, 0)
+    XCTAssertEqual(base.snapshotPending().count, 0)
     XCTAssertEqual(client.sentRequests.count, 1)
   }
 
   func testFlushWithPendingSpans() {
     let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError()), .success])
-    let exporter = OtlpHttpTraceExporter(httpClient: client)
+    let base = OtlpHttpExporterBase<SpanData>(endpoint: defaultOltpHttpTracesEndpoint(),
+                                              httpClient: client)
+    let exporter = OtlpHttpTraceExporter(base: base)
     _ = exporter.export(spans: [sampleSpanData()])  // failure → back to pending
     XCTAssertEqual(exporter.flush(), .success)
     XCTAssertEqual(client.sentRequests.count, 2)
     // flush() must drop successfully-flushed spans.
-    XCTAssertEqual(exporter.pendingSpans.count, 0)
+    XCTAssertEqual(base.snapshotPending().count, 0)
   }
 
   func testFlushWithNoPendingReturnsSuccess() {
@@ -308,11 +320,15 @@ final class OtlpHttpExporterFlushTimeoutTests: XCTestCase {
 
   func testMetricFlushTimesOutWhenResponseNeverArrives() {
     let client = HangingAfterFirstFailureHTTPClient()
-    let exporter = OtlpHttpMetricExporter(endpoint: URL(string: "http://localhost:4318/v1/metrics")!,
-                                          config: OtlpConfiguration(timeout: timeout),
-                                          httpClient: client)
+    let endpoint = URL(string: "http://localhost:4318/v1/metrics")!
+    let base = OtlpHttpExporterBase<MetricData>(endpoint: endpoint,
+                                                config: OtlpConfiguration(timeout: timeout),
+                                                httpClient: client)
+    let exporter = OtlpHttpMetricExporter(base: base,
+                                          aggregationTemporalitySelector: AggregationTemporality.alwaysCumulative(),
+                                          defaultAggregationSelector: AggregationSelector.instance)
     _ = exporter.export(metrics: [.empty])
-    XCTAssertEqual(exporter.pendingMetrics.count, 1)
+    XCTAssertEqual(base.snapshotPending().count, 1)
 
     let start = Date()
     XCTAssertEqual(exporter.flush(), .failure)
@@ -321,10 +337,12 @@ final class OtlpHttpExporterFlushTimeoutTests: XCTestCase {
 
   func testLogFlushTimesOutWhenResponseNeverArrives() {
     let client = HangingAfterFirstFailureHTTPClient()
-    let exporter = OtlpHttpLogExporter(config: OtlpConfiguration(timeout: timeout),
-                                       httpClient: client)
+    let base = OtlpHttpExporterBase<ReadableLogRecord>(endpoint: defaultOltpHttpLoggingEndpoint(),
+                                                       config: OtlpConfiguration(timeout: timeout),
+                                                       httpClient: client)
+    let exporter = OtlpHttpLogExporter(base: base)
     _ = exporter.export(logRecords: [sampleLogRecord()])
-    XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+    XCTAssertEqual(base.snapshotPending().count, 1)
 
     let start = Date()
     XCTAssertEqual(exporter.flush(), .failure)
@@ -333,12 +351,15 @@ final class OtlpHttpExporterFlushTimeoutTests: XCTestCase {
 
   func testExportFailureWithRequeueDisabledLeavesPendingEmpty() {
     let client = StubHTTPClient(outcomes: [.failure(TransientNetworkError())])
-    let exporter = OtlpHttpMetricExporter(
-      endpoint: URL(string: "http://localhost:4318/v1/metrics")!,
-      httpClient: client,
-      requeueOnFailure: false)
+    let endpoint = URL(string: "http://localhost:4318/v1/metrics")!
+    let base = OtlpHttpExporterBase<MetricData>(endpoint: endpoint,
+                                                httpClient: client,
+                                                requeueOnFailure: false)
+    let exporter = OtlpHttpMetricExporter(base: base,
+                                          aggregationTemporalitySelector: AggregationTemporality.alwaysCumulative(),
+                                          defaultAggregationSelector: AggregationSelector.instance)
     _ = exporter.export(metrics: [.empty])
-    XCTAssertEqual(exporter.pendingMetrics.count, 0)
+    XCTAssertEqual(base.snapshotPending().count, 0)
     XCTAssertEqual(client.sentRequests.count, 1)
   }
 }

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
@@ -63,19 +63,25 @@ final class OtlpHttpMetricExporterCoverageTests: XCTestCase {
 
   func testExportFailurePutsMetricsBackInPending() {
     let client = StubHTTPClient(outcomes: [.failure(FakeError())])
-    let exporter = OtlpHttpMetricExporter(endpoint: endpoint, httpClient: client)
+    let base = OtlpHttpExporterBase<MetricData>(endpoint: endpoint, httpClient: client)
+    let exporter = OtlpHttpMetricExporter(base: base,
+                                          aggregationTemporalitySelector: AggregationTemporality.alwaysCumulative(),
+                                          defaultAggregationSelector: AggregationSelector.instance)
     _ = exporter.export(metrics: [.empty])
-    XCTAssertEqual(exporter.pendingMetrics.count, 1)
+    XCTAssertEqual(base.snapshotPending().count, 1)
   }
 
   func testFlushWithPendingReturnsSuccessAfterRetry() {
     let client = StubHTTPClient(outcomes: [.failure(FakeError()), .success])
-    let exporter = OtlpHttpMetricExporter(endpoint: endpoint, httpClient: client)
+    let base = OtlpHttpExporterBase<MetricData>(endpoint: endpoint, httpClient: client)
+    let exporter = OtlpHttpMetricExporter(base: base,
+                                          aggregationTemporalitySelector: AggregationTemporality.alwaysCumulative(),
+                                          defaultAggregationSelector: AggregationSelector.instance)
     _ = exporter.export(metrics: [.empty])
     XCTAssertEqual(exporter.flush(), .success)
     XCTAssertEqual(client.sentRequests.count, 2)
     // flush() must drop successfully-flushed metrics.
-    XCTAssertEqual(exporter.pendingMetrics.count, 0)
+    XCTAssertEqual(base.snapshotPending().count, 0)
   }
 
   func testFlushWithPendingFailureReturnsFailure() {


### PR DESCRIPTION
## Motivation
I'm working on this https://github.com/open-telemetry/opentelemetry-swift/pull/1146#issuecomment-5207600952
But the code needs a lot of changes. 
To avoid a large PR, I started by refactoring the related code. 

## Summary

- Replace OTLP HTTP exporter inheritance from `OtlpHttpExporterBase` with composition via a generic `OtlpHttpExporterBase<Signal>`.
- Centralize pending queue handling (`drainPending`, `requeue`, `snapshotPending`, `dropFlushed`) and HTTP transport in the internal base helper.
- Mark trace, log, and metric HTTP exporters as `final`; keep their public initializers and export behavior unchanged.

## Test plan

- [x] `swift build --build-tests`
- [x] `swift test --filter 'OtlpHttp|OtlpHTTP'` (69 tests)