### PR TITLE
fix(otlp-http): return upload failures from log exporter

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -62,6 +62,7 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
 
   public func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord],
                      explicitTimeout: TimeInterval? = nil) -> OpenTelemetrySdk.ExportResult {
+    var resultValue: ExportResult = .success
     var sendingLogRecords: [ReadableLogRecord] = []
     exporterLock.withLockVoid {
       pendingLogRecords.append(contentsOf: logRecords)
@@ -77,7 +78,9 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
 
     var request = createRequest(body: body, endpoint: endpoint)
     exporterMetrics?.addSeen(value: sendingLogRecords.count)
-    request.timeoutInterval = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let semaphore = DispatchSemaphore(value: 0)
+    request.timeoutInterval = timeout
     httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success:
@@ -90,10 +93,17 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter, @unch
           }
         }
         OpenTelemetry.instance.feedbackHandler?("\(error)")
+        resultValue = .failure
       }
+      semaphore.signal()
     }
 
-    return .success
+    let waitResult = semaphore.wait(timeout: .now() + timeout)
+    if waitResult == .timedOut {
+      exporterMetrics?.addFailed(value: sendingLogRecords.count)
+      return .failure
+    }
+    return resultValue
   }
 
   public func forceFlush(explicitTimeout: TimeInterval? = nil) -> ExportResult {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersFailurePathTests.swift
@@ -61,6 +61,43 @@ private struct TransientNetworkError: Error {}
 /// Fails the first request, then never invokes the completion handler. This gives
 /// `flush()` pending data to send and no response to wait on — the shape that made
 /// an unbounded `semaphore.wait()` block the calling thread forever.
+private final class HangingHTTPClient: HTTPClient {
+  private(set) var sentRequests: [URLRequest] = []
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sentRequests.append(request)
+  }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sentRequests.append(request)
+    return await withCheckedContinuation { (_: CheckedContinuation<HTTPURLResponse, Never>) in }
+  }
+}
+
+private final class DelayedFailureHTTPClient: HTTPClient {
+  private let delay: TimeInterval
+  private(set) var sentRequests: [URLRequest] = []
+
+  init(delay: TimeInterval) {
+    self.delay = delay
+  }
+
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sentRequests.append(request)
+    nonisolated(unsafe) let completion = completion
+    DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+      completion(.failure(TransientNetworkError()))
+    }
+  }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sentRequests.append(request)
+    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    throw TransientNetworkError()
+  }
+}
+
 private final class HangingAfterFirstFailureHTTPClient: HTTPClient {
   private var sendCount = 0
   func send(request: URLRequest,
@@ -116,10 +153,36 @@ final class OtlpHttpLogExporterCoverageTests: XCTestCase {
 
     let rec = sampleLogRecord()
     let result = exporter.export(logRecords: [rec])
-    XCTAssertEqual(result, .success)
+    XCTAssertEqual(result, .failure)
 
     // Failure path should put the record back into pendingLogRecords.
     XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testExportWaitsForDelayedFailureBeforeReturning() {
+    let delay: TimeInterval = 0.05
+    let client = DelayedFailureHTTPClient(delay: delay)
+    let exporter = OtlpHttpLogExporter(httpClient: client)
+
+    let start = Date()
+    let result = exporter.export(logRecords: [sampleLogRecord()])
+
+    XCTAssertEqual(result, .failure)
+    XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), delay)
+    XCTAssertEqual(exporter.pendingLogRecords.count, 1)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testExportTimesOutWhenResponseNeverArrives() {
+    let timeout: TimeInterval = 0.05
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpLogExporter(config: OtlpConfiguration(timeout: timeout),
+                                       httpClient: client)
+
+    let start = Date()
+    XCTAssertEqual(exporter.export(logRecords: [sampleLogRecord()]), .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
     XCTAssertEqual(client.sentRequests.count, 1)
   }
 


### PR DESCRIPTION
## Summary

- Make `OtlpHttpLogExporter.export` wait for the HTTP callback and return `.failure` when upload fails or times out.
- Add regression coverage for immediate failure, delayed failure, and no-response timeout paths.

This is the logs-only portion of #1146. The metric exporter change is deferred until the SIG concern about blocking metric processing is resolved.

## Motivation

Persistence deletes or keeps stored batches based on the exporter's synchronous return value. The HTTP log exporter was returning `.success` immediately after scheduling an async upload, so durable batches could be deleted before the upload outcome was known.

`OtlpHttpTraceExporter.export` already waits for the callback and returns the real result. This change aligns log export behavior with that existing contract.

## Notes

Timeout behavior remains trace-like: export returns `.failure` on timeout without adding new in-memory timeout requeue behavior.

<details>
<summary>Related work</summary>

- Supersedes the log portion of #1146
- Metrics follow-up blocked on SIG feedback about synchronous wait blocking metric collection threads
</details>

## Test plan

- [x] `swift build --build-tests`
- [x] `swift test --filter OtlpHttpLogExporterCoverageTests`