### PR TITLE
feat(sessions): add explicit linked reset

### DIFF
--- a/Sources/Instrumentation/Sessions/README.md
+++ b/Sources/Instrumentation/Sessions/README.md
@@ -4,7 +4,7 @@ Automatic session tracking for OpenTelemetry Swift applications. Creates unique 
 
 ## Features
 
-- **Automatic Session Management** - Creates and manages session lifecycles with configurable timeouts
+- **Session Management** - Creates and manages session lifecycles with configurable timeouts and explicit activity
 - **Session Events** - Emits OpenTelemetry log records for session start/end events
 - **Span Attribution** - Automatically adds session IDs to all spans via span processor
 - **Persistence** - Sessions persist across app restarts using UserDefaults
@@ -18,22 +18,31 @@ Automatic session tracking for OpenTelemetry Swift applications. Creates unique 
 import Sessions
 import OpenTelemetrySdk
 
+let sessionManager = SessionManager()
+SessionManagerProvider.register(sessionManager: sessionManager)
+
 // Record session start and end events
 SessionEventInstrumentation.install()
 
 // Add session attributes to spans
-let sessionSpanProcessor = SessionSpanProcessor()
+let sessionSpanProcessor = SessionSpanProcessor(sessionManager: sessionManager)
 let tracerProvider = TracerProviderBuilder()
     .add(spanProcessor: sessionSpanProcessor)
     .build()
 
-// Add session atttributes to log records
+// Add session attributes to log records
 let sessionProcessor = SessionLogRecordProcessor(
-    nextProcessor: SimpleLogRecordProcessor(logRecordExporter: ConsoleLogRecordExporter())
+    nextProcessor: SimpleLogRecordProcessor(logRecordExporter: ConsoleLogRecordExporter()),
+    sessionManager: sessionManager
 )
 let builder = LoggerProviderBuilder()
   .with(processors: [sessionProcessor])
   .with(resource: resource)
+
+// Call this from your app's foreground callback and other meaningful interactions.
+func applicationBecameActive() {
+    sessionManager.recordActivity()
+}
 ```
 
 **Custom Configuration**:
@@ -51,7 +60,7 @@ SessionManagerProvider.register(sessionManager: sessionManager)
 **Getting Session Information**:
 
 ```swift
-// Get the current session without extending inactivity
+// Get the current session and record activity, preserving the existing API behavior
 let session = SessionManagerProvider.getInstance().getSession()
 print("Session ID: \(session.id)")
 
@@ -71,11 +80,13 @@ if let session = SessionManagerProvider.getInstance().peekSession() {
 
 ### SessionManager
 
-Manages session lifecycle with automatic expiration and explicit activity tracking.
+Manages session lifecycle with automatic expiration and explicit activity tracking. Direct
+`getSession()` calls continue to record activity for compatibility, while automatic span and log
+attribution is passive.
 
 ```swift
 let manager = SessionManager(configuration: SessionConfig(sessionTimeout: 1800))
-let session = manager.getSession() // Creates or retrieves without extending
+let session = manager.getSession() // Creates or retrieves and records activity
 manager.recordActivity() // Extends inactivity after meaningful activity
 manager.resetSession() // Starts a linked replacement
 let current = manager.peekSession() // Peek without creating or extending
@@ -155,10 +166,10 @@ let config = SessionConfig.builder()
 
 ### Session Timeout Behavior
 
-- Sessions automatically expire after the configured timeout period of inactivity
-- `getSession()` creates or retrieves a session without extending inactivity
+- Sessions expire after the configured timeout since the most recent recorded activity
+- `getSession()` preserves its existing behavior and records activity
 - Call `recordActivity()` for meaningful interactions or lifecycle transitions that should extend inactivity
-- Passive spans, logs, and background work do not keep a session alive
+- Span and log processors use passive access, so telemetry and background work do not keep a session alive
 - Sessions can also expire after `maxLifetime`, even if `recordActivity()` continues to extend inactivity
 - `resetSession()` ends the current session and persists one linked replacement
 - Set `restorePersistedSession` to `false` to start a new session on each clean application start while linking the persisted session as `previous_id`
@@ -236,7 +247,7 @@ The session's end time is carried on the log record's `timestamp` field, not as 
 
 1. **Use SessionManagerProvider** - Register your session manager as a singleton for consistent access
 2. **Configure Appropriate Timeouts** - Set session timeouts based on your app's usage patterns
-3. **Record Meaningful Activity** - Call `recordActivity()` from user interactions or foreground transitions, not passive telemetry
+3. **Record Meaningful Activity** - Wire `recordActivity()` to foreground transitions and meaningful user interactions
 4. **Add Span Processor Early** - Register the SessionSpanProcessor before creating spans
 5. **Handle Session Events** - Set up SessionEventInstrumentation to capture session lifecycle
 
@@ -247,7 +258,8 @@ Sessions are automatically persisted to UserDefaults and can be resumed on app r
 - By default, active persisted sessions continue from their previous state
 - Set `restorePersistedSession` to `false` to start a new session on clean start while linking and ending the persisted session
 - Expired sessions create new sessions with proper `previous_id` linking
-- Session data is saved periodically (every 30 seconds) to minimize disk I/O
+- Session starts and resets are saved immediately
+- Activity updates are coalesced and saved on a 30-second timer to minimize disk I/O
 
 ## Thread Safety
 

--- a/Sources/Instrumentation/Sessions/README.md
+++ b/Sources/Instrumentation/Sessions/README.md
@@ -170,6 +170,7 @@ let config = SessionConfig.builder()
 - `getSession()` preserves its existing behavior and records activity
 - Call `recordActivity()` for meaningful interactions or lifecycle transitions that should extend inactivity
 - Span and log processors use passive access, so telemetry and background work do not keep a session alive
+- Without a `recordActivity()` call, a session ends at `sessionTimeout`; its duration is zero because no meaningful activity was recorded, and a longer `maxLifetime` does not apply
 - Sessions can also expire after `maxLifetime`, even if `recordActivity()` continues to extend inactivity
 - `resetSession()` ends the current session and persists one linked replacement
 - Set `restorePersistedSession` to `false` to start a new session on each clean application start while linking the persisted session as `previous_id`
@@ -266,5 +267,6 @@ Sessions are automatically persisted to UserDefaults and can be resumed on app r
 All components are designed for concurrent access:
 
 - `SessionManager` uses locks for thread-safe session access
+- Concurrent lifecycle effects are published in session order without making one caller wait on another thread's exporter or observer callbacks
 - `SessionManagerProvider` provides thread-safe singleton access
 - `SessionStore` handles concurrent persistence operations safely

--- a/Sources/Instrumentation/Sessions/README.md
+++ b/Sources/Instrumentation/Sessions/README.md
@@ -4,7 +4,7 @@ Automatic session tracking for OpenTelemetry Swift applications. Creates unique 
 
 ## Features
 
-- **Session Management** - Creates and manages session lifecycles with configurable timeouts and explicit activity
+- **Session Management** - Creates and manages session lifecycles with configurable timeouts and explicit reset
 - **Session Events** - Emits OpenTelemetry log records for session start/end events
 - **Span Attribution** - Automatically adds session IDs to all spans via span processor
 - **Persistence** - Sessions persist across app restarts using UserDefaults
@@ -39,10 +39,6 @@ let builder = LoggerProviderBuilder()
   .with(processors: [sessionProcessor])
   .with(resource: resource)
 
-// Call this from your app's foreground callback and other meaningful interactions.
-func applicationBecameActive() {
-    sessionManager.recordActivity()
-}
 ```
 
 **Custom Configuration**:
@@ -60,12 +56,9 @@ SessionManagerProvider.register(sessionManager: sessionManager)
 **Getting Session Information**:
 
 ```swift
-// Get the current session and record activity, preserving the existing API behavior
+// Get the current session and extend its inactivity deadline
 let session = SessionManagerProvider.getInstance().getSession()
 print("Session ID: \(session.id)")
-
-// Record a meaningful user interaction or foreground transition
-SessionManagerProvider.getInstance().recordActivity()
 
 // End the current session after sign-out and start a linked replacement
 SessionManagerProvider.getInstance().resetSession()
@@ -80,14 +73,12 @@ if let session = SessionManagerProvider.getInstance().peekSession() {
 
 ### SessionManager
 
-Manages session lifecycle with automatic expiration and explicit activity tracking. Direct
-`getSession()` calls continue to record activity for compatibility, while automatic span and log
-attribution is passive.
+Manages session lifecycle with automatic expiration and explicit reset. Session access, including
+automatic span and log attribution, extends the inactivity deadline.
 
 ```swift
 let manager = SessionManager(configuration: SessionConfig(sessionTimeout: 1800))
-let session = manager.getSession() // Creates or retrieves and records activity
-manager.recordActivity() // Extends inactivity after meaningful activity
+let session = manager.getSession() // Creates or retrieves and extends the session
 manager.resetSession() // Starts a linked replacement
 let current = manager.peekSession() // Peek without creating or extending
 ```
@@ -166,12 +157,9 @@ let config = SessionConfig.builder()
 
 ### Session Timeout Behavior
 
-- Sessions expire after the configured timeout since the most recent recorded activity
-- `getSession()` preserves its existing behavior and records activity
-- Call `recordActivity()` for meaningful interactions or lifecycle transitions that should extend inactivity
-- Span and log processors use passive access, so telemetry and background work do not keep a session alive
-- Without a `recordActivity()` call, a session ends at `sessionTimeout`; its duration is zero because no meaningful activity was recorded, and a longer `maxLifetime` does not apply
-- Sessions can also expire after `maxLifetime`, even if `recordActivity()` continues to extend inactivity
+- Sessions expire after the configured timeout since the most recent access
+- `getSession()` and automatic span and log attribution extend the inactivity deadline
+- Sessions can also expire after `maxLifetime`, even if access continues to extend inactivity
 - `resetSession()` ends the current session and persists one linked replacement
 - Set `restorePersistedSession` to `false` to start a new session on each clean application start while linking the persisted session as `previous_id`
 - When `restorePersistedSession` is `false`, the persisted session's `session.end` uses its last known activity time, capped at the new session start time
@@ -248,9 +236,8 @@ The session's end time is carried on the log record's `timestamp` field, not as 
 
 1. **Use SessionManagerProvider** - Register your session manager as a singleton for consistent access
 2. **Configure Appropriate Timeouts** - Set session timeouts based on your app's usage patterns
-3. **Record Meaningful Activity** - Wire `recordActivity()` to foreground transitions and meaningful user interactions
-4. **Add Span Processor Early** - Register the SessionSpanProcessor before creating spans
-5. **Handle Session Events** - Set up SessionEventInstrumentation to capture session lifecycle
+3. **Add Span Processor Early** - Register the SessionSpanProcessor before creating spans
+4. **Handle Session Events** - Set up SessionEventInstrumentation to capture session lifecycle
 
 ## Persistence
 
@@ -260,7 +247,7 @@ Sessions are automatically persisted to UserDefaults and can be resumed on app r
 - Set `restorePersistedSession` to `false` to start a new session on clean start while linking and ending the persisted session
 - Expired sessions create new sessions with proper `previous_id` linking
 - Session starts and resets are saved immediately
-- Activity updates are coalesced and saved on a 30-second timer to minimize disk I/O
+- Access updates are coalesced and saved on a 30-second timer to minimize disk I/O
 
 ## Thread Safety
 

--- a/Sources/Instrumentation/Sessions/README.md
+++ b/Sources/Instrumentation/Sessions/README.md
@@ -51,9 +51,15 @@ SessionManagerProvider.register(sessionManager: sessionManager)
 **Getting Session Information**:
 
 ```swift
-// Get current session (extends session if active)
+// Get the current session without extending inactivity
 let session = SessionManagerProvider.getInstance().getSession()
 print("Session ID: \(session.id)")
+
+// Record a meaningful user interaction or foreground transition
+SessionManagerProvider.getInstance().recordActivity()
+
+// End the current session after sign-out and start a linked replacement
+SessionManagerProvider.getInstance().resetSession()
 
 // Peek at session without extending it
 if let session = SessionManagerProvider.getInstance().peekSession() {
@@ -65,12 +71,14 @@ if let session = SessionManagerProvider.getInstance().peekSession() {
 
 ### SessionManager
 
-Manages session lifecycle with automatic expiration and renewal.
+Manages session lifecycle with automatic expiration and explicit activity tracking.
 
 ```swift
 let manager = SessionManager(configuration: SessionConfig(sessionTimeout: 1800))
-let session = manager.getSession() // Creates or extends session
-let session = manager.peekSession() // Peek without extending
+let session = manager.getSession() // Creates or retrieves without extending
+manager.recordActivity() // Extends inactivity after meaningful activity
+manager.resetSession() // Starts a linked replacement
+let current = manager.peekSession() // Peek without creating or extending
 ```
 
 ### SessionManagerProvider
@@ -148,8 +156,11 @@ let config = SessionConfig.builder()
 ### Session Timeout Behavior
 
 - Sessions automatically expire after the configured timeout period of inactivity
-- Accessing a session via `getSession()` extends the expiration time
-- Sessions can also expire after `maxLifetime`, even if `getSession()` continues to extend inactivity
+- `getSession()` creates or retrieves a session without extending inactivity
+- Call `recordActivity()` for meaningful interactions or lifecycle transitions that should extend inactivity
+- Passive spans, logs, and background work do not keep a session alive
+- Sessions can also expire after `maxLifetime`, even if `recordActivity()` continues to extend inactivity
+- `resetSession()` ends the current session and persists one linked replacement
 - Set `restorePersistedSession` to `false` to start a new session on each clean application start while linking the persisted session as `previous_id`
 - When `restorePersistedSession` is `false`, the persisted session's `session.end` uses its last known activity time, capped at the new session start time
 - Expired sessions trigger `session.end` events and create new sessions with `previous_id` links
@@ -225,8 +236,9 @@ The session's end time is carried on the log record's `timestamp` field, not as 
 
 1. **Use SessionManagerProvider** - Register your session manager as a singleton for consistent access
 2. **Configure Appropriate Timeouts** - Set session timeouts based on your app's usage patterns
-3. **Add Span Processor Early** - Register the SessionSpanProcessor before creating spans
-4. **Handle Session Events** - Set up SessionEventInstrumentation to capture session lifecycle
+3. **Record Meaningful Activity** - Call `recordActivity()` from user interactions or foreground transitions, not passive telemetry
+4. **Add Span Processor Early** - Register the SessionSpanProcessor before creating spans
+5. **Handle Session Events** - Set up SessionEventInstrumentation to capture session lifecycle
 
 ## Persistence
 

--- a/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift
+++ b/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift
@@ -34,7 +34,7 @@ public class SessionLogRecordProcessor: LogRecordProcessor {
 
     // Only add session attributes if they don't already exist
     if logRecord.attributes[SemanticConventions.Session.id.rawValue] == nil || logRecord.attributes[SemanticConventions.Session.previousId.rawValue] == nil {
-      let session = sessionManager.getSessionForAttribution()
+      let session = sessionManager.getSession()
 
       // Add session.id if not already present
       if logRecord.attributes[SemanticConventions.Session.id.rawValue] == nil {

--- a/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift
+++ b/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift
@@ -23,7 +23,8 @@ public class SessionLogRecordProcessor: LogRecordProcessor {
   /// Called when a log record is emitted - adds session attributes and forwards to next processor
   public func onEmit(logRecord: ReadableLogRecord) {
     if logRecord.eventName == SessionConstants.sessionStartEvent ||
-      logRecord.eventName == SessionConstants.sessionEndEvent {
+      logRecord.eventName == SessionConstants.sessionEndEvent,
+      logRecord.attributes[SemanticConventions.Session.id.rawValue] != nil {
       // Lifecycle events already carry the historical session context they describe.
       nextProcessor.onEmit(logRecord: logRecord)
       return

--- a/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift
+++ b/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift
@@ -22,11 +22,18 @@ public class SessionLogRecordProcessor: LogRecordProcessor {
 
   /// Called when a log record is emitted - adds session attributes and forwards to next processor
   public func onEmit(logRecord: ReadableLogRecord) {
+    if logRecord.eventName == SessionConstants.sessionStartEvent ||
+      logRecord.eventName == SessionConstants.sessionEndEvent {
+      // Lifecycle events already carry the historical session context they describe.
+      nextProcessor.onEmit(logRecord: logRecord)
+      return
+    }
+
     var enhancedRecord = logRecord
 
     // Only add session attributes if they don't already exist
     if logRecord.attributes[SemanticConventions.Session.id.rawValue] == nil || logRecord.attributes[SemanticConventions.Session.previousId.rawValue] == nil {
-      let session = sessionManager.getSession()
+      let session = sessionManager.getSessionForAttribution()
 
       // Add session.id if not already present
       if logRecord.attributes[SemanticConventions.Session.id.rawValue] == nil {

--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -14,11 +14,6 @@ public class SessionManager: @unchecked Sendable {
     let previousSessionToEnd: Session?
   }
 
-  private enum EffectOperation {
-    case save(Session)
-    case transition(SessionTransition)
-  }
-
   private struct SessionAccess {
     let session: Session
     let shouldDrainEffects: Bool
@@ -29,7 +24,8 @@ public class SessionManager: @unchecked Sendable {
   private var persistedPreviousSession: Session?
   private let lock = NSLock()
   private let effectsLock = NSLock()
-  private var pendingEffects: [EffectOperation] = []
+  private let effectDrainQueue = DispatchQueue(label: "io.opentelemetry.sessions.effects")
+  private var pendingTransitions: [SessionTransition] = []
   private var isDrainingEffects = false
 
   /// Initializes the session manager and restores any previous session from disk
@@ -76,7 +72,7 @@ public class SessionManager: @unchecked Sendable {
   /// - Returns: The newly created session
   @discardableResult
   public func resetSession() -> Session {
-    let nextSession: Session = lock.withLock {
+    let access: SessionAccess = lock.withLock {
       let now = Date()
       let previousSession = session ?? persistedPreviousSession
       let previousSessionToEnd = previousSession.map { previous in
@@ -85,15 +81,18 @@ public class SessionManager: @unchecked Sendable {
       let nextSession = locked_startSession(previousId: previousSession?.id, at: now)
       session = nextSession
       persistedPreviousSession = nil
-      enqueueEffect(.transition(SessionTransition(
+      SessionStore.saveImmediately(session: nextSession)
+      let shouldDrainEffects = enqueueTransition(SessionTransition(
         session: nextSession,
         previousSessionToEnd: previousSessionToEnd
-      )))
-      return nextSession
+      ))
+      return SessionAccess(session: nextSession, shouldDrainEffects: shouldDrainEffects)
     }
 
-    drainPendingEffects()
-    return nextSession
+    if access.shouldDrainEffects {
+      drainClaimedTransition()
+    }
+    return access.session
   }
 
   /// Gets the current session without extending its inactivity deadline
@@ -164,19 +163,20 @@ public class SessionManager: @unchecked Sendable {
 
       let refreshedSession = locked_refreshSession(session: session, at: now)
       self.session = refreshedSession
-      enqueueEffect(.save(refreshedSession))
-      return SessionAccess(session: refreshedSession, shouldDrainEffects: true)
+      SessionStore.scheduleSave(session: refreshedSession)
+      return SessionAccess(session: refreshedSession, shouldDrainEffects: false)
     }
 
     let previousSession = session ?? persistedPreviousSession
     let nextSession = locked_startSession(previousId: previousSession?.id, at: now)
     session = nextSession
     persistedPreviousSession = nil
-    enqueueEffect(.transition(SessionTransition(
+    SessionStore.saveImmediately(session: nextSession)
+    let shouldDrainEffects = enqueueTransition(SessionTransition(
       session: nextSession,
       previousSessionToEnd: previousSession
-    )))
-    return SessionAccess(session: nextSession, shouldDrainEffects: true)
+    ))
+    return SessionAccess(session: nextSession, shouldDrainEffects: shouldDrainEffects)
   }
 
   /// Creates an ended snapshot whose end time is fixed to `date`.
@@ -198,53 +198,60 @@ public class SessionManager: @unchecked Sendable {
       locked_accessSession(recordActivity: recordActivity, at: Date())
     }
     if access.shouldDrainEffects {
-      drainPendingEffects()
+      drainClaimedTransition()
     }
     return access.session
   }
 
-  /// Enqueues an effect while a state transition holds `lock`.
-  /// Effect draining never acquires `lock` while holding `effectsLock`.
-  private func enqueueEffect(_ operation: EffectOperation) {
-    effectsLock.withLock { pendingEffects.append(operation) }
-  }
-
-  /// Drains ordered persistence and lifecycle effects without holding a lock around user code.
-  ///
-  /// One caller claims the drain. Other callers return after queuing their work so callbacks in
-  /// exporters and observers cannot create a cross-thread wait cycle. The drainer preserves state
-  /// order and completes effects that are enqueued while it is publishing.
-  private func drainPendingEffects() {
-    let shouldDrain = effectsLock.withLock {
+  /// Enqueues a transition and claims its drain while a state transition holds `lock`.
+  /// Transition draining never acquires `lock` while holding `effectsLock`.
+  private func enqueueTransition(_ transition: SessionTransition) -> Bool {
+    return effectsLock.withLock {
+      pendingTransitions.append(transition)
       guard !isDrainingEffects else { return false }
       isDrainingEffects = true
       return true
     }
-    guard shouldDrain else { return }
+  }
 
-    while true {
-      guard let effect = effectsLock.withLock({ () -> EffectOperation? in
-        guard !pendingEffects.isEmpty else {
-          isDrainingEffects = false
-          return nil
-        }
-        return pendingEffects.removeFirst()
-      }) else {
-        return
-      }
+  /// Publishes the transition claimed by the caller without holding a lock around user code.
+  ///
+  /// Follow-on transitions queued by concurrent or reentrant callers are handed to a private
+  /// serial queue so one caller cannot absorb unrelated exporter or observer work.
+  private func drainClaimedTransition() {
+    guard let transition = takeNextTransitionOrReleaseClaim() else { return }
+    publish(transition)
 
-      switch effect {
-      case let .save(session):
-        SessionStore.scheduleSave(session: session)
-      case let .transition(transition):
-        publish(transition)
-      }
+    let shouldContinue = effectsLock.withLock {
+      guard pendingTransitions.isEmpty else { return true }
+      isDrainingEffects = false
+      return false
+    }
+    if shouldContinue {
+      effectDrainQueue.async { [self] in drainRemainingTransitions() }
     }
   }
 
-  /// Persists and publishes one session transition.
+  /// Drains transitions after caller-side work has been bounded to one transition.
+  private func drainRemainingTransitions() {
+    while let transition = takeNextTransitionOrReleaseClaim() {
+      publish(transition)
+    }
+  }
+
+  /// Returns the next transition or releases the drain claim atomically with the empty check.
+  private func takeNextTransitionOrReleaseClaim() -> SessionTransition? {
+    return effectsLock.withLock {
+      guard !pendingTransitions.isEmpty else {
+        isDrainingEffects = false
+        return nil
+      }
+      return pendingTransitions.removeFirst()
+    }
+  }
+
+  /// Publishes one already-persisted session transition.
   private func publish(_ transition: SessionTransition) {
-    SessionStore.saveImmediately(session: transition.session)
     if let previousSessionToEnd = transition.previousSessionToEnd {
       SessionEventInstrumentation.addSession(session: previousSessionToEnd, eventType: .end)
     }

--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -7,19 +7,49 @@ import Foundation
 
 /// Manages OpenTelemetry sessions with automatic expiration and persistence.
 /// Provides thread-safe access to session information and handles session lifecycle.
-/// Sessions are extended only when meaningful activity is recorded.
+/// Direct access and explicit activity extend a session. Telemetry attribution is passive.
 public class SessionManager: @unchecked Sendable {
-  private struct SessionAccess {
+  private struct SessionTransition {
     let session: Session
     let previousSessionToEnd: Session?
-    let startedNewSession: Bool
   }
 
-  private var configuration: SessionConfig
+  private enum EffectOperation {
+    case save(Session)
+    case transition(SessionTransition)
+
+    var requiresSynchronousCompletion: Bool {
+      switch self {
+      case .save:
+        return false
+      case .transition:
+        return true
+      }
+    }
+  }
+
+  private final class PendingEffect: @unchecked Sendable {
+    let operation: EffectOperation
+    let completion = DispatchSemaphore(value: 0)
+
+    init(operation: EffectOperation) {
+      self.operation = operation
+    }
+  }
+
+  private struct SessionAccess {
+    let session: Session
+    let pendingEffect: PendingEffect?
+  }
+
+  private let configuration: SessionConfig
   private var session: Session?
   private var persistedPreviousSession: Session?
-  private let operationLock = NSRecursiveLock()
   private let lock = NSLock()
+  private let effectsLock = NSLock()
+  private var pendingEffects: [PendingEffect] = []
+  private var isDrainingEffects = false
+  private let effectDrainerThreadKey = "io.opentelemetry.sessions.effect-drainer.\(UUID().uuidString)"
 
   /// Initializes the session manager and restores any previous session from disk
   /// - Parameter configuration: Session configuration settings
@@ -28,19 +58,14 @@ public class SessionManager: @unchecked Sendable {
     loadPersistedSessionFromDisk()
   }
 
-  /// Gets the current session, creating a linked replacement if it has expired.
+  /// Gets the current session, creating or extending it as needed.
   ///
-  /// Access is passive and does not extend the inactivity deadline. Call
-  /// ``recordActivity()`` when a user interaction or lifecycle transition should
-  /// keep the current session active.
+  /// This preserves the existing behavior where direct access records activity.
+  /// Automatic telemetry processors use a passive internal access path instead.
   /// - Returns: The current active session
   @discardableResult
   public func getSession() -> Session {
-    return operationLock.withLock {
-      let access = lock.withLock { locked_accessSession() }
-      completeAccess(access)
-      return access.session
-    }
+    return accessSession(recordActivity: true)
   }
 
   /// Records meaningful user activity and extends the current session's inactivity deadline.
@@ -50,29 +75,16 @@ public class SessionManager: @unchecked Sendable {
   /// - Returns: The active session after recording activity
   @discardableResult
   public func recordActivity() -> Session {
-    return operationLock.withLock {
-      let access = lock.withLock {
-        let access = locked_accessSession()
-        guard !access.startedNewSession else {
-          return access
-        }
+    return accessSession(recordActivity: true)
+  }
 
-        let refreshedSession = locked_refreshSession(session: access.session)
-        session = refreshedSession
-        return SessionAccess(
-          session: refreshedSession,
-          previousSessionToEnd: nil,
-          startedNewSession: false
-        )
-      }
-
-      if access.startedNewSession {
-        completeAccess(access)
-      } else {
-        SessionStore.scheduleSave(session: access.session)
-      }
-      return access.session
-    }
+  /// Gets the session used to attribute telemetry without recording activity.
+  ///
+  /// Span and log processors use this path so passive telemetry cannot keep a session alive.
+  /// - Returns: The current active session
+  @discardableResult
+  func getSessionForAttribution() -> Session {
+    return accessSession(recordActivity: false)
   }
 
   /// Ends the current session and starts a linked replacement.
@@ -82,29 +94,27 @@ public class SessionManager: @unchecked Sendable {
   /// - Returns: The newly created session
   @discardableResult
   public func resetSession() -> Session {
-    return operationLock.withLock {
-      let access = lock.withLock {
-        let now = Date()
-        let previousSession = session ?? persistedPreviousSession
-        let previousSessionToEnd = previousSession.map { previous in
-          previous.isExpired() ? previous : locked_endSession(previous, at: now)
-        }
-        let nextSession = locked_startSession(previousId: previousSession?.id, at: now)
-        session = nextSession
-        persistedPreviousSession = nil
-        return SessionAccess(
-          session: nextSession,
-          previousSessionToEnd: previousSessionToEnd,
-          startedNewSession: true
-        )
+    let (nextSession, pendingEffect): (Session, PendingEffect) = lock.withLock {
+      let now = Date()
+      let previousSession = session ?? persistedPreviousSession
+      let previousSessionToEnd = previousSession.map { previous in
+        previous.isExpired() ? previous : locked_endSession(previous, at: now)
       }
-
-      completeAccess(access)
-      return access.session
+      let nextSession = locked_startSession(previousId: previousSession?.id, at: now)
+      session = nextSession
+      persistedPreviousSession = nil
+      let effect = enqueueEffect(.transition(SessionTransition(
+        session: nextSession,
+        previousSessionToEnd: previousSessionToEnd
+      )))
+      return (nextSession, effect)
     }
+
+    drainPendingEffects(through: pendingEffect)
+    return nextSession
   }
 
-  /// Gets the current session without extending its expireTime time
+  /// Gets the current session without extending its inactivity deadline
   /// - Returns: The current session if one exists, nil otherwise
   public func peekSession() -> Session? {
     return lock.withLock { session }
@@ -150,10 +160,10 @@ public class SessionManager: @unchecked Sendable {
 
   /// Extends the current session expiry time
   /// *Warning* - this must be a pure function since it is used inside a lock
-  private func locked_refreshSession(session: Session) -> Session {
+  private func locked_refreshSession(session: Session, at now: Date) -> Session {
     return Session(
       id: session.id,
-      expireTime: Date(timeIntervalSinceNow: Double(configuration.sessionTimeout)),
+      expireTime: now.addingTimeInterval(Double(configuration.sessionTimeout)),
       previousId: session.previousId,
       startTime: session.startTime,
       sessionTimeout: configuration.sessionTimeout,
@@ -163,24 +173,32 @@ public class SessionManager: @unchecked Sendable {
 
   /// Returns the active session without changing its inactivity deadline.
   /// *Warning* - call only while holding `lock`.
-  private func locked_accessSession() -> SessionAccess {
+  private func locked_accessSession(recordActivity: Bool, at now: Date) -> SessionAccess {
     if let session,
        !session.isExpired() {
+      guard recordActivity else {
+        return SessionAccess(session: session, pendingEffect: nil)
+      }
+
+      let refreshedSession = locked_refreshSession(session: session, at: now)
+      self.session = refreshedSession
       return SessionAccess(
-        session: session,
-        previousSessionToEnd: nil,
-        startedNewSession: false
+        session: refreshedSession,
+        pendingEffect: enqueueEffect(.save(refreshedSession))
       )
     }
 
     let previousSession = session ?? persistedPreviousSession
-    let nextSession = locked_startSession(previousId: previousSession?.id)
+    let nextSession = locked_startSession(previousId: previousSession?.id, at: now)
     session = nextSession
     persistedPreviousSession = nil
+    let effect = enqueueEffect(.transition(SessionTransition(
+      session: nextSession,
+      previousSessionToEnd: previousSession
+    )))
     return SessionAccess(
       session: nextSession,
-      previousSessionToEnd: previousSession,
-      startedNewSession: true
+      pendingEffect: effect
     )
   }
 
@@ -197,16 +215,76 @@ public class SessionManager: @unchecked Sendable {
     )
   }
 
-  /// Persists and publishes a newly started session without invoking external code under `lock`.
-  private func completeAccess(_ access: SessionAccess) {
-    guard access.startedNewSession else { return }
+  /// Retrieves a session and queues any persistence or lifecycle work in state order.
+  private func accessSession(recordActivity: Bool) -> Session {
+    let access = lock.withLock {
+      locked_accessSession(recordActivity: recordActivity, at: Date())
+    }
+    if let pendingEffect = access.pendingEffect {
+      drainPendingEffects(through: pendingEffect)
+    }
+    return access.session
+  }
 
-    SessionStore.saveImmediately(session: access.session)
-    if let previousSessionToEnd = access.previousSessionToEnd {
+  /// Enqueues an effect while a state transition holds `lock`.
+  /// Effect draining never acquires `lock` while holding `effectsLock`.
+  private func enqueueEffect(_ operation: EffectOperation) -> PendingEffect {
+    let effect = PendingEffect(operation: operation)
+    effectsLock.withLock { pendingEffects.append(effect) }
+    return effect
+  }
+
+  /// Drains ordered persistence and lifecycle effects without holding a lock around user code.
+  ///
+  /// One caller claims the drain. Transition callers wait for persistence and publication, while
+  /// coalesced activity saves may return once queued. If an exporter calls back on the drainer
+  /// thread, the outer loop completes the nested effect after the callback returns.
+  private func drainPendingEffects(through pendingEffect: PendingEffect) {
+    let shouldDrain = effectsLock.withLock {
+      guard !isDrainingEffects else { return false }
+      isDrainingEffects = true
+      return true
+    }
+    guard shouldDrain else {
+      if pendingEffect.operation.requiresSynchronousCompletion,
+         Thread.current.threadDictionary[effectDrainerThreadKey] == nil {
+        pendingEffect.completion.wait()
+      }
+      return
+    }
+
+    Thread.current.threadDictionary[effectDrainerThreadKey] = true
+    defer { Thread.current.threadDictionary.removeObject(forKey: effectDrainerThreadKey) }
+
+    while true {
+      guard let effect = effectsLock.withLock({ () -> PendingEffect? in
+        guard !pendingEffects.isEmpty else {
+          isDrainingEffects = false
+          return nil
+        }
+        return pendingEffects.removeFirst()
+      }) else {
+        return
+      }
+
+      switch effect.operation {
+      case let .save(session):
+        SessionStore.scheduleSave(session: session)
+      case let .transition(transition):
+        publish(transition)
+      }
+      effect.completion.signal()
+    }
+  }
+
+  /// Persists and publishes one session transition.
+  private func publish(_ transition: SessionTransition) {
+    SessionStore.saveImmediately(session: transition.session)
+    if let previousSessionToEnd = transition.previousSessionToEnd {
       SessionEventInstrumentation.addSession(session: previousSessionToEnd, eventType: .end)
     }
-    SessionEventInstrumentation.addSession(session: access.session, eventType: .start)
-    NotificationCenter.default.post(name: SessionEventNotification, object: access.session)
+    SessionEventInstrumentation.addSession(session: transition.session, eventType: .start)
+    NotificationCenter.default.post(name: SessionEventNotification, object: transition.session)
   }
 
   /// Loads a saved session from UserDefaults according to the configured restore behavior

--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -17,29 +17,11 @@ public class SessionManager: @unchecked Sendable {
   private enum EffectOperation {
     case save(Session)
     case transition(SessionTransition)
-
-    var requiresSynchronousCompletion: Bool {
-      switch self {
-      case .save:
-        return false
-      case .transition:
-        return true
-      }
-    }
-  }
-
-  private final class PendingEffect: @unchecked Sendable {
-    let operation: EffectOperation
-    let completion = DispatchSemaphore(value: 0)
-
-    init(operation: EffectOperation) {
-      self.operation = operation
-    }
   }
 
   private struct SessionAccess {
     let session: Session
-    let pendingEffect: PendingEffect?
+    let shouldDrainEffects: Bool
   }
 
   private let configuration: SessionConfig
@@ -47,9 +29,8 @@ public class SessionManager: @unchecked Sendable {
   private var persistedPreviousSession: Session?
   private let lock = NSLock()
   private let effectsLock = NSLock()
-  private var pendingEffects: [PendingEffect] = []
+  private var pendingEffects: [EffectOperation] = []
   private var isDrainingEffects = false
-  private let effectDrainerThreadKey = "io.opentelemetry.sessions.effect-drainer.\(UUID().uuidString)"
 
   /// Initializes the session manager and restores any previous session from disk
   /// - Parameter configuration: Session configuration settings
@@ -61,7 +42,7 @@ public class SessionManager: @unchecked Sendable {
   /// Gets the current session, creating or extending it as needed.
   ///
   /// This preserves the existing behavior where direct access records activity.
-  /// Automatic telemetry processors use a passive internal access path instead.
+  /// Automatic telemetry processors use the passive attribution access path instead.
   /// - Returns: The current active session
   @discardableResult
   public func getSession() -> Session {
@@ -80,10 +61,11 @@ public class SessionManager: @unchecked Sendable {
 
   /// Gets the session used to attribute telemetry without recording activity.
   ///
-  /// Span and log processors use this path so passive telemetry cannot keep a session alive.
+  /// Span, log, metric, and custom processors can use this path so passive telemetry cannot keep
+  /// a session alive. It creates or rotates an expired session before returning it.
   /// - Returns: The current active session
   @discardableResult
-  func getSessionForAttribution() -> Session {
+  public func getSessionForAttribution() -> Session {
     return accessSession(recordActivity: false)
   }
 
@@ -94,7 +76,7 @@ public class SessionManager: @unchecked Sendable {
   /// - Returns: The newly created session
   @discardableResult
   public func resetSession() -> Session {
-    let (nextSession, pendingEffect): (Session, PendingEffect) = lock.withLock {
+    let nextSession: Session = lock.withLock {
       let now = Date()
       let previousSession = session ?? persistedPreviousSession
       let previousSessionToEnd = previousSession.map { previous in
@@ -103,14 +85,14 @@ public class SessionManager: @unchecked Sendable {
       let nextSession = locked_startSession(previousId: previousSession?.id, at: now)
       session = nextSession
       persistedPreviousSession = nil
-      let effect = enqueueEffect(.transition(SessionTransition(
+      enqueueEffect(.transition(SessionTransition(
         session: nextSession,
         previousSessionToEnd: previousSessionToEnd
       )))
-      return (nextSession, effect)
+      return nextSession
     }
 
-    drainPendingEffects(through: pendingEffect)
+    drainPendingEffects()
     return nextSession
   }
 
@@ -177,29 +159,24 @@ public class SessionManager: @unchecked Sendable {
     if let session,
        !session.isExpired() {
       guard recordActivity else {
-        return SessionAccess(session: session, pendingEffect: nil)
+        return SessionAccess(session: session, shouldDrainEffects: false)
       }
 
       let refreshedSession = locked_refreshSession(session: session, at: now)
       self.session = refreshedSession
-      return SessionAccess(
-        session: refreshedSession,
-        pendingEffect: enqueueEffect(.save(refreshedSession))
-      )
+      enqueueEffect(.save(refreshedSession))
+      return SessionAccess(session: refreshedSession, shouldDrainEffects: true)
     }
 
     let previousSession = session ?? persistedPreviousSession
     let nextSession = locked_startSession(previousId: previousSession?.id, at: now)
     session = nextSession
     persistedPreviousSession = nil
-    let effect = enqueueEffect(.transition(SessionTransition(
+    enqueueEffect(.transition(SessionTransition(
       session: nextSession,
       previousSessionToEnd: previousSession
     )))
-    return SessionAccess(
-      session: nextSession,
-      pendingEffect: effect
-    )
+    return SessionAccess(session: nextSession, shouldDrainEffects: true)
   }
 
   /// Creates an ended snapshot whose end time is fixed to `date`.
@@ -220,44 +197,33 @@ public class SessionManager: @unchecked Sendable {
     let access = lock.withLock {
       locked_accessSession(recordActivity: recordActivity, at: Date())
     }
-    if let pendingEffect = access.pendingEffect {
-      drainPendingEffects(through: pendingEffect)
+    if access.shouldDrainEffects {
+      drainPendingEffects()
     }
     return access.session
   }
 
   /// Enqueues an effect while a state transition holds `lock`.
   /// Effect draining never acquires `lock` while holding `effectsLock`.
-  private func enqueueEffect(_ operation: EffectOperation) -> PendingEffect {
-    let effect = PendingEffect(operation: operation)
-    effectsLock.withLock { pendingEffects.append(effect) }
-    return effect
+  private func enqueueEffect(_ operation: EffectOperation) {
+    effectsLock.withLock { pendingEffects.append(operation) }
   }
 
   /// Drains ordered persistence and lifecycle effects without holding a lock around user code.
   ///
-  /// One caller claims the drain. Transition callers wait for persistence and publication, while
-  /// coalesced activity saves may return once queued. If an exporter calls back on the drainer
-  /// thread, the outer loop completes the nested effect after the callback returns.
-  private func drainPendingEffects(through pendingEffect: PendingEffect) {
+  /// One caller claims the drain. Other callers return after queuing their work so callbacks in
+  /// exporters and observers cannot create a cross-thread wait cycle. The drainer preserves state
+  /// order and completes effects that are enqueued while it is publishing.
+  private func drainPendingEffects() {
     let shouldDrain = effectsLock.withLock {
       guard !isDrainingEffects else { return false }
       isDrainingEffects = true
       return true
     }
-    guard shouldDrain else {
-      if pendingEffect.operation.requiresSynchronousCompletion,
-         Thread.current.threadDictionary[effectDrainerThreadKey] == nil {
-        pendingEffect.completion.wait()
-      }
-      return
-    }
-
-    Thread.current.threadDictionary[effectDrainerThreadKey] = true
-    defer { Thread.current.threadDictionary.removeObject(forKey: effectDrainerThreadKey) }
+    guard shouldDrain else { return }
 
     while true {
-      guard let effect = effectsLock.withLock({ () -> PendingEffect? in
+      guard let effect = effectsLock.withLock({ () -> EffectOperation? in
         guard !pendingEffects.isEmpty else {
           isDrainingEffects = false
           return nil
@@ -267,13 +233,12 @@ public class SessionManager: @unchecked Sendable {
         return
       }
 
-      switch effect.operation {
+      switch effect {
       case let .save(session):
         SessionStore.scheduleSave(session: session)
       case let .transition(transition):
         publish(transition)
       }
-      effect.completion.signal()
     }
   }
 

--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Manages OpenTelemetry sessions with automatic expiration and persistence.
 /// Provides thread-safe access to session information and handles session lifecycle.
-/// Direct access and explicit activity extend a session. Telemetry attribution is passive.
+/// Sessions are extended on access and persisted to UserDefaults.
 public class SessionManager: @unchecked Sendable {
   private struct SessionTransition {
     let session: Session
@@ -37,32 +37,11 @@ public class SessionManager: @unchecked Sendable {
 
   /// Gets the current session, creating or extending it as needed.
   ///
-  /// This preserves the existing behavior where direct access records activity.
-  /// Automatic telemetry processors use the passive attribution access path instead.
+  /// Access records application activity and extends the inactivity deadline.
   /// - Returns: The current active session
   @discardableResult
   public func getSession() -> Session {
-    return accessSession(recordActivity: true)
-  }
-
-  /// Records meaningful user activity and extends the current session's inactivity deadline.
-  ///
-  /// If the previous session has already expired, this creates a linked replacement before
-  /// recording the activity.
-  /// - Returns: The active session after recording activity
-  @discardableResult
-  public func recordActivity() -> Session {
-    return accessSession(recordActivity: true)
-  }
-
-  /// Gets the session used to attribute telemetry without recording activity.
-  ///
-  /// Span, log, metric, and custom processors can use this path so passive telemetry cannot keep
-  /// a session alive. It creates or rotates an expired session before returning it.
-  /// - Returns: The current active session
-  @discardableResult
-  public func getSessionForAttribution() -> Session {
-    return accessSession(recordActivity: false)
+    return accessSession()
   }
 
   /// Ends the current session and starts a linked replacement.
@@ -152,15 +131,11 @@ public class SessionManager: @unchecked Sendable {
     )
   }
 
-  /// Returns the active session without changing its inactivity deadline.
+  /// Returns the active session and extends its inactivity deadline.
   /// *Warning* - call only while holding `lock`.
-  private func locked_accessSession(recordActivity: Bool, at now: Date) -> SessionAccess {
+  private func locked_accessSession(at now: Date) -> SessionAccess {
     if let session,
        !session.isExpired() {
-      guard recordActivity else {
-        return SessionAccess(session: session, shouldDrainEffects: false)
-      }
-
       let refreshedSession = locked_refreshSession(session: session, at: now)
       self.session = refreshedSession
       SessionStore.scheduleSave(session: refreshedSession)
@@ -193,9 +168,9 @@ public class SessionManager: @unchecked Sendable {
   }
 
   /// Retrieves a session and queues any persistence or lifecycle work in state order.
-  private func accessSession(recordActivity: Bool) -> Session {
+  private func accessSession() -> Session {
     let access = lock.withLock {
-      locked_accessSession(recordActivity: recordActivity, at: Date())
+      locked_accessSession(at: Date())
     }
     if access.shouldDrainEffects {
       drainClaimedTransition()

--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -7,11 +7,18 @@ import Foundation
 
 /// Manages OpenTelemetry sessions with automatic expiration and persistence.
 /// Provides thread-safe access to session information and handles session lifecycle.
-/// Sessions are automatically extended on access and persisted to UserDefaults.
+/// Sessions are extended only when meaningful activity is recorded.
 public class SessionManager: @unchecked Sendable {
+  private struct SessionAccess {
+    let session: Session
+    let previousSessionToEnd: Session?
+    let startedNewSession: Bool
+  }
+
   private var configuration: SessionConfig
   private var session: Session?
   private var persistedPreviousSession: Session?
+  private let operationLock = NSRecursiveLock()
   private let lock = NSLock()
 
   /// Initializes the session manager and restores any previous session from disk
@@ -21,41 +28,80 @@ public class SessionManager: @unchecked Sendable {
     loadPersistedSessionFromDisk()
   }
 
-  /// Gets the current session, creating or extending it as needed
-  /// This method is thread-safe and will extend the session expireTime time
+  /// Gets the current session, creating a linked replacement if it has expired.
+  ///
+  /// Access is passive and does not extend the inactivity deadline. Call
+  /// ``recordActivity()`` when a user interaction or lifecycle transition should
+  /// keep the current session active.
   /// - Returns: The current active session
   @discardableResult
   public func getSession() -> Session {
-    let (currentSession,
-         previousSessionToEnd,
-         sessionDidExpire) = lock.withLock {
-      if let session,
-         !session.isExpired() {
-        // extend session
-        let extendedSession = locked_refreshSession(session: session)
-        self.session = extendedSession
-        return (extendedSession, nil as Session?, false)
+    return operationLock.withLock {
+      let access = lock.withLock { locked_accessSession() }
+      completeAccess(access)
+      return access.session
+    }
+  }
+
+  /// Records meaningful user activity and extends the current session's inactivity deadline.
+  ///
+  /// If the previous session has already expired, this creates a linked replacement before
+  /// recording the activity.
+  /// - Returns: The active session after recording activity
+  @discardableResult
+  public func recordActivity() -> Session {
+    return operationLock.withLock {
+      let access = lock.withLock {
+        let access = locked_accessSession()
+        guard !access.startedNewSession else {
+          return access
+        }
+
+        let refreshedSession = locked_refreshSession(session: access.session)
+        session = refreshedSession
+        return SessionAccess(
+          session: refreshedSession,
+          previousSessionToEnd: nil,
+          startedNewSession: false
+        )
+      }
+
+      if access.startedNewSession {
+        completeAccess(access)
       } else {
-        // start new session
-        let prev = session ?? persistedPreviousSession
-        let nextSession = locked_startSession()
-        self.session = nextSession
-        self.persistedPreviousSession = nil
-        return (nextSession, prev, true)
+        SessionStore.scheduleSave(session: access.session)
       }
+      return access.session
     }
+  }
 
-    // Call external code outside the lock only if new session was created
-    if sessionDidExpire {
-      if let previousSessionToEnd {
-        SessionEventInstrumentation.addSession(session: previousSessionToEnd, eventType: .end)
+  /// Ends the current session and starts a linked replacement.
+  ///
+  /// Use this after a sign-out, account change, or another explicit session boundary.
+  /// The replacement is persisted before lifecycle events are emitted.
+  /// - Returns: The newly created session
+  @discardableResult
+  public func resetSession() -> Session {
+    return operationLock.withLock {
+      let access = lock.withLock {
+        let now = Date()
+        let previousSession = session ?? persistedPreviousSession
+        let previousSessionToEnd = previousSession.map { previous in
+          previous.isExpired() ? previous : locked_endSession(previous, at: now)
+        }
+        let nextSession = locked_startSession(previousId: previousSession?.id, at: now)
+        session = nextSession
+        persistedPreviousSession = nil
+        return SessionAccess(
+          session: nextSession,
+          previousSessionToEnd: previousSessionToEnd,
+          startedNewSession: true
+        )
       }
-      SessionEventInstrumentation.addSession(session: currentSession, eventType: .start)
-      NotificationCenter.default.post(name: SessionEventNotification, object: currentSession)
-    }
 
-    SessionStore.scheduleSave(session: currentSession)
-    return currentSession
+      completeAccess(access)
+      return access.session
+    }
   }
 
   /// Gets the current session without extending its expireTime time
@@ -66,13 +112,11 @@ public class SessionManager: @unchecked Sendable {
 
   /// Creates a new session with a unique identifier
   /// *Warning* - this must be a pure function since it is used inside a lock
-  private func locked_startSession() -> Session {
-    let now = Date()
-
+  private func locked_startSession(previousId: String?, at now: Date = Date()) -> Session {
     return Session(
       id: UUID().uuidString,
       expireTime: now.addingTimeInterval(Double(configuration.sessionTimeout)),
-      previousId: session?.id ?? persistedPreviousSession?.id,
+      previousId: previousId,
       startTime: now,
       sessionTimeout: configuration.sessionTimeout,
       maxLifetime: configuration.maxLifetime
@@ -115,6 +159,54 @@ public class SessionManager: @unchecked Sendable {
       sessionTimeout: configuration.sessionTimeout,
       maxLifetime: session.maxLifetime
     )
+  }
+
+  /// Returns the active session without changing its inactivity deadline.
+  /// *Warning* - call only while holding `lock`.
+  private func locked_accessSession() -> SessionAccess {
+    if let session,
+       !session.isExpired() {
+      return SessionAccess(
+        session: session,
+        previousSessionToEnd: nil,
+        startedNewSession: false
+      )
+    }
+
+    let previousSession = session ?? persistedPreviousSession
+    let nextSession = locked_startSession(previousId: previousSession?.id)
+    session = nextSession
+    persistedPreviousSession = nil
+    return SessionAccess(
+      session: nextSession,
+      previousSessionToEnd: previousSession,
+      startedNewSession: true
+    )
+  }
+
+  /// Creates an ended snapshot whose end time is fixed to `date`.
+  /// *Warning* - this must remain a pure function because it is called inside `lock`.
+  private func locked_endSession(_ session: Session, at date: Date) -> Session {
+    return Session(
+      id: session.id,
+      expireTime: date,
+      previousId: session.previousId,
+      startTime: session.startTime,
+      sessionTimeout: 0,
+      maxLifetime: nil
+    )
+  }
+
+  /// Persists and publishes a newly started session without invoking external code under `lock`.
+  private func completeAccess(_ access: SessionAccess) {
+    guard access.startedNewSession else { return }
+
+    SessionStore.saveImmediately(session: access.session)
+    if let previousSessionToEnd = access.previousSessionToEnd {
+      SessionEventInstrumentation.addSession(session: previousSessionToEnd, eventType: .end)
+    }
+    SessionEventInstrumentation.addSession(session: access.session, eventType: .start)
+    NotificationCenter.default.post(name: SessionEventNotification, object: access.session)
   }
 
   /// Loads a saved session from UserDefaults according to the configured restore behavior

--- a/Sources/Instrumentation/Sessions/SessionSpanProcessor.swift
+++ b/Sources/Instrumentation/Sessions/SessionSpanProcessor.swift
@@ -28,10 +28,10 @@ public class SessionSpanProcessor: SpanProcessor {
   ///   - parentContext: The parent span context (unused)
   ///   - span: The span being started
   public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
-    let session = sessionManager.getSession()
+    let session = sessionManager.getSessionForAttribution()
     span.setAttribute(key: SemanticConventions.Session.id.rawValue, value: session.id)
-    if session.previousId != nil {
-      span.setAttribute(key: SemanticConventions.Session.previousId.rawValue, value: session.previousId!)
+    if let previousId = session.previousId {
+      span.setAttribute(key: SemanticConventions.Session.previousId.rawValue, value: previousId)
     }
   }
 

--- a/Sources/Instrumentation/Sessions/SessionSpanProcessor.swift
+++ b/Sources/Instrumentation/Sessions/SessionSpanProcessor.swift
@@ -28,7 +28,7 @@ public class SessionSpanProcessor: SpanProcessor {
   ///   - parentContext: The parent span context (unused)
   ///   - span: The span being started
   public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
-    let session = sessionManager.getSessionForAttribution()
+    let session = sessionManager.getSession()
     span.setAttribute(key: SemanticConventions.Session.id.rawValue, value: session.id)
     if let previousId = session.previousId {
       span.setAttribute(key: SemanticConventions.Session.previousId.rawValue, value: previousId)

--- a/Sources/Instrumentation/Sessions/SessionStore.swift
+++ b/Sources/Instrumentation/Sessions/SessionStore.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Handles persistence of OpenTelemetry sessions to UserDefaults
 /// Provides static methods for saving and loading session data
-internal final class SessionStore {
+enum SessionStore {
   /// UserDefaults key for storing session ID
   static let idKey = "otel-session-id"
   /// UserDefaults key for storing previous session ID
@@ -21,63 +21,62 @@ internal final class SessionStore {
   /// UserDefaults key for storing session maximum lifetime
   static let maxLifetimeKey = "otel-session-max-lifetime"
 
-  /// To avoid writing to disk too often, SessionStore only keeps the current session
-  /// in memory and saves to disk on an interval (every 30 seconds).
+  // To avoid writing to disk too often, SessionStore only keeps the current session
+  // in memory and saves to disk on an interval (every 30 seconds).
 
   /// Guards all static mutable state below; every access goes through this lock so
   /// callers from different threads (`SessionManager.getSession()` callers, the
   /// repeating `saveTimer` callback, and test `teardown`) do not race.
   private static let lock = NSLock()
   /// The most recent session to be saved to disk
-  nonisolated(unsafe) private static var pendingSession: Session?
+  private nonisolated(unsafe) static var pendingSession: Session?
   /// The previous session
-  nonisolated(unsafe) private static var prevSession: Session?
+  private nonisolated(unsafe) static var prevSession: Session?
   /// The interval period after which the current session is saved to disk
   private static let saveInterval: TimeInterval = 30 // in seconds
   /// The timer responsible for saving the current session to disk
-  nonisolated(unsafe) private static var saveTimer: Timer?
+  private nonisolated(unsafe) static var saveTimer: Timer?
 
   /// Schedules a session to be saved to UserDefaults on the next timer interval
   /// - Parameter session: The session to save
   static func scheduleSave(session: Session) {
-    let needsTimer: Bool = lock.withLock {
+    let timerToSchedule: Timer? = lock.withLock {
       pendingSession = session
-      return saveTimer == nil
-    }
-
-    if needsTimer {
-      // save initial session
-      saveImmediately(session: session)
+      guard saveTimer == nil else { return nil }
 
       // `Timer.scheduledTimer` schedules on the current RunLoop; callers reach
       // here from arbitrary threads (incl. GCD workers with no run loop), so
       // pin the timer to RunLoop.main to guarantee it fires.
       let timer = Timer(timeInterval: saveInterval, repeats: true) { _ in
-        let pendingToSave: Session? = lock.withLock {
+        lock.withLock {
           if let pending = pendingSession, prevSession != pending {
-            return pending
+            locked_save(session: pending)
           }
-          return nil
-        }
-        if let pendingToSave {
-          saveImmediately(session: pendingToSave)
         }
       }
+      locked_save(session: session)
+      saveTimer = timer
+      return timer
+    }
+
+    if let timerToSchedule {
       if Thread.isMainThread {
-        RunLoop.main.add(timer, forMode: .common)
+        RunLoop.main.add(timerToSchedule, forMode: .common)
       } else {
-        nonisolated(unsafe) let timerRef = timer
+        nonisolated(unsafe) let timerRef = timerToSchedule
         DispatchQueue.main.async { RunLoop.main.add(timerRef, forMode: .common) }
       }
-      lock.withLock { saveTimer = timer }
     }
   }
 
   /// Immediately saves a session to UserDefaults
   /// - Parameter session: The session to save
   static func saveImmediately(session: Session) {
-    // Persist session. UserDefaults is thread-safe so the writes themselves
-    // don't need our lock; only the in-memory bookkeeping does.
+    lock.withLock { locked_save(session: session) }
+  }
+
+  /// Persists a session while `lock` is held.
+  private static func locked_save(session: Session) {
     UserDefaults.standard.set(session.id, forKey: idKey)
     UserDefaults.standard.set(session.expireTime, forKey: expireTimeKey)
     UserDefaults.standard.set(session.startTime, forKey: startTimeKey)
@@ -89,42 +88,39 @@ internal final class SessionStore {
       UserDefaults.standard.removeObject(forKey: maxLifetimeKey)
     }
 
-    lock.withLock {
-      // update prev session
-      prevSession = session
-      // clear pending session, since it is now outdated
-      pendingSession = nil
-    }
+    prevSession = session
+    // An immediate lifecycle write supersedes any older pending activity update.
+    pendingSession = nil
   }
 
   /// Loads a previously saved session from UserDefaults
   /// - Returns: The saved session if ID, startTime, and expireTime exist. nil otherwise
   static func load() -> Session? {
-    guard let startTime = UserDefaults.standard.object(forKey: startTimeKey) as? Date,
-          let id = UserDefaults.standard.string(forKey: idKey),
-          let expireTime = UserDefaults.standard.object(forKey: expireTimeKey) as? Date,
-          let sessionTimeout = UserDefaults.standard.object(forKey: sessionTimeoutKey) as? TimeInterval
-    else {
-      return nil
-    }
+    return lock.withLock {
+      guard let startTime = UserDefaults.standard.object(forKey: startTimeKey) as? Date,
+            let id = UserDefaults.standard.string(forKey: idKey),
+            let expireTime = UserDefaults.standard.object(forKey: expireTimeKey) as? Date,
+            let sessionTimeout = UserDefaults.standard.object(forKey: sessionTimeoutKey) as? TimeInterval
+      else {
+        return nil
+      }
 
-    let previousId = UserDefaults.standard.string(forKey: previousIdKey)
-    let maxLifetime = UserDefaults.standard.object(forKey: maxLifetimeKey) as? TimeInterval
+      let previousId = UserDefaults.standard.string(forKey: previousIdKey)
+      let maxLifetime = UserDefaults.standard.object(forKey: maxLifetimeKey) as? TimeInterval
 
-    let session = Session(
-      id: id,
-      expireTime: expireTime,
-      previousId: previousId,
-      startTime: startTime,
-      sessionTimeout: sessionTimeout,
-      maxLifetime: maxLifetime
-    )
-    lock.withLock {
+      let session = Session(
+        id: id,
+        expireTime: expireTime,
+        previousId: previousId,
+        startTime: startTime,
+        sessionTimeout: sessionTimeout,
+        maxLifetime: maxLifetime
+      )
       // reset sessions so it does not get overridden in the next scheduled save
       pendingSession = nil
       prevSession = session
+      return session
     }
-    return session
   }
 
   /// Cleans up timer and UserDefaults
@@ -134,14 +130,14 @@ internal final class SessionStore {
       saveTimer = nil
       pendingSession = nil
       prevSession = nil
+      UserDefaults.standard.removeObject(forKey: idKey)
+      UserDefaults.standard.removeObject(forKey: startTimeKey)
+      UserDefaults.standard.removeObject(forKey: expireTimeKey)
+      UserDefaults.standard.removeObject(forKey: previousIdKey)
+      UserDefaults.standard.removeObject(forKey: sessionTimeoutKey)
+      UserDefaults.standard.removeObject(forKey: maxLifetimeKey)
       return t
     }
     timer?.invalidate()
-    UserDefaults.standard.removeObject(forKey: idKey)
-    UserDefaults.standard.removeObject(forKey: startTimeKey)
-    UserDefaults.standard.removeObject(forKey: expireTimeKey)
-    UserDefaults.standard.removeObject(forKey: previousIdKey)
-    UserDefaults.standard.removeObject(forKey: sessionTimeoutKey)
-    UserDefaults.standard.removeObject(forKey: maxLifetimeKey)
   }
 }

--- a/Tests/InstrumentationTests/SessionTests/SessionEventInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionEventInstrumentationTests.swift
@@ -389,8 +389,11 @@ final class SessionEventInstrumentationTests: XCTestCase {
       record.eventName == "session.start" &&
         record.attributes["session.id"] == AttributeValue.string(sessions[0].id)
     }
-    XCTAssertNotNil(firstStartRecord)
-    XCTAssertNil(firstStartRecord?.attributes["session.previous_id"])
+    guard let firstStartRecord else {
+      XCTFail("Expected a session.start event for the first session")
+      return
+    }
+    XCTAssertNil(firstStartRecord.attributes["session.previous_id"])
 
     // Verify session chain linking
     for i in 1 ..< sessions.count {
@@ -398,8 +401,11 @@ final class SessionEventInstrumentationTests: XCTestCase {
         record.eventName == "session.start" &&
           record.attributes["session.id"] == AttributeValue.string(sessions[i].id)
       }
-      XCTAssertNotNil(sessionStartRecord)
-      XCTAssertEqual(sessionStartRecord?.attributes["session.previous_id"], AttributeValue.string(sessions[i - 1].id))
+      guard let sessionStartRecord else {
+        XCTFail("Expected a session.start event for session \(i)")
+        continue
+      }
+      XCTAssertEqual(sessionStartRecord.attributes["session.previous_id"], AttributeValue.string(sessions[i - 1].id))
     }
   }
 

--- a/Tests/InstrumentationTests/SessionTests/SessionEventInstrumentationTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionEventInstrumentationTests.swift
@@ -55,6 +55,8 @@ final class SessionEventInstrumentationTests: XCTestCase {
     super.tearDown()
 
     SessionStore.teardown()
+    SessionEventInstrumentation.queue.removeAll()
+    SessionEventInstrumentation.isApplied = false
     OpenTelemetry.registerTracerProvider(tracerProvider: DefaultTracerProvider.instance)
     OpenTelemetry.registerLoggerProvider(loggerProvider: DefaultLoggerProvider.instance)
   }
@@ -388,7 +390,7 @@ final class SessionEventInstrumentationTests: XCTestCase {
         record.attributes["session.id"] == AttributeValue.string(sessions[0].id)
     }
     XCTAssertNotNil(firstStartRecord)
-    XCTAssertNil(firstStartRecord!.attributes["session.previous_id"])
+    XCTAssertNil(firstStartRecord?.attributes["session.previous_id"])
 
     // Verify session chain linking
     for i in 1 ..< sessions.count {
@@ -466,7 +468,7 @@ final class SessionEventInstrumentationTests: XCTestCase {
 
     XCTAssertTrue(SessionEventInstrumentation.isApplied)
     XCTAssertEqual(SessionEventInstrumentation.queue.count, 0)
-    
+
     let logRecords = logExporter.getFinishedLogRecords()
     XCTAssertEqual(logRecords.count, 1)
     XCTAssertEqual(logRecords[0].eventName, "session.start")

--- a/Tests/InstrumentationTests/SessionTests/SessionLogRecordProcessorTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionLogRecordProcessorTests.swift
@@ -43,6 +43,21 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     }
   }
 
+  func testOnEmitDoesNotRefreshSessionActivity() {
+    SessionStore.teardown()
+    defer { SessionStore.teardown() }
+    let manager = SessionManager()
+    let session = manager.getSession()
+    let processor = SessionLogRecordProcessor(
+      nextProcessor: mockNextProcessor,
+      sessionManager: manager
+    )
+
+    processor.onEmit(logRecord: testLogRecord)
+
+    XCTAssertEqual(manager.peekSession()?.expireTime, session.expireTime)
+  }
+
   func testOnEmitPreservesOriginalAttributes() {
     mockSessionManager.sessionId = "test-session"
 
@@ -225,33 +240,33 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     XCTAssertEqual(enhancedRecord.severity, logRecordWithEventName.severity)
     XCTAssertEqual(enhancedRecord.body?.description, logRecordWithEventName.body?.description)
     XCTAssertEqual(enhancedRecord.spanContext, logRecordWithEventName.spanContext)
-    
+
     // Verify session attributes were added
     if case let .string(sessionId) = enhancedRecord.attributes[SemanticConventions.Session.id.rawValue] {
       XCTAssertEqual(sessionId, "test-session-123")
     } else {
       XCTFail("Expected session.id attribute to be added")
     }
-    
+
     // Verify original attributes preserved
     if case let .string(testValue) = enhancedRecord.attributes["test.key"] {
       XCTAssertEqual(testValue, "test.value")
     } else {
       XCTFail("Expected original attributes to be preserved")
     }
-    
+
     // Verify total attribute count (original + session attributes)
     XCTAssertEqual(enhancedRecord.attributes.count, 2, "Should have original attribute + session.id")
   }
 
-  func testConcurrentOnEmitThreadSafety() {
+  func testConcurrentOnEmitThreadSafety() throws {
     let mockNextProcessor = MockLogRecordProcessor()
     let expectation = XCTestExpectation(description: "Concurrent processing")
     let queue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
     let group = DispatchGroup()
-    
-    let logRecord = self.testLogRecord!
-    for i in 0..<10 {
+
+    let logRecord = try XCTUnwrap(testLogRecord)
+    for i in 0 ..< 10 {
       group.enter()
       queue.async {
         let sessionManager = MockSessionManager()
@@ -261,13 +276,13 @@ final class SessionLogRecordProcessorTests: XCTestCase {
         group.leave()
       }
     }
-    
+
     group.notify(queue: .main) {
       expectation.fulfill()
     }
-    
+
     wait(for: [expectation], timeout: 5.0)
-    
+
     XCTAssertEqual(mockNextProcessor.receivedLogRecords.count, 10)
     for record in mockNextProcessor.receivedLogRecords {
       XCTAssertTrue(record.attributes.keys.contains(SemanticConventions.Session.id.rawValue))
@@ -280,7 +295,7 @@ final class SessionLogRecordProcessorTests: XCTestCase {
 class MockLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
   private let queue = DispatchQueue(label: "MockLogRecordProcessor")
   private var _receivedLogRecords: [ReadableLogRecord] = []
-  
+
   var receivedLogRecords: [ReadableLogRecord] {
     return queue.sync { _receivedLogRecords }
   }

--- a/Tests/InstrumentationTests/SessionTests/SessionLogRecordProcessorTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionLogRecordProcessorTests.swift
@@ -218,6 +218,33 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     XCTAssertEqual(mockSessionManager.attributionAccessCount, 0)
   }
 
+  func testApplicationEventsUsingLifecycleNamesStillGetSessionAttributes() {
+    mockSessionManager.sessionId = "current-session-123"
+
+    for eventName in [SessionConstants.sessionStartEvent, SessionConstants.sessionEndEvent] {
+      let applicationRecord = ReadableLogRecord(
+        resource: Resource(attributes: [:]),
+        instrumentationScopeInfo: InstrumentationScopeInfo(),
+        timestamp: Date(),
+        observedTimestamp: Date(),
+        spanContext: nil,
+        severity: .info,
+        body: AttributeValue.string("application event"),
+        attributes: [:],
+        eventName: eventName
+      )
+      logRecordProcessor.onEmit(logRecord: applicationRecord)
+    }
+
+    XCTAssertEqual(mockSessionManager.attributionAccessCount, 2)
+    for record in mockNextProcessor.receivedLogRecords {
+      XCTAssertEqual(
+        record.attributes[SemanticConventions.Session.id.rawValue],
+        AttributeValue.string("current-session-123")
+      )
+    }
+  }
+
   func testDataIsPreserved() {
     let logRecordWithEventName = ReadableLogRecord(
       resource: Resource(attributes: [:]),

--- a/Tests/InstrumentationTests/SessionTests/SessionLogRecordProcessorTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionLogRecordProcessorTests.swift
@@ -34,6 +34,7 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     logRecordProcessor.onEmit(logRecord: testLogRecord)
 
     XCTAssertEqual(mockNextProcessor.receivedLogRecords.count, 1)
+    XCTAssertEqual(mockSessionManager.attributionAccessCount, 1)
     let enhancedRecord = mockNextProcessor.receivedLogRecords[0]
 
     if case let .string(sessionId) = enhancedRecord.attributes[SemanticConventions.Session.id.rawValue] {
@@ -165,7 +166,8 @@ final class SessionLogRecordProcessorTests: XCTestCase {
       attributes: [
         SemanticConventions.Session.id.rawValue: AttributeValue.string("existing-session-123"),
         SemanticConventions.Session.previousId.rawValue: AttributeValue.string("existing-previous-456")
-      ]
+      ],
+      eventName: SessionConstants.sessionStartEvent
     )
 
     mockSessionManager.sessionId = "current-session-999"
@@ -184,6 +186,7 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     } else {
       XCTFail("Expected existing session.previous_id to be preserved")
     }
+    XCTAssertEqual(mockSessionManager.attributionAccessCount, 0)
   }
 
   func testSessionEndEventPreservesExistingAttributes() {
@@ -197,7 +200,8 @@ final class SessionLogRecordProcessorTests: XCTestCase {
       body: AttributeValue.string("session.end"),
       attributes: [
         SemanticConventions.Session.id.rawValue: AttributeValue.string("ending-session-789")
-      ]
+      ],
+      eventName: SessionConstants.sessionEndEvent
     )
 
     mockSessionManager.sessionId = "current-session-999"
@@ -210,6 +214,8 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     } else {
       XCTFail("Expected existing session.id to be preserved")
     }
+    XCTAssertNil(enhancedRecord.attributes[SemanticConventions.Session.previousId.rawValue])
+    XCTAssertEqual(mockSessionManager.attributionAccessCount, 0)
   }
 
   func testDataIsPreserved() {

--- a/Tests/InstrumentationTests/SessionTests/SessionLogRecordProcessorTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionLogRecordProcessorTests.swift
@@ -34,7 +34,7 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     logRecordProcessor.onEmit(logRecord: testLogRecord)
 
     XCTAssertEqual(mockNextProcessor.receivedLogRecords.count, 1)
-    XCTAssertEqual(mockSessionManager.attributionAccessCount, 1)
+    XCTAssertEqual(mockSessionManager.sessionAccessCount, 1)
     let enhancedRecord = mockNextProcessor.receivedLogRecords[0]
 
     if case let .string(sessionId) = enhancedRecord.attributes[SemanticConventions.Session.id.rawValue] {
@@ -44,7 +44,7 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     }
   }
 
-  func testOnEmitDoesNotRefreshSessionActivity() {
+  func testOnEmitRefreshesSessionActivity() {
     SessionStore.teardown()
     defer { SessionStore.teardown() }
     let manager = SessionManager()
@@ -54,9 +54,10 @@ final class SessionLogRecordProcessorTests: XCTestCase {
       sessionManager: manager
     )
 
+    Thread.sleep(forTimeInterval: 0.01)
     processor.onEmit(logRecord: testLogRecord)
 
-    XCTAssertEqual(manager.peekSession()?.expireTime, session.expireTime)
+    XCTAssertGreaterThan(manager.peekSession()?.expireTime ?? .distantPast, session.expireTime)
   }
 
   func testOnEmitPreservesOriginalAttributes() {
@@ -186,7 +187,7 @@ final class SessionLogRecordProcessorTests: XCTestCase {
     } else {
       XCTFail("Expected existing session.previous_id to be preserved")
     }
-    XCTAssertEqual(mockSessionManager.attributionAccessCount, 0)
+    XCTAssertEqual(mockSessionManager.sessionAccessCount, 0)
   }
 
   func testSessionEndEventPreservesExistingAttributes() {
@@ -215,7 +216,7 @@ final class SessionLogRecordProcessorTests: XCTestCase {
       XCTFail("Expected existing session.id to be preserved")
     }
     XCTAssertNil(enhancedRecord.attributes[SemanticConventions.Session.previousId.rawValue])
-    XCTAssertEqual(mockSessionManager.attributionAccessCount, 0)
+    XCTAssertEqual(mockSessionManager.sessionAccessCount, 0)
   }
 
   func testApplicationEventsUsingLifecycleNamesStillGetSessionAttributes() {
@@ -236,7 +237,7 @@ final class SessionLogRecordProcessorTests: XCTestCase {
       logRecordProcessor.onEmit(logRecord: applicationRecord)
     }
 
-    XCTAssertEqual(mockSessionManager.attributionAccessCount, 2)
+    XCTAssertEqual(mockSessionManager.sessionAccessCount, 2)
     for record in mockNextProcessor.receivedLogRecords {
       XCTAssertEqual(
         record.attributes[SemanticConventions.Session.id.rawValue],

--- a/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
@@ -11,7 +11,6 @@ final class SessionManagerTests: XCTestCase {
   }
 
   override func tearDown() {
-    NotificationCenter.default.removeObserver(self)
     SessionStore.teardown()
     super.tearDown()
   }
@@ -30,20 +29,123 @@ final class SessionManagerTests: XCTestCase {
     XCTAssertEqual(id1, id2)
   }
 
-  func testGetSessionRenewed() {
+  func testGetSessionDoesNotRecordActivity() {
     let t1 = sessionManager.getSession().expireTime
     let t2 = sessionManager.getSession().expireTime
-    XCTAssertGreaterThan(t2, t1)
+    XCTAssertEqual(t2, t1)
   }
 
-  func testStartTimePreservedWhenSessionExtended() {
+  func testRecordActivityExtendsSessionAndPreservesStartTime() {
     let originalSession = sessionManager.getSession()
     Thread.sleep(forTimeInterval: 0.1)
-    let extendedSession = sessionManager.getSession()
+    let extendedSession = sessionManager.recordActivity()
 
     XCTAssertEqual(originalSession.id, extendedSession.id)
     XCTAssertGreaterThan(extendedSession.expireTime, originalSession.expireTime)
     XCTAssertEqual(originalSession.startTime, extendedSession.startTime)
+  }
+
+  func testRecordActivityAfterExpiryStartsLinkedSession() {
+    sessionManager = SessionManager(configuration: SessionConfig(sessionTimeout: 0))
+    let expiredSession = sessionManager.getSession()
+
+    let activeSession = sessionManager.recordActivity()
+
+    XCTAssertNotEqual(activeSession.id, expiredSession.id)
+    XCTAssertEqual(activeSession.previousId, expiredSession.id)
+  }
+
+  func testResetSessionEndsCurrentSessionAndPersistsLinkedReplacement() {
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = false
+    defer {
+      SessionEventInstrumentation.queue = []
+      SessionEventInstrumentation.isApplied = false
+    }
+    let originalSession = sessionManager.getSession()
+    SessionEventInstrumentation.queue = []
+
+    let replacementSession = sessionManager.resetSession()
+
+    XCTAssertNotEqual(replacementSession.id, originalSession.id)
+    XCTAssertEqual(replacementSession.previousId, originalSession.id)
+    XCTAssertEqual(SessionStore.load()?.id, replacementSession.id)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 2)
+    guard SessionEventInstrumentation.queue.count == 2 else { return }
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].session.id, originalSession.id)
+    XCTAssertNotNil(SessionEventInstrumentation.queue[0].session.endTime)
+    if case .end = SessionEventInstrumentation.queue[0].eventType {} else {
+      XCTFail("Expected one session.end event")
+    }
+    XCTAssertEqual(SessionEventInstrumentation.queue[1].session.id, replacementSession.id)
+    if case .start = SessionEventInstrumentation.queue[1].eventType {} else {
+      XCTFail("Expected one session.start event")
+    }
+  }
+
+  func testConcurrentAccessAfterExpiryStartsOneReplacement() throws {
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = false
+    defer {
+      SessionEventInstrumentation.queue = []
+      SessionEventInstrumentation.isApplied = false
+    }
+    let expiredSession = Session(
+      id: "expired-session",
+      expireTime: Date(timeIntervalSinceNow: -60),
+      startTime: Date(timeIntervalSinceNow: -120),
+      sessionTimeout: 60
+    )
+    SessionStore.saveImmediately(session: expiredSession)
+    sessionManager = SessionManager()
+    let manager = try XCTUnwrap(sessionManager)
+
+    let resultLock = NSLock()
+    nonisolated(unsafe) var sessionIds: [String] = []
+    DispatchQueue.concurrentPerform(iterations: 50) { _ in
+      let sessionId = manager.getSession().id
+      resultLock.withLock { sessionIds.append(sessionId) }
+    }
+
+    XCTAssertEqual(Set(sessionIds).count, 1)
+    XCTAssertEqual(sessionManager.peekSession()?.previousId, expiredSession.id)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 2)
+  }
+
+  func testConcurrentResetsPersistAndPublishOneLinkedChain() throws {
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = false
+    defer {
+      SessionEventInstrumentation.queue = []
+      SessionEventInstrumentation.isApplied = false
+    }
+    let originalSession = sessionManager.getSession()
+    let manager = try XCTUnwrap(sessionManager)
+    SessionEventInstrumentation.queue = []
+
+    DispatchQueue.concurrentPerform(iterations: 10) { _ in
+      manager.resetSession()
+    }
+
+    let events = SessionEventInstrumentation.queue
+    XCTAssertEqual(events.count, 20)
+    guard events.count == 20 else { return }
+    var expectedPreviousId = originalSession.id
+    for eventIndex in stride(from: 0, to: events.count, by: 2) {
+      let endEvent = events[eventIndex]
+      let startEvent = events[eventIndex + 1]
+      if case .end = endEvent.eventType {} else {
+        XCTFail("Expected session.end before each replacement")
+      }
+      if case .start = startEvent.eventType {} else {
+        XCTFail("Expected session.start after each ended session")
+      }
+      XCTAssertEqual(endEvent.session.id, expectedPreviousId)
+      XCTAssertEqual(startEvent.session.previousId, endEvent.session.id)
+      expectedPreviousId = startEvent.session.id
+    }
+    XCTAssertEqual(SessionStore.load()?.id, expectedPreviousId)
+    XCTAssertEqual(manager.peekSession()?.id, expectedPreviousId)
   }
 
   func testGetSessionExpired() {

--- a/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
@@ -426,8 +426,44 @@ final class SessionManagerTests: XCTestCase {
     }
     wait(for: [activityFinished], timeout: 0.5)
 
+    let resetFinished = expectation(description: "Explicit reset remained available")
+    DispatchQueue.global().async {
+      manager.resetSession()
+      resetFinished.fulfill()
+    }
+    wait(for: [resetFinished], timeout: 0.5)
+
     blockingProcessor.allowCompletion.signal()
     wait(for: [transitionFinished], timeout: 1)
+    XCTAssertEqual(SessionStore.load()?.id, manager.peekSession()?.id)
+  }
+
+  func testTransitionDoesNotWaitForCrossThreadDrainerCallback() {
+    let manager = SessionManager()
+    let callbackQueue = DispatchQueue(label: "io.opentelemetry.sessions.callback")
+    let processor = QueueHoppingLogRecordProcessor(callbackQueue: callbackQueue)
+    let loggerProvider = LoggerProviderBuilder()
+      .with(processors: [processor])
+      .build()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+    SessionEventInstrumentation.install()
+
+    let resetFinished = expectation(description: "Reset returned from callback queue")
+    callbackQueue.async {
+      guard processor.didStart.wait(timeout: .now() + 1) == .success else { return }
+      manager.resetSession()
+      resetFinished.fulfill()
+    }
+
+    let transitionFinished = expectation(description: "Initial transition finished")
+    DispatchQueue.global().async {
+      manager.getSessionForAttribution()
+      transitionFinished.fulfill()
+    }
+
+    wait(for: [resetFinished, transitionFinished], timeout: 2)
+    XCTAssertEqual(processor.hopCount, 1)
+    XCTAssertEqual(SessionStore.load()?.id, manager.peekSession()?.id)
   }
 
   func testReentrantResetDrainsNestedTransition() {
@@ -578,6 +614,44 @@ private final class ReentrantResetLogRecordProcessor: LogRecordProcessor, @unche
     }
     if shouldReset {
       sessionManager.resetSession()
+    }
+  }
+
+  func shutdown(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+
+  func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+}
+
+private final class QueueHoppingLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
+  let didStart = DispatchSemaphore(value: 0)
+  private let callbackQueue: DispatchQueue
+  private let lock = NSLock()
+  private var shouldHop = true
+  private var _hopCount = 0
+
+  init(callbackQueue: DispatchQueue) {
+    self.callbackQueue = callbackQueue
+  }
+
+  var hopCount: Int {
+    return lock.withLock { _hopCount }
+  }
+
+  func onEmit(logRecord: ReadableLogRecord) {
+    let hop = lock.withLock {
+      guard shouldHop else { return false }
+      shouldHop = false
+      return true
+    }
+    guard hop else { return }
+
+    didStart.signal()
+    callbackQueue.sync {
+      lock.withLock { _hopCount += 1 }
     }
   }
 

--- a/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
@@ -47,27 +47,31 @@ final class SessionManagerTests: XCTestCase {
     XCTAssertGreaterThan(t2, t1)
   }
 
-  func testAttributionDoesNotRecordActivity() {
-    let t1 = sessionManager.getSessionForAttribution().expireTime
-    let t2 = sessionManager.getSessionForAttribution().expireTime
-    XCTAssertEqual(t2, t1)
+  func testResetWithoutExistingSessionCreatesInitialSession() {
+    let session = sessionManager.resetSession()
+
+    XCTAssertNil(session.previousId)
+    XCTAssertEqual(SessionStore.load()?.id, session.id)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 1)
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].eventType, .start)
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].session.id, session.id)
   }
 
-  func testRecordActivityExtendsSessionAndPreservesStartTime() {
+  func testGetSessionExtendsSessionAndPreservesStartTime() {
     let originalSession = sessionManager.getSession()
     Thread.sleep(forTimeInterval: 0.1)
-    let extendedSession = sessionManager.recordActivity()
+    let extendedSession = sessionManager.getSession()
 
     XCTAssertEqual(originalSession.id, extendedSession.id)
     XCTAssertGreaterThan(extendedSession.expireTime, originalSession.expireTime)
     XCTAssertEqual(originalSession.startTime, extendedSession.startTime)
   }
 
-  func testRecordActivityAfterExpiryStartsLinkedSession() {
+  func testGetSessionAfterExpiryStartsLinkedSession() {
     sessionManager = SessionManager(configuration: SessionConfig(sessionTimeout: 0))
     let expiredSession = sessionManager.getSession()
 
-    let activeSession = sessionManager.recordActivity()
+    let activeSession = sessionManager.getSession()
 
     XCTAssertNotEqual(activeSession.id, expiredSession.id)
     XCTAssertEqual(activeSession.previousId, expiredSession.id)
@@ -164,7 +168,7 @@ final class SessionManagerTests: XCTestCase {
 
   func testResetSessionKeepsAnExpiredSessionEndTime() {
     sessionManager = SessionManager(configuration: SessionConfig(sessionTimeout: 0))
-    let expiredSession = sessionManager.getSessionForAttribution()
+    let expiredSession = sessionManager.getSession()
     let expiredEndTime = expiredSession.endTime
     SessionEventInstrumentation.queue = []
 
@@ -383,7 +387,7 @@ final class SessionManagerTests: XCTestCase {
     XCTAssertNotNil(session.id)
   }
 
-  func testAppliedSessionEventPipelineDoesNotReenterAttribution() {
+  func testAppliedSessionEventPipelineDoesNotReenterSessionAccess() {
     let manager = CountingSessionManager()
     let exporter = InMemoryLogRecordExporter()
     let processor = SessionLogRecordProcessor(
@@ -396,10 +400,10 @@ final class SessionManagerTests: XCTestCase {
     OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
     SessionEventInstrumentation.install()
 
-    let session = manager.getSessionForAttribution()
+    let session = manager.getSession()
 
     let records = exporter.getFinishedLogRecords()
-    XCTAssertEqual(manager.attributionAccessCount, 1)
+    XCTAssertEqual(manager.sessionAccessCount, 1)
     XCTAssertEqual(records.count, 1)
     XCTAssertEqual(records[0].eventName, SessionConstants.sessionStartEvent)
     XCTAssertEqual(
@@ -408,7 +412,7 @@ final class SessionManagerTests: XCTestCase {
     )
   }
 
-  func testSlowSessionExporterDoesNotBlockPassiveAttribution() {
+  func testSlowSessionExporterDoesNotBlockConcurrentAccessOrReset() {
     let manager = SessionManager()
     let blockingProcessor = BlockingLogRecordProcessor()
     let loggerProvider = LoggerProviderBuilder()
@@ -419,23 +423,23 @@ final class SessionManagerTests: XCTestCase {
 
     let transitionFinished = expectation(description: "Session transition finished")
     DispatchQueue.global().async {
-      manager.getSessionForAttribution()
+      manager.getSession()
       transitionFinished.fulfill()
     }
     XCTAssertEqual(blockingProcessor.didStart.wait(timeout: .now() + 1), .success)
-    let passiveAccessFinished = expectation(description: "Passive attribution remained available")
+    let secondAccessFinished = expectation(description: "Second access remained available")
     DispatchQueue.global().async {
-      manager.getSessionForAttribution()
-      passiveAccessFinished.fulfill()
+      manager.getSession()
+      secondAccessFinished.fulfill()
     }
-    wait(for: [passiveAccessFinished], timeout: 0.5)
+    wait(for: [secondAccessFinished], timeout: 0.5)
 
-    let activityFinished = expectation(description: "Activity update remained available")
+    let thirdAccessFinished = expectation(description: "Third access remained available")
     DispatchQueue.global().async {
-      manager.recordActivity()
-      activityFinished.fulfill()
+      manager.getSession()
+      thirdAccessFinished.fulfill()
     }
-    wait(for: [activityFinished], timeout: 0.5)
+    wait(for: [thirdAccessFinished], timeout: 0.5)
 
     let resetFinished = expectation(description: "Explicit reset remained available")
     let resetLock = NSLock()
@@ -479,7 +483,7 @@ final class SessionManagerTests: XCTestCase {
 
     let transitionFinished = expectation(description: "Initial transition finished")
     DispatchQueue.global().async {
-      manager.getSessionForAttribution()
+      manager.getSession()
       transitionFinished.fulfill()
     }
 
@@ -507,7 +511,7 @@ final class SessionManagerTests: XCTestCase {
 
     let callerFinished = expectation(description: "Initial caller returned")
     callerQueue.async {
-      manager.getSessionForAttribution()
+      manager.getSession()
       callerFinished.fulfill()
     }
 
@@ -533,7 +537,7 @@ final class SessionManagerTests: XCTestCase {
 
     let transitionFinished = expectation(description: "Nested session transition finished")
     DispatchQueue.global().async {
-      manager.getSessionForAttribution()
+      manager.getSession()
       transitionFinished.fulfill()
     }
     wait(for: [transitionFinished, eventsPublished], timeout: 1)
@@ -605,15 +609,15 @@ final class SessionManagerTests: XCTestCase {
 
 private final class CountingSessionManager: SessionManager, @unchecked Sendable {
   private let countLock = NSLock()
-  private var _attributionAccessCount = 0
+  private var _sessionAccessCount = 0
 
-  var attributionAccessCount: Int {
-    return countLock.withLock { _attributionAccessCount }
+  var sessionAccessCount: Int {
+    return countLock.withLock { _sessionAccessCount }
   }
 
-  override func getSessionForAttribution() -> Session {
-    countLock.withLock { _attributionAccessCount += 1 }
-    return super.getSessionForAttribution()
+  override func getSession() -> Session {
+    countLock.withLock { _sessionAccessCount += 1 }
+    return super.getSession()
   }
 }
 

--- a/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
@@ -125,10 +125,21 @@ final class SessionManagerTests: XCTestCase {
     let originalSession = sessionManager.getSession()
     let manager = try XCTUnwrap(sessionManager)
     SessionEventInstrumentation.queue = []
+    let transitionsPublished = expectation(description: "Concurrent transitions published")
+    transitionsPublished.expectedFulfillmentCount = 10
+    let observer = NotificationCenter.default.addObserver(
+      forName: SessionEventNotification,
+      object: nil,
+      queue: nil
+    ) { _ in
+      transitionsPublished.fulfill()
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
 
     DispatchQueue.concurrentPerform(iterations: 10) { _ in
       manager.resetSession()
     }
+    wait(for: [transitionsPublished], timeout: 2)
 
     let events = SessionEventInstrumentation.queue
     XCTAssertEqual(events.count, 20)
@@ -427,11 +438,17 @@ final class SessionManagerTests: XCTestCase {
     wait(for: [activityFinished], timeout: 0.5)
 
     let resetFinished = expectation(description: "Explicit reset remained available")
+    let resetLock = NSLock()
+    nonisolated(unsafe) var resetSession: Session?
     DispatchQueue.global().async {
-      manager.resetSession()
+      let replacement = manager.resetSession()
+      resetLock.withLock { resetSession = replacement }
       resetFinished.fulfill()
     }
     wait(for: [resetFinished], timeout: 0.5)
+    let replacement = resetLock.withLock { resetSession }
+    XCTAssertEqual(SessionStore.load()?.id, replacement?.id)
+    XCTAssertEqual(SessionStore.load()?.id, manager.peekSession()?.id)
 
     blockingProcessor.allowCompletion.signal()
     wait(for: [transitionFinished], timeout: 1)
@@ -441,7 +458,12 @@ final class SessionManagerTests: XCTestCase {
   func testTransitionDoesNotWaitForCrossThreadDrainerCallback() {
     let manager = SessionManager()
     let callbackQueue = DispatchQueue(label: "io.opentelemetry.sessions.callback")
-    let processor = QueueHoppingLogRecordProcessor(callbackQueue: callbackQueue)
+    let eventsPublished = expectation(description: "Initial and reset events published")
+    eventsPublished.expectedFulfillmentCount = 3
+    let processor = QueueHoppingLogRecordProcessor(
+      callbackQueue: callbackQueue,
+      eventExpectation: eventsPublished
+    )
     let loggerProvider = LoggerProviderBuilder()
       .with(processors: [processor])
       .build()
@@ -461,14 +483,48 @@ final class SessionManagerTests: XCTestCase {
       transitionFinished.fulfill()
     }
 
-    wait(for: [resetFinished, transitionFinished], timeout: 2)
+    wait(for: [resetFinished, transitionFinished, eventsPublished], timeout: 2)
     XCTAssertEqual(processor.hopCount, 1)
+    XCTAssertEqual(SessionStore.load()?.id, manager.peekSession()?.id)
+  }
+
+  func testCallerDoesNotDrainTransitionsQueuedDuringCallback() {
+    let manager = SessionManager()
+    let callerQueue = DispatchQueue(label: "io.opentelemetry.sessions.caller")
+    let eventsPublished = expectation(description: "Contended transitions published")
+    eventsPublished.expectedFulfillmentCount = 11
+    let processor = ContendedTransitionLogRecordProcessor(
+      sessionManager: manager,
+      callerQueue: callerQueue,
+      eventExpectation: eventsPublished,
+      resetCount: 5
+    )
+    let loggerProvider = LoggerProviderBuilder()
+      .with(processors: [processor])
+      .build()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+    SessionEventInstrumentation.install()
+
+    let callerFinished = expectation(description: "Initial caller returned")
+    callerQueue.async {
+      manager.getSessionForAttribution()
+      callerFinished.fulfill()
+    }
+
+    wait(for: [callerFinished, eventsPublished], timeout: 2)
+    XCTAssertTrue(processor.producerFinishedSuccessfully)
+    XCTAssertEqual(processor.callerQueueEventCount, 1)
     XCTAssertEqual(SessionStore.load()?.id, manager.peekSession()?.id)
   }
 
   func testReentrantResetDrainsNestedTransition() {
     let manager = SessionManager()
-    let processor = ReentrantResetLogRecordProcessor(sessionManager: manager)
+    let eventsPublished = expectation(description: "Nested transition events published")
+    eventsPublished.expectedFulfillmentCount = 3
+    let processor = ReentrantResetLogRecordProcessor(
+      sessionManager: manager,
+      eventExpectation: eventsPublished
+    )
     let loggerProvider = LoggerProviderBuilder()
       .with(processors: [processor])
       .build()
@@ -480,7 +536,7 @@ final class SessionManagerTests: XCTestCase {
       manager.getSessionForAttribution()
       transitionFinished.fulfill()
     }
-    wait(for: [transitionFinished], timeout: 1)
+    wait(for: [transitionFinished, eventsPublished], timeout: 1)
 
     XCTAssertEqual(processor.eventNames, [
       SessionConstants.sessionStartEvent,
@@ -589,12 +645,14 @@ private final class BlockingLogRecordProcessor: LogRecordProcessor, @unchecked S
 
 private final class ReentrantResetLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
   private let sessionManager: SessionManager
+  private let eventExpectation: XCTestExpectation
   private let lock = NSLock()
   private var didReset = false
   private var _eventNames: [String] = []
 
-  init(sessionManager: SessionManager) {
+  init(sessionManager: SessionManager, eventExpectation: XCTestExpectation) {
     self.sessionManager = sessionManager
+    self.eventExpectation = eventExpectation
   }
 
   var eventNames: [String] {
@@ -602,6 +660,7 @@ private final class ReentrantResetLogRecordProcessor: LogRecordProcessor, @unche
   }
 
   func onEmit(logRecord: ReadableLogRecord) {
+    eventExpectation.fulfill()
     let shouldReset = lock.withLock {
       if let eventName = logRecord.eventName {
         _eventNames.append(eventName)
@@ -629,12 +688,14 @@ private final class ReentrantResetLogRecordProcessor: LogRecordProcessor, @unche
 private final class QueueHoppingLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
   let didStart = DispatchSemaphore(value: 0)
   private let callbackQueue: DispatchQueue
+  private let eventExpectation: XCTestExpectation
   private let lock = NSLock()
   private var shouldHop = true
   private var _hopCount = 0
 
-  init(callbackQueue: DispatchQueue) {
+  init(callbackQueue: DispatchQueue, eventExpectation: XCTestExpectation) {
     self.callbackQueue = callbackQueue
+    self.eventExpectation = eventExpectation
   }
 
   var hopCount: Int {
@@ -642,6 +703,7 @@ private final class QueueHoppingLogRecordProcessor: LogRecordProcessor, @uncheck
   }
 
   func onEmit(logRecord: ReadableLogRecord) {
+    eventExpectation.fulfill()
     let hop = lock.withLock {
       guard shouldHop else { return false }
       shouldHop = false
@@ -653,6 +715,66 @@ private final class QueueHoppingLogRecordProcessor: LogRecordProcessor, @uncheck
     callbackQueue.sync {
       lock.withLock { _hopCount += 1 }
     }
+  }
+
+  func shutdown(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+
+  func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+}
+
+private final class ContendedTransitionLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
+  private let sessionManager: SessionManager
+  private let callerQueueKey = DispatchSpecificKey<Void>()
+  private let eventExpectation: XCTestExpectation
+  private let resetCount: Int
+  private let producerFinished = DispatchSemaphore(value: 0)
+  private let lock = NSLock()
+  private var startedProducer = false
+  private var _producerFinishedSuccessfully = false
+  private var _callerQueueEventCount = 0
+
+  init(sessionManager: SessionManager,
+       callerQueue: DispatchQueue,
+       eventExpectation: XCTestExpectation,
+       resetCount: Int) {
+    self.sessionManager = sessionManager
+    self.eventExpectation = eventExpectation
+    self.resetCount = resetCount
+    callerQueue.setSpecific(key: callerQueueKey, value: ())
+  }
+
+  var producerFinishedSuccessfully: Bool {
+    return lock.withLock { _producerFinishedSuccessfully }
+  }
+
+  var callerQueueEventCount: Int {
+    return lock.withLock { _callerQueueEventCount }
+  }
+
+  func onEmit(logRecord: ReadableLogRecord) {
+    eventExpectation.fulfill()
+    let shouldProduce = lock.withLock {
+      if DispatchQueue.getSpecific(key: callerQueueKey) != nil {
+        _callerQueueEventCount += 1
+      }
+      guard !startedProducer else { return false }
+      startedProducer = true
+      return true
+    }
+    guard shouldProduce else { return }
+
+    DispatchQueue.global().async { [self] in
+      for _ in 0 ..< resetCount {
+        sessionManager.resetSession()
+      }
+      producerFinished.signal()
+    }
+    let finished = producerFinished.wait(timeout: .now() + 1) == .success
+    lock.withLock { _producerFinishedSuccessfully = finished }
   }
 
   func shutdown(explicitTimeout: TimeInterval?) -> ExportResult {

--- a/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionManagerTests.swift
@@ -1,17 +1,28 @@
 import XCTest
+import OpenTelemetryApi
 @testable import Sessions
+@testable import OpenTelemetrySdk
 
 final class SessionManagerTests: XCTestCase {
   var sessionManager: SessionManager!
+  private var previousQueuedEvents: [SessionEvent] = []
+  private var previousInstrumentationState = false
 
   override func setUp() {
     super.setUp()
+    previousQueuedEvents = SessionEventInstrumentation.queue
+    previousInstrumentationState = SessionEventInstrumentation.isApplied
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = false
     SessionStore.teardown()
     sessionManager = SessionManager()
   }
 
   override func tearDown() {
     SessionStore.teardown()
+    SessionEventInstrumentation.queue = previousQueuedEvents
+    SessionEventInstrumentation.isApplied = previousInstrumentationState
+    OpenTelemetry.registerLoggerProvider(loggerProvider: DefaultLoggerProvider.instance)
     super.tearDown()
   }
 
@@ -29,9 +40,16 @@ final class SessionManagerTests: XCTestCase {
     XCTAssertEqual(id1, id2)
   }
 
-  func testGetSessionDoesNotRecordActivity() {
+  func testGetSessionRecordsActivity() {
     let t1 = sessionManager.getSession().expireTime
+    Thread.sleep(forTimeInterval: 0.1)
     let t2 = sessionManager.getSession().expireTime
+    XCTAssertGreaterThan(t2, t1)
+  }
+
+  func testAttributionDoesNotRecordActivity() {
+    let t1 = sessionManager.getSessionForAttribution().expireTime
+    let t2 = sessionManager.getSessionForAttribution().expireTime
     XCTAssertEqual(t2, t1)
   }
 
@@ -56,12 +74,6 @@ final class SessionManagerTests: XCTestCase {
   }
 
   func testResetSessionEndsCurrentSessionAndPersistsLinkedReplacement() {
-    SessionEventInstrumentation.queue = []
-    SessionEventInstrumentation.isApplied = false
-    defer {
-      SessionEventInstrumentation.queue = []
-      SessionEventInstrumentation.isApplied = false
-    }
     let originalSession = sessionManager.getSession()
     SessionEventInstrumentation.queue = []
 
@@ -73,7 +85,10 @@ final class SessionManagerTests: XCTestCase {
     XCTAssertEqual(SessionEventInstrumentation.queue.count, 2)
     guard SessionEventInstrumentation.queue.count == 2 else { return }
     XCTAssertEqual(SessionEventInstrumentation.queue[0].session.id, originalSession.id)
-    XCTAssertNotNil(SessionEventInstrumentation.queue[0].session.endTime)
+    XCTAssertEqual(
+      SessionEventInstrumentation.queue[0].session.endTime,
+      replacementSession.startTime
+    )
     if case .end = SessionEventInstrumentation.queue[0].eventType {} else {
       XCTFail("Expected one session.end event")
     }
@@ -84,12 +99,6 @@ final class SessionManagerTests: XCTestCase {
   }
 
   func testConcurrentAccessAfterExpiryStartsOneReplacement() throws {
-    SessionEventInstrumentation.queue = []
-    SessionEventInstrumentation.isApplied = false
-    defer {
-      SessionEventInstrumentation.queue = []
-      SessionEventInstrumentation.isApplied = false
-    }
     let expiredSession = Session(
       id: "expired-session",
       expireTime: Date(timeIntervalSinceNow: -60),
@@ -113,12 +122,6 @@ final class SessionManagerTests: XCTestCase {
   }
 
   func testConcurrentResetsPersistAndPublishOneLinkedChain() throws {
-    SessionEventInstrumentation.queue = []
-    SessionEventInstrumentation.isApplied = false
-    defer {
-      SessionEventInstrumentation.queue = []
-      SessionEventInstrumentation.isApplied = false
-    }
     let originalSession = sessionManager.getSession()
     let manager = try XCTUnwrap(sessionManager)
     SessionEventInstrumentation.queue = []
@@ -146,6 +149,48 @@ final class SessionManagerTests: XCTestCase {
     }
     XCTAssertEqual(SessionStore.load()?.id, expectedPreviousId)
     XCTAssertEqual(manager.peekSession()?.id, expectedPreviousId)
+  }
+
+  func testResetSessionKeepsAnExpiredSessionEndTime() {
+    sessionManager = SessionManager(configuration: SessionConfig(sessionTimeout: 0))
+    let expiredSession = sessionManager.getSessionForAttribution()
+    let expiredEndTime = expiredSession.endTime
+    SessionEventInstrumentation.queue = []
+
+    let replacementSession = sessionManager.resetSession()
+
+    XCTAssertEqual(replacementSession.previousId, expiredSession.id)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 2)
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].session.id, expiredSession.id)
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].session.endTime, expiredEndTime)
+  }
+
+  func testResetSessionUsesPersistedPreviousSessionBeforeFirstAccess() {
+    let sessionTimeout: TimeInterval = 60 * 60
+    let lastActivity = Date(timeIntervalSinceNow: -60)
+    let persistedSession = Session(
+      id: "persisted-session",
+      expireTime: lastActivity.addingTimeInterval(sessionTimeout),
+      startTime: Date(timeIntervalSinceNow: -120),
+      sessionTimeout: sessionTimeout
+    )
+    SessionStore.saveImmediately(session: persistedSession)
+    sessionManager = SessionManager(configuration: SessionConfig(
+      sessionTimeout: sessionTimeout,
+      restorePersistedSession: false
+    ))
+
+    let replacementSession = sessionManager.resetSession()
+
+    XCTAssertEqual(replacementSession.previousId, persistedSession.id)
+    XCTAssertEqual(SessionStore.load()?.id, replacementSession.id)
+    XCTAssertEqual(SessionEventInstrumentation.queue.count, 2)
+    XCTAssertEqual(SessionEventInstrumentation.queue[0].session.id, persistedSession.id)
+    XCTAssertEqual(
+      SessionEventInstrumentation.queue[0].session.endTime?.timeIntervalSince1970 ?? 0,
+      lastActivity.timeIntervalSince1970,
+      accuracy: 1.0
+    )
   }
 
   func testGetSessionExpired() {
@@ -199,12 +244,6 @@ final class SessionManagerTests: XCTestCase {
   }
 
   func testRestorePersistedSessionFalseEndsPersistedSessionAtLastActivity() {
-    SessionEventInstrumentation.queue = []
-    SessionEventInstrumentation.isApplied = false
-    defer {
-      SessionEventInstrumentation.queue = []
-      SessionEventInstrumentation.isApplied = false
-    }
     let sessionTimeout: TimeInterval = 60 * 60
     let lastActivity = Date(timeIntervalSinceNow: -5 * 60)
     let persistedSession = Session(
@@ -333,6 +372,88 @@ final class SessionManagerTests: XCTestCase {
     XCTAssertNotNil(session.id)
   }
 
+  func testAppliedSessionEventPipelineDoesNotReenterAttribution() {
+    let manager = CountingSessionManager()
+    let exporter = InMemoryLogRecordExporter()
+    let processor = SessionLogRecordProcessor(
+      nextProcessor: SimpleLogRecordProcessor(logRecordExporter: exporter),
+      sessionManager: manager
+    )
+    let loggerProvider = LoggerProviderBuilder()
+      .with(processors: [processor])
+      .build()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+    SessionEventInstrumentation.install()
+
+    let session = manager.getSessionForAttribution()
+
+    let records = exporter.getFinishedLogRecords()
+    XCTAssertEqual(manager.attributionAccessCount, 1)
+    XCTAssertEqual(records.count, 1)
+    XCTAssertEqual(records[0].eventName, SessionConstants.sessionStartEvent)
+    XCTAssertEqual(
+      records[0].attributes[SemanticConventions.Session.id.rawValue],
+      AttributeValue.string(session.id)
+    )
+  }
+
+  func testSlowSessionExporterDoesNotBlockPassiveAttribution() {
+    let manager = SessionManager()
+    let blockingProcessor = BlockingLogRecordProcessor()
+    let loggerProvider = LoggerProviderBuilder()
+      .with(processors: [blockingProcessor])
+      .build()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+    SessionEventInstrumentation.install()
+
+    let transitionFinished = expectation(description: "Session transition finished")
+    DispatchQueue.global().async {
+      manager.getSessionForAttribution()
+      transitionFinished.fulfill()
+    }
+    XCTAssertEqual(blockingProcessor.didStart.wait(timeout: .now() + 1), .success)
+    let passiveAccessFinished = expectation(description: "Passive attribution remained available")
+    DispatchQueue.global().async {
+      manager.getSessionForAttribution()
+      passiveAccessFinished.fulfill()
+    }
+    wait(for: [passiveAccessFinished], timeout: 0.5)
+
+    let activityFinished = expectation(description: "Activity update remained available")
+    DispatchQueue.global().async {
+      manager.recordActivity()
+      activityFinished.fulfill()
+    }
+    wait(for: [activityFinished], timeout: 0.5)
+
+    blockingProcessor.allowCompletion.signal()
+    wait(for: [transitionFinished], timeout: 1)
+  }
+
+  func testReentrantResetDrainsNestedTransition() {
+    let manager = SessionManager()
+    let processor = ReentrantResetLogRecordProcessor(sessionManager: manager)
+    let loggerProvider = LoggerProviderBuilder()
+      .with(processors: [processor])
+      .build()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+    SessionEventInstrumentation.install()
+
+    let transitionFinished = expectation(description: "Nested session transition finished")
+    DispatchQueue.global().async {
+      manager.getSessionForAttribution()
+      transitionFinished.fulfill()
+    }
+    wait(for: [transitionFinished], timeout: 1)
+
+    XCTAssertEqual(processor.eventNames, [
+      SessionConstants.sessionStartEvent,
+      SessionConstants.sessionEndEvent,
+      SessionConstants.sessionStartEvent
+    ])
+    XCTAssertEqual(SessionStore.load()?.id, manager.peekSession()?.id)
+  }
+
   func testSessionStartNotificationPosted() {
     let expectation = XCTestExpectation(description: "Session start notification")
     nonisolated(unsafe) var receivedSession: Session?
@@ -387,5 +508,84 @@ final class SessionManagerTests: XCTestCase {
     XCTAssertTrue(receivedSessions.contains(session1.id))
     XCTAssertTrue(receivedSessions.contains(session2.id))
     XCTAssertTrue(receivedSessions.contains(session3.id))
+  }
+}
+
+private final class CountingSessionManager: SessionManager, @unchecked Sendable {
+  private let countLock = NSLock()
+  private var _attributionAccessCount = 0
+
+  var attributionAccessCount: Int {
+    return countLock.withLock { _attributionAccessCount }
+  }
+
+  override func getSessionForAttribution() -> Session {
+    countLock.withLock { _attributionAccessCount += 1 }
+    return super.getSessionForAttribution()
+  }
+}
+
+private final class BlockingLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
+  let didStart = DispatchSemaphore(value: 0)
+  let allowCompletion = DispatchSemaphore(value: 0)
+  private let lock = NSLock()
+  private var shouldBlock = true
+
+  func onEmit(logRecord: ReadableLogRecord) {
+    let block = lock.withLock {
+      defer { shouldBlock = false }
+      return shouldBlock
+    }
+    guard block else { return }
+
+    didStart.signal()
+    _ = allowCompletion.wait(timeout: .now() + 5)
+  }
+
+  func shutdown(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+
+  func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+}
+
+private final class ReentrantResetLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
+  private let sessionManager: SessionManager
+  private let lock = NSLock()
+  private var didReset = false
+  private var _eventNames: [String] = []
+
+  init(sessionManager: SessionManager) {
+    self.sessionManager = sessionManager
+  }
+
+  var eventNames: [String] {
+    return lock.withLock { _eventNames }
+  }
+
+  func onEmit(logRecord: ReadableLogRecord) {
+    let shouldReset = lock.withLock {
+      if let eventName = logRecord.eventName {
+        _eventNames.append(eventName)
+      }
+      guard !didReset, logRecord.eventName == SessionConstants.sessionStartEvent else {
+        return false
+      }
+      didReset = true
+      return true
+    }
+    if shouldReset {
+      sessionManager.resetSession()
+    }
+  }
+
+  func shutdown(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+
+  func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
   }
 }

--- a/Tests/InstrumentationTests/SessionTests/SessionPublicAPITests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionPublicAPITests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import Sessions
+
+final class SessionPublicAPITests: XCTestCase {
+  func testAttributionAccessorIsPublic() {
+    let accessor: (SessionManager) -> () -> Session = SessionManager.getSessionForAttribution
+    XCTAssertNotNil(accessor)
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionPublicAPITests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionPublicAPITests.swift
@@ -2,8 +2,8 @@ import XCTest
 import Sessions
 
 final class SessionPublicAPITests: XCTestCase {
-  func testAttributionAccessorIsPublic() {
-    let accessor: (SessionManager) -> () -> Session = SessionManager.getSessionForAttribution
-    XCTAssertNotNil(accessor)
+  func testResetSessionIsPublic() {
+    let reset: (SessionManager) -> () -> Session = SessionManager.resetSession
+    XCTAssertNotNil(reset)
   }
 }

--- a/Tests/InstrumentationTests/SessionTests/SessionSpanProcessorTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionSpanProcessorTests.swift
@@ -26,6 +26,7 @@ final class SessionSpanProcessorTests: XCTestCase {
 
     spanProcessor.onStart(parentContext: nil, span: mockSpan)
 
+    XCTAssertEqual(mockSessionManager.attributionAccessCount, 1)
     if case let .string(sessionId) = mockSpan.capturedAttributes["session.id"] {
       XCTAssertEqual(sessionId, expectedSessionId)
     } else {
@@ -125,12 +126,22 @@ final class SessionSpanProcessorTests: XCTestCase {
 
 // MARK: - Mock Classes
 
-class MockSessionManager: SessionManager {
+class MockSessionManager: SessionManager, @unchecked Sendable {
   var sessionId: String = "default-session-id"
   var previousSessionId: String?
   var startTime: Date = .init()
+  var attributionAccessCount = 0
 
   override func getSession() -> Session {
+    return mockSession()
+  }
+
+  override func getSessionForAttribution() -> Session {
+    attributionAccessCount += 1
+    return mockSession()
+  }
+
+  private func mockSession() -> Session {
     return Session(
       id: sessionId,
       expireTime: Date(timeIntervalSinceNow: 1800),
@@ -196,4 +207,5 @@ final class MockReadableSpan: ReadableSpan, @unchecked Sendable {
   func recordException(_ exception: any SpanException, timestamp: Date) {}
   func recordException(_ exception: any SpanException, attributes: [String: AttributeValue]) {}
   func recordException(_ exception: any SpanException, attributes: [String: AttributeValue], timestamp: Date) {}
+  func addLink(spanContext: SpanContext, attributes: [String: AttributeValue]) {}
 }

--- a/Tests/InstrumentationTests/SessionTests/SessionSpanProcessorTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionSpanProcessorTests.swift
@@ -33,6 +33,18 @@ final class SessionSpanProcessorTests: XCTestCase {
     }
   }
 
+  func testOnStartDoesNotRefreshSessionActivity() {
+    SessionStore.teardown()
+    defer { SessionStore.teardown() }
+    let manager = SessionManager()
+    let session = manager.getSession()
+    let processor = SessionSpanProcessor(sessionManager: manager)
+
+    processor.onStart(parentContext: nil, span: mockSpan)
+
+    XCTAssertEqual(manager.peekSession()?.expireTime, session.expireTime)
+  }
+
   func testOnStartWithDifferentSessionIds() {
     mockSessionManager.sessionId = "session-1"
     spanProcessor.onStart(parentContext: nil, span: mockSpan)
@@ -103,7 +115,7 @@ final class SessionSpanProcessorTests: XCTestCase {
 
     XCTAssertNil(mockSpan.capturedAttributes["session.previous_id"], "Previous session ID should not be set when nil")
   }
-  
+
   func testInitializationWithNilSessionManager() {
     let processor = SessionSpanProcessor()
     XCTAssertTrue(processor.isStartRequired)
@@ -140,11 +152,11 @@ final class MockReadableSpan: ReadableSpan, @unchecked Sendable {
   var isRecording: Bool = true
   var status: Status = .unset
   var description: String = "MockReadableSpan"
-  
+
   func getAttributes() -> [String: AttributeValue] {
     return capturedAttributes
   }
-  
+
   func setAttributes(_ attributes: [String: AttributeValue]) {
     capturedAttributes.merge(attributes) { _, new in new }
   }
@@ -171,7 +183,7 @@ final class MockReadableSpan: ReadableSpan, @unchecked Sendable {
   }
 
   func setAttribute(key: String, value: AttributeValue?) {
-    if let value = value {
+    if let value {
       capturedAttributes[key] = value
     }
   }

--- a/Tests/InstrumentationTests/SessionTests/SessionSpanProcessorTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionSpanProcessorTests.swift
@@ -26,7 +26,7 @@ final class SessionSpanProcessorTests: XCTestCase {
 
     spanProcessor.onStart(parentContext: nil, span: mockSpan)
 
-    XCTAssertEqual(mockSessionManager.attributionAccessCount, 1)
+    XCTAssertEqual(mockSessionManager.sessionAccessCount, 1)
     if case let .string(sessionId) = mockSpan.capturedAttributes["session.id"] {
       XCTAssertEqual(sessionId, expectedSessionId)
     } else {
@@ -34,16 +34,17 @@ final class SessionSpanProcessorTests: XCTestCase {
     }
   }
 
-  func testOnStartDoesNotRefreshSessionActivity() {
+  func testOnStartRefreshesSessionActivity() {
     SessionStore.teardown()
     defer { SessionStore.teardown() }
     let manager = SessionManager()
     let session = manager.getSession()
     let processor = SessionSpanProcessor(sessionManager: manager)
 
+    Thread.sleep(forTimeInterval: 0.01)
     processor.onStart(parentContext: nil, span: mockSpan)
 
-    XCTAssertEqual(manager.peekSession()?.expireTime, session.expireTime)
+    XCTAssertGreaterThan(manager.peekSession()?.expireTime ?? .distantPast, session.expireTime)
   }
 
   func testOnStartWithDifferentSessionIds() {
@@ -130,14 +131,10 @@ class MockSessionManager: SessionManager, @unchecked Sendable {
   var sessionId: String = "default-session-id"
   var previousSessionId: String?
   var startTime: Date = .init()
-  var attributionAccessCount = 0
+  var sessionAccessCount = 0
 
   override func getSession() -> Session {
-    return mockSession()
-  }
-
-  override func getSessionForAttribution() -> Session {
-    attributionAccessCount += 1
+    sessionAccessCount += 1
     return mockSession()
   }
 

--- a/Tests/InstrumentationTests/SessionTests/SessionStoreTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionStoreTests.swift
@@ -69,6 +69,37 @@ final class SessionStoreTests: XCTestCase {
     XCTAssertEqual(loaded2?.id, "session-2")
   }
 
+  func testConcurrentSaveAndLoadReturnsCompleteSession() {
+    let first = Session(
+      id: "session-1",
+      expireTime: Date(timeIntervalSince1970: 1_000),
+      previousId: "previous-1",
+      startTime: Date(timeIntervalSince1970: 100),
+      sessionTimeout: 900,
+      maxLifetime: 1_800
+    )
+    let second = Session(
+      id: "session-2",
+      expireTime: Date(timeIntervalSince1970: 2_000),
+      previousId: "previous-2",
+      startTime: Date(timeIntervalSince1970: 200),
+      sessionTimeout: 1_800,
+      maxLifetime: nil
+    )
+    let resultLock = NSLock()
+    nonisolated(unsafe) var unexpectedSessions: [Session] = []
+
+    DispatchQueue.concurrentPerform(iterations: 200) { index in
+      if index.isMultiple(of: 2) {
+        SessionStore.saveImmediately(session: index.isMultiple(of: 4) ? first : second)
+      } else if let loaded = SessionStore.load(), loaded != first, loaded != second {
+        resultLock.withLock { unexpectedSessions.append(loaded) }
+      }
+    }
+
+    XCTAssertTrue(unexpectedSessions.isEmpty)
+  }
+
   func testSaveWithoutMaxLifetimeClearsPreviousMaxLifetime() {
     let cappedSession = Session(
       id: "session-1",
@@ -102,8 +133,6 @@ final class SessionStoreTests: XCTestCase {
     XCTAssertEqual(SessionStore.sessionTimeoutKey, "otel-session-timeout")
     XCTAssertEqual(SessionStore.maxLifetimeKey, "otel-session-max-lifetime")
   }
-
-
 
   func testSaveAndLoadSessionWithPreviousId() {
     let sessionId = "current-session-123"
@@ -157,81 +186,81 @@ final class SessionStoreTests: XCTestCase {
     let savedId = UserDefaults.standard.string(forKey: SessionStore.idKey)
     XCTAssertEqual(savedId, session2.id)
   }
-  
+
   func testLoadSessionWithCorruptedId() {
     UserDefaults.standard.set(["invalid": "id"], forKey: SessionStore.idKey)
     UserDefaults.standard.set(Date(), forKey: SessionStore.expireTimeKey)
     UserDefaults.standard.set(Date(), forKey: SessionStore.startTimeKey)
     UserDefaults.standard.set(1800.0, forKey: SessionStore.sessionTimeoutKey)
-    
+
     let loadedSession = SessionStore.load()
     XCTAssertNil(loadedSession)
   }
-  
+
   func testLoadSessionWithCorruptedExpireTime() {
     UserDefaults.standard.set("test-id", forKey: SessionStore.idKey)
     UserDefaults.standard.set("invalid-date", forKey: SessionStore.expireTimeKey)
     UserDefaults.standard.set(Date(), forKey: SessionStore.startTimeKey)
     UserDefaults.standard.set(1800.0, forKey: SessionStore.sessionTimeoutKey)
-    
+
     let loadedSession = SessionStore.load()
     XCTAssertNil(loadedSession)
   }
-  
+
   func testLoadSessionWithCorruptedStartTime() {
     UserDefaults.standard.set("test-id", forKey: SessionStore.idKey)
     UserDefaults.standard.set(Date(), forKey: SessionStore.expireTimeKey)
     UserDefaults.standard.set("invalid-date", forKey: SessionStore.startTimeKey)
     UserDefaults.standard.set(1800.0, forKey: SessionStore.sessionTimeoutKey)
-    
+
     let loadedSession = SessionStore.load()
     XCTAssertNil(loadedSession)
   }
-  
+
   func testLoadSessionWithCorruptedTimeout() {
     UserDefaults.standard.set("test-id", forKey: SessionStore.idKey)
     UserDefaults.standard.set(Date(), forKey: SessionStore.expireTimeKey)
     UserDefaults.standard.set(Date(), forKey: SessionStore.startTimeKey)
     UserDefaults.standard.set("invalid-timeout", forKey: SessionStore.sessionTimeoutKey)
-    
+
     let loadedSession = SessionStore.load()
     XCTAssertNil(loadedSession)
   }
-  
+
   func testLoadSessionMissingTimeout() {
     UserDefaults.standard.set("test-id", forKey: SessionStore.idKey)
     UserDefaults.standard.set(Date(), forKey: SessionStore.expireTimeKey)
     UserDefaults.standard.set(Date(), forKey: SessionStore.startTimeKey)
-    
+
     let loadedSession = SessionStore.load()
     XCTAssertNil(loadedSession)
   }
-  
+
   func testScheduleSaveWithSameSession() {
     let session1 = Session(id: "session-1", expireTime: Date(), startTime: Date())
-    
+
     SessionStore.scheduleSave(session: session1)
     let savedId1 = UserDefaults.standard.string(forKey: SessionStore.idKey)
     XCTAssertEqual(savedId1, session1.id)
-    
+
     // Schedule the same session again - should not trigger another save
     SessionStore.scheduleSave(session: session1)
     let savedId2 = UserDefaults.standard.string(forKey: SessionStore.idKey)
     XCTAssertEqual(savedId2, session1.id)
   }
-  
+
   func testScheduleSaveWithExistingTimer() {
     let session1 = Session(id: "session-1", expireTime: Date(), startTime: Date())
     let session2 = Session(id: "session-2", expireTime: Date(), startTime: Date())
-    
+
     // First call creates timer and saves session1
     SessionStore.scheduleSave(session: session1)
     let savedId1 = UserDefaults.standard.string(forKey: SessionStore.idKey)
     XCTAssertEqual(savedId1, session1.id)
-    
+
     // Second call should use existing timer and update pending session
     SessionStore.scheduleSave(session: session2)
-    
+
     // The first session is still saved until timer fires
     let savedId2 = UserDefaults.standard.string(forKey: SessionStore.idKey)
     XCTAssertEqual(savedId2, session1.id)


### PR DESCRIPTION
## Summary

- Add `SessionManager.resetSession()` for explicit session boundaries such as sign-out or account changes.
- Create and persist a replacement session linked through `session.previous_id`.
- Keep session end and start events ordered during concurrent and reentrant resets.
- Avoid re-entering session access while publishing session lifecycle telemetry.
- Preserve the existing behavior where `getSession()`, spans, and logs refresh session activity.

## Validation

- `swift test --enable-code-coverage`: 633 tests passed.
- 131 session tests passed with Thread Sanitizer on an ARM64 iPhone 17 simulator running iOS 26.5, with no sanitizer findings.

Closes #1180