### PR TITLE
test: add thread sanitizer approval gate

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -200,6 +200,19 @@ jobs:
         run: swift build --build-tests
       - name: Run tests for Linux
         run: swift test
+  ThreadSanitizer:
+    needs: should-run
+    if: ${{ needs.should-run.outputs.should-run == 'true' }}
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+      with:
+        xcode-version: latest-stable
+    - name: Build and Test with Thread Sanitizer
+      run: swift test --sanitize=thread
   required-status-checks:
     needs: 
       - FormattingLint
@@ -210,6 +223,7 @@ jobs:
       - watchOS
       - visionOS
       - linux
+      - ThreadSanitizer
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -222,7 +236,8 @@ jobs:
           ${{ needs.tvOS.result }} == 'failure' || \
           ${{ needs.watchOS.result }} == 'failure' || \
           ${{ needs.visionOS.result }} == 'failure' || \
-          ${{ needs.linux.result }} == 'failure' ]]; then
+          ${{ needs.linux.result }} == 'failure' || \
+          ${{ needs.ThreadSanitizer.result }} == 'failure' ]]; then
             echo "One or more required jobs failed. Failing the workflow."
             exit 1
           else

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -213,6 +213,9 @@ jobs:
         xcode-version: latest-stable
     - name: Build and Test with Thread Sanitizer
       run: swift test --sanitize=thread
+      env:
+        # Enables the concurrency stress tests (skipped in the other jobs).
+        OTEL_CONCURRENCY_TESTS: "1"
   required-status-checks:
     needs: 
       - FormattingLint

--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,9 @@ test-without-building-watchos:
 .PHONY: test-without-building-visionos
 test-without-building-visionos:
 	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_VISIONOS) test-without-building | xcbeautify
+
+# Runs the whole suite under Thread Sanitizer with the concurrency stress
+# tests enabled (they are skipped in a normal `swift test`).
+.PHONY: test-tsan
+test-tsan:
+	OTEL_CONCURRENCY_TESTS=1 swift test --sanitize=thread

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,10 @@ let package = Package(
   targets: [
     .target(
       name: "SharedTestUtils",
-      dependencies: []
+      dependencies: [
+        .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
+        .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
+      ]
     ),
     .target(
       name: "OTelSwiftLog",
@@ -142,6 +145,7 @@ let package = Package(
     .testTarget(
       name: "OTelSwiftLogTests",
       dependencies: [
+        "SharedTestUtils",
         "OTelSwiftLog",
         .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
       ],
@@ -155,6 +159,7 @@ let package = Package(
     .testTarget(
       name: "OTelSwiftTracingTests",
       dependencies: [
+        "SharedTestUtils",
         "OTelSwiftTracing",
         "InMemoryExporter",
         .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
@@ -164,6 +169,7 @@ let package = Package(
     .testTarget(
       name: "SwiftMetricsShimTests",
       dependencies: [
+        "SharedTestUtils",
         "SwiftMetricsShim",
         .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
       ],
@@ -171,7 +177,10 @@ let package = Package(
     ),
     .testTarget(
       name: "PrometheusExporterTests",
-      dependencies: ["PrometheusExporter"],
+      dependencies: [
+        "PrometheusExporter",
+        "SharedTestUtils"
+      ],
       path: "Tests/ExportersTests/Prometheus"
     ),
     .testTarget(
@@ -185,12 +194,16 @@ let package = Package(
     ),
     .testTarget(
       name: "InMemoryExporterTests",
-      dependencies: ["InMemoryExporter"],
+      dependencies: [
+        "InMemoryExporter",
+        "SharedTestUtils"
+      ],
       path: "Tests/ExportersTests/InMemory"
     ),
     .testTarget(
       name: "PersistenceExporterTests",
       dependencies: [
+        "SharedTestUtils",
         "PersistenceExporter",
         "OpenTelemetryProtocolExporterHttp",
       ],
@@ -199,6 +212,7 @@ let package = Package(
     .testTarget(
       name: "ContribTests",
       dependencies: [
+        "SharedTestUtils",
         "BaggagePropagationProcessor",
         "InMemoryExporter"
       ]
@@ -206,6 +220,7 @@ let package = Package(
     .testTarget(
       name: "SessionTests",
       dependencies: [
+        "SharedTestUtils",
         "Sessions",
         .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
       ],
@@ -262,6 +277,7 @@ extension Package {
         .testTarget(
           name: "OpenTracingShimTests",
           dependencies: [
+            "SharedTestUtils",
             "OpenTracingShim",
             .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
           ],
@@ -300,7 +316,10 @@ extension Package {
         ),
         .testTarget(
           name: "JaegerExporterTests",
-          dependencies: ["JaegerExporter"],
+          dependencies: [
+            "JaegerExporter",
+            "SharedTestUtils"
+          ],
           path: "Tests/ExportersTests/Jaeger"
         ),
         .executableTarget(
@@ -364,7 +383,10 @@ extension Package {
         ),
         .testTarget(
           name: "ZipkinExporterTests",
-          dependencies: ["ZipkinExporter"],
+          dependencies: [
+            "ZipkinExporter",
+            "SharedTestUtils"
+          ],
           path: "Tests/ExportersTests/Zipkin"
         ),
         .executableTarget(
@@ -409,6 +431,7 @@ extension Package {
         .testTarget(
           name: "ResourceExtensionTests",
           dependencies: [
+            "SharedTestUtils",
             "ResourceExtension",
             .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
           ],

--- a/Package.swift
+++ b/Package.swift
@@ -206,6 +206,7 @@ let package = Package(
         "SharedTestUtils",
         "PersistenceExporter",
         "OpenTelemetryProtocolExporterHttp",
+        "InMemoryExporter",
       ],
       path: "Tests/ExportersTests/PersistenceExporter"
     ),

--- a/Sources/Exporters/OpenTelemetryProtocolCommon/common/ExporterMetrics.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolCommon/common/ExporterMetrics.swift
@@ -25,6 +25,10 @@ public class ExporterMetrics {
   private var successAttrs: [String: AttributeValue] = [:]
   private var failedAttrs: [String: AttributeValue] = [:]
 
+  // `LongCounter.add` is a `mutating` protocol requirement, so calling it on a
+  // stored property from the caller thread and the HTTP callback thread at
+  // once is an exclusivity violation. Serialize all counter access.
+  private let lock = NSLock()
   private var seen: LongCounter?
   private var exported: LongCounter?
 
@@ -55,14 +59,20 @@ public class ExporterMetrics {
   }
 
   public func addSeen(value: Int) {
+    lock.lock()
+    defer { lock.unlock() }
     seen?.add(value: value, attributes: seenAttrs)
   }
 
   public func addSuccess(value: Int) {
+    lock.lock()
+    defer { lock.unlock() }
     exported?.add(value: value, attributes: successAttrs)
   }
 
   public func addFailed(value: Int) {
+    lock.lock()
+    defer { lock.unlock() }
     exported?.add(value: value, attributes: failedAttrs)
   }
 

--- a/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceJsonExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolGrpc/trace/OtlpTraceJsonExporter.swift
@@ -33,7 +33,13 @@ public final class OtlpTraceJsonExporter: SpanExporter, @unchecked Sendable {
       let jsonData = try exportRequest.jsonUTF8Data()
       do {
         let span = try JSONDecoder().decode(OtlpSpan.self, from: jsonData)
-        lock.withLock { exportedSpans.append(span) }
+        // Re-check under the lock so an export racing `shutdown()` cannot
+        // append after the exporter has stopped.
+        lock.withLock {
+          if isRunning {
+            exportedSpans.append(span)
+          }
+        }
       } catch {
         OpenTelemetry.instance.feedbackHandler?("Decode Error: \(error)")
       }

--- a/Sources/Exporters/Persistence/Storage/FilesOrchestrator.swift
+++ b/Sources/Exporters/Persistence/Storage/FilesOrchestrator.swift
@@ -91,7 +91,7 @@ final class FilesOrchestrator: Sendable {
 
   func getReadableFile(excludingFilesNamed excludedFileNames: Set<String> = []) -> ReadableFile? {
     do {
-      let filesWithCreationDate = try directory.files()
+      let filesWithCreationDate = try orchestratedFiles()
         .map { (file: $0, creationDate: fileCreationDateFrom(fileName: $0.name)) }
         .compactMap { try deleteFileIfItsObsolete(file: $0.file, fileCreationDate: $0.creationDate) }
 
@@ -114,7 +114,7 @@ final class FilesOrchestrator: Sendable {
 
   func getAllFiles(excludingFilesNamed excludedFileNames: Set<String> = []) -> [ReadableFile]? {
     do {
-      return try directory.files()
+      return try orchestratedFiles()
         .filter { excludedFileNames.contains($0.name) == false }
     } catch {
       return nil
@@ -127,16 +127,32 @@ final class FilesOrchestrator: Sendable {
     } catch {}
   }
 
+  // MARK: - Directory listing
+
+  /// Files managed by this orchestrator are named by their creation timestamp.
+  /// `FileManager` writes new files through a transient safe-save file in the
+  /// same directory, which a concurrent listing can observe before it is
+  /// renamed; such files must not be treated as batches.
+  private func orchestratedFiles() throws -> [File] {
+    try directory.files().filter { UInt64($0.name) != nil }
+  }
+
   // MARK: - Directory size management
 
   /// Removes oldest files from the directory if it becomes too big.
   private func purgeFilesDirectoryIfNeeded() throws {
-    let filesSortedByCreationDate = try directory.files()
+    let filesSortedByCreationDate = try orchestratedFiles()
       .map { (file: $0, creationDate: fileCreationDateFrom(fileName: $0.name)) }
       .sorted { $0.creationDate < $1.creationDate }
 
-    var filesWithSizeSortedByCreationDate = try filesSortedByCreationDate
-      .map { try (file: $0.file, size: $0.file.size()) }
+    // The reader runs on another queue and may delete a file between the
+    // directory listing and the size lookup. Such a file is already gone, so
+    // skip it instead of failing the write that triggered the purge.
+    var filesWithSizeSortedByCreationDate = filesSortedByCreationDate
+      .compactMap { entry -> (file: File, size: UInt64)? in
+        guard let size = try? entry.file.size() else { return nil }
+        return (file: entry.file, size: size)
+      }
 
     let accumulatedFilesSize = filesWithSizeSortedByCreationDate.map(\.size).reduce(0, +)
 
@@ -146,7 +162,7 @@ final class FilesOrchestrator: Sendable {
 
       while sizeFreed < sizeToFree, !filesWithSizeSortedByCreationDate.isEmpty {
         let fileWithSize = filesWithSizeSortedByCreationDate.removeFirst()
-        try fileWithSize.file.delete()
+        try? fileWithSize.file.delete() // may already be gone, see above
         sizeFreed += fileWithSize.size
       }
     }

--- a/Sources/Importers/SwiftMetricsShim/MetricHandlers.swift
+++ b/Sources/Importers/SwiftMetricsShim/MetricHandlers.swift
@@ -32,67 +32,67 @@ final class SwiftCounterMetric: CounterHandler, SwiftMetric, @unchecked Sendable
 final class SwiftGaugeMetric: RecorderHandler, SwiftMetric, @unchecked Sendable {
   let metricName: String
   let metricType: MetricType = .gauge
-  var counter: DoubleGauge
+  let counter: Locked<DoubleGauge>
   let labels: [String: AttributeValue]
 
   required init(name: String,
                 labels: [String: String],
                 meter: any OpenTelemetryApi.Meter) {
     metricName = name
-    counter = meter.gaugeBuilder(name: name).build()
+    counter = .init(initialValue: meter.gaugeBuilder(name: name).build())
     self.labels = labels.mapValues { value in
       return AttributeValue.string(value)
     }
   }
 
   func record(_ value: Int64) {
-    counter.record(value: Double(value), attributes: labels)
+    counter.protectedValue.record(value: Double(value), attributes: labels)
   }
 
   func record(_ value: Double) {
-    counter.record(value: value, attributes: labels)
+    counter.protectedValue.record(value: value, attributes: labels)
   }
 }
 
 final class SwiftHistogramMetric: RecorderHandler, SwiftMetric, @unchecked Sendable {
   let metricName: String
   let metricType: MetricType = .histogram
-  var measure: DoubleHistogram
+  let measure: Locked<DoubleHistogram>
   let labels: [String: AttributeValue]
 
   required init(name: String, labels: [String: String], meter: any OpenTelemetryApi.Meter) {
     metricName = name
-    measure = meter.histogramBuilder(name: name).build()
+    measure = .init(initialValue: meter.histogramBuilder(name: name).build())
     self.labels = labels.mapValues { value in
       return AttributeValue.string(value)
     }
   }
 
   func record(_ value: Int64) {
-    measure.record(value: Double(value), attributes: labels)
+    measure.protectedValue.record(value: Double(value), attributes: labels)
   }
 
   func record(_ value: Double) {
-    measure.record(value: value, attributes: labels)
+    measure.protectedValue.record(value: value, attributes: labels)
   }
 }
 
 final class SwiftSummaryMetric: TimerHandler, SwiftMetric, @unchecked Sendable {
   let metricName: String
   let metricType: MetricType = .summary
-  var measure: DoubleCounter
+  let measure: Locked<DoubleCounter>
   let labels: [String: AttributeValue]
 
   required init(name: String, labels: [String: String], meter: any OpenTelemetryApi.Meter) {
     metricName = name
-    measure = meter.counterBuilder(name: name).ofDoubles().build()
+    measure = .init(initialValue: meter.counterBuilder(name: name).ofDoubles().build())
     self.labels = labels.mapValues { value in
       return AttributeValue.string(value)
     }
   }
 
   func recordNanoseconds(_ duration: Int64) {
-    measure.add(value: Double(duration), attributes: labels)
+    measure.protectedValue.add(value: Double(duration), attributes: labels)
   }
 }
 

--- a/Sources/SharedTestUtils/ConcurrencyTesting.swift
+++ b/Sources/SharedTestUtils/ConcurrencyTesting.swift
@@ -1,0 +1,217 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#elseif canImport(Musl)
+  import Musl
+#endif
+
+/// Gate and helpers for concurrency stress tests.
+///
+/// Stress tests hammer a shared object from many threads at once. On their own
+/// they rarely fail deterministically, so they are only worth running under
+/// Thread Sanitizer, which reports unsynchronized access even when the
+/// interleaving happened to be benign. They are enabled when either:
+///
+/// - the process was built with `--sanitize=thread` (detected at runtime), or
+/// - the `OTEL_CONCURRENCY_TESTS` environment variable is set to a truthy value.
+///
+/// Set `OTEL_CONCURRENCY_TESTS=0` to force them off even under TSan.
+public enum ConcurrencyTesting {
+  /// Environment variable that forces the stress tests on (`1`) or off (`0`).
+  public static let environmentVariable = "OTEL_CONCURRENCY_TESTS"
+
+  /// Whether the Thread Sanitizer runtime is linked into this process.
+  public static let isThreadSanitizerActive: Bool = {
+    guard let handle = dlopen(nil, RTLD_NOW) else { return false }
+    return dlsym(handle, "__tsan_init") != nil
+  }()
+
+  /// Whether stress tests should run in this process.
+  public static let isEnabled: Bool = {
+    if let raw = ProcessInfo.processInfo.environment[environmentVariable]?
+      .trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+      !raw.isEmpty {
+      return !["0", "false", "no", "off"].contains(raw)
+    }
+    return isThreadSanitizerActive
+  }()
+
+  /// Throws `XCTSkip` unless stress tests are enabled. Call at the top of
+  /// each stress test, or from `setUpWithError()`.
+  public static func skipUnlessEnabled() throws {
+    guard isEnabled else {
+      throw XCTSkip(
+        "Concurrency stress tests only run under Thread Sanitizer "
+          + "(swift test --sanitize=thread) or with \(environmentVariable)=1"
+      )
+    }
+  }
+
+  /// Default number of worker threads for `stress`.
+  public static let defaultThreads = 8
+
+  /// Default number of iterations per worker for `stress`. Kept modest because
+  /// TSan slows execution down considerably.
+  public static let defaultIterations = 200
+
+  /// Runs `body` on `threads` dedicated OS threads, `iterations` times each,
+  /// and blocks until all of them finish.
+  ///
+  /// Every worker waits on a shared start gate so they contend from the very
+  /// first iteration instead of trickling in as threads spin up. Dedicated
+  /// `Thread`s are used rather than `DispatchQueue.concurrentPerform` so the
+  /// worker count does not depend on the size of the GCD pool on the CI host.
+  public static func stress(threads: Int = defaultThreads,
+                            iterations: Int = defaultIterations,
+                            timeout: TimeInterval = 60,
+                            file: StaticString = #filePath,
+                            line: UInt = #line,
+                            _ body: @escaping @Sendable (_ thread: Int, _ iteration: Int) -> Void) {
+    precondition(threads > 0 && iterations > 0)
+
+    let startGate = DispatchSemaphore(value: 0)
+    let done = DispatchGroup()
+
+    for threadIndex in 0 ..< threads {
+      done.enter()
+      let worker = Thread {
+        startGate.wait()
+        for iteration in 0 ..< iterations {
+          body(threadIndex, iteration)
+        }
+        done.leave()
+      }
+      worker.name = "ConcurrencyTesting.stress.\(threadIndex)"
+      worker.start()
+    }
+
+    for _ in 0 ..< threads {
+      startGate.signal()
+    }
+
+    if done.wait(timeout: .now() + timeout) == .timedOut {
+      XCTFail("Stress workers did not finish within \(timeout)s", file: file, line: line)
+    }
+  }
+
+  /// Runs each operation once, on its own thread, all released together, and
+  /// blocks until every one has finished. Use this to mix distinct operations
+  /// against the same object, e.g. `export` racing `shutdown`.
+  public static func concurrently(timeout: TimeInterval = 60,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line,
+                                  _ operations: [@Sendable () -> Void]) {
+    guard !operations.isEmpty else { return }
+
+    let startGate = DispatchSemaphore(value: 0)
+    let done = DispatchGroup()
+
+    for (index, operation) in operations.enumerated() {
+      done.enter()
+      let worker = Thread {
+        startGate.wait()
+        operation()
+        done.leave()
+      }
+      worker.name = "ConcurrencyTesting.concurrently.\(index)"
+      worker.start()
+    }
+
+    for _ in operations {
+      startGate.signal()
+    }
+
+    if done.wait(timeout: .now() + timeout) == .timedOut {
+      XCTFail("Concurrent operations did not finish within \(timeout)s", file: file, line: line)
+    }
+  }
+
+  /// Async variant of `stress` for APIs that are `async`. Runs `tasks`
+  /// concurrent child tasks, each performing `iterations` calls to `body`.
+  public static func stress(tasks: Int = defaultThreads,
+                            iterations: Int = defaultIterations,
+                            _ body: @escaping @Sendable (_ task: Int, _ iteration: Int) async -> Void) async {
+    precondition(tasks > 0 && iterations > 0)
+
+    await withTaskGroup(of: Void.self) { group in
+      for taskIndex in 0 ..< tasks {
+        group.addTask {
+          for iteration in 0 ..< iterations {
+            await body(taskIndex, iteration)
+          }
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Helpers for stress bodies
+
+/// Wraps a value so it can be captured by a `@Sendable` stress closure.
+///
+/// Use it only for objects that are documented as safe to share across
+/// threads but are not annotated `Sendable`, or for objects whose thread
+/// safety is exactly what the test is probing. It does no synchronization.
+public struct UncheckedSendable<Value>: @unchecked Sendable {
+  public let value: Value
+
+  public init(_ value: Value) {
+    self.value = value
+  }
+}
+
+/// A lock-guarded append-only bag for collecting results from stress workers
+/// so assertions can run on the test thread afterwards.
+public final class ConcurrentCollector<Element>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var elements: [Element] = []
+
+  public init() {}
+
+  public func append(_ element: Element) {
+    lock.lock()
+    elements.append(element)
+    lock.unlock()
+  }
+
+  public var values: [Element] {
+    lock.lock()
+    defer { lock.unlock() }
+    return elements
+  }
+
+  public var count: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return elements.count
+  }
+}
+
+/// A lock-guarded counter for stress workers.
+public final class ConcurrentCounter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var count = 0
+
+  public init() {}
+
+  public func increment(by amount: Int = 1) {
+    lock.lock()
+    count += amount
+    lock.unlock()
+  }
+
+  public var value: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return count
+  }
+}

--- a/Sources/SharedTestUtils/HttpTestServer.swift
+++ b/Sources/SharedTestUtils/HttpTestServer.swift
@@ -20,9 +20,21 @@ import Musl
 /// A unified HTTP test server using POSIX sockets
 /// Combines functionality from both OTLP exporter tests and URLSession instrumentation tests
 public class HttpTestServer: @unchecked Sendable {
-    private var serverSocket: Int32 = -1
+    // `serverSocket` and `isRunning` are written by `start()`/`stop()` on the
+    // caller's thread and read by `acceptLoop()` on `serverQueue`, so guard
+    // them with a lock to keep Thread Sanitizer happy.
+    private let stateLock = NSLock()
+    private var _serverSocket: Int32 = -1
+    private var _isRunning = false
+    private var serverSocket: Int32 {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _serverSocket }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _serverSocket = newValue }
+    }
+    private var isRunning: Bool {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _isRunning }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _isRunning = newValue }
+    }
     public private(set) var serverPort: Int = 0
-    private var isRunning = false
     private var serverQueue: DispatchQueue?
     private let startSemaphore = DispatchSemaphore(value: 0)
 
@@ -130,20 +142,23 @@ public class HttpTestServer: @unchecked Sendable {
     }
 
     public func stop() {
-        isRunning = false
+        stateLock.lock()
+        _isRunning = false
+        let socketToClose = _serverSocket
+        _serverSocket = -1
+        stateLock.unlock()
 
         // Close server socket
-        if serverSocket >= 0 {
+        if socketToClose >= 0 {
             // Use platform-specific shutdown
             #if canImport(Darwin)
-            Darwin.shutdown(serverSocket, SHUT_RDWR)
+            Darwin.shutdown(socketToClose, SHUT_RDWR)
             #elseif canImport(Glibc)
-            Glibc.shutdown(serverSocket, Int32(SHUT_RDWR))
+            Glibc.shutdown(socketToClose, Int32(SHUT_RDWR))
             #elseif canImport(Musl)
-            Musl.shutdown(serverSocket, Int32(SHUT_RDWR))
+            Musl.shutdown(socketToClose, Int32(SHUT_RDWR))
             #endif
-            close(serverSocket)
-            serverSocket = -1
+            close(socketToClose)
         }
 
         // Clear received requests
@@ -222,8 +237,11 @@ public class HttpTestServer: @unchecked Sendable {
             var clientAddr = sockaddr_in()
             var clientAddrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
 
+            let listeningSocket = serverSocket
+            guard listeningSocket >= 0 else { break }
+
             let clientSocket = withUnsafeMutablePointer(to: &clientAddr) { ptr in
-                accept(serverSocket, UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: sockaddr.self), &clientAddrLen)
+                accept(listeningSocket, UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: sockaddr.self), &clientAddrLen)
             }
 
             if clientSocket < 0 {

--- a/Sources/SharedTestUtils/TelemetryFixtures.swift
+++ b/Sources/SharedTestUtils/TelemetryFixtures.swift
@@ -1,0 +1,67 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+
+/// Small, self-contained telemetry values for exporter tests that need
+/// something to export but do not care about its contents.
+public enum TelemetryFixtures {
+  public static func spanData(name: String = "span",
+                              kind: SpanKind = .internal,
+                              resource: Resource = Resource(),
+                              attributes: [String: AttributeValue] = [:],
+                              status: Status = .ok) -> SpanData {
+    let start = Date()
+    var data = SpanData(traceId: TraceId.random(),
+                    spanId: SpanId.random(),
+                    parentSpanId: nil,
+                    resource: resource,
+                    name: name,
+                    kind: kind,
+                    startTime: start,
+                    attributes: attributes,
+                    events: [SpanData.Event(name: "event", timestamp: start)],
+                    status: status,
+                    endTime: start.addingTimeInterval(0.001))
+    // Exporters derive dropped counts from these totals; keep them consistent.
+    data.settingTotalRecordedEvents(1)
+    data.settingTotalAttributeCount(attributes.count)
+    return data
+  }
+
+  public static func logRecord(body: String = "hello",
+                               attributes: [String: AttributeValue] = [:]) -> ReadableLogRecord {
+    let context = SpanContext.create(traceId: TraceId.random(),
+                                     spanId: SpanId.random(),
+                                     traceFlags: TraceFlags(),
+                                     traceState: TraceState())
+    return ReadableLogRecord(resource: Resource(),
+                             instrumentationScopeInfo: InstrumentationScopeInfo(name: "fixture"),
+                             timestamp: Date(),
+                             observedTimestamp: Date(),
+                             spanContext: context,
+                             severity: .info,
+                             body: .string(body),
+                             attributes: attributes)
+  }
+
+  public static func metricData(name: String = "metric", value: Double = 1) -> MetricData {
+    let point = DoublePointData(startEpochNanos: 0,
+                                endEpochNanos: 1,
+                                attributes: [:],
+                                exemplars: [],
+                                value: value)
+    return MetricData(resource: Resource(),
+                      instrumentationScopeInfo: InstrumentationScopeInfo(name: "fixture"),
+                      name: name,
+                      description: "fixture metric",
+                      unit: "",
+                      type: .DoubleSum,
+                      isMonotonic: true,
+                      data: MetricData.Data(aggregationTemporality: .cumulative, points: [point]))
+  }
+}

--- a/Sources/SharedTestUtils/ThreadLocalContextManager.swift
+++ b/Sources/SharedTestUtils/ThreadLocalContextManager.swift
@@ -1,0 +1,40 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import OpenTelemetryApi
+
+/// A `ContextManager` that keeps the active span and baggage in
+/// `Thread.current.threadDictionary`.
+///
+/// The SDK's default managers are built around `os_activity` or task-locals,
+/// which is the right behaviour in production but makes stress tests that
+/// install per-thread context from plain `Thread`s nondeterministic. Swap
+/// this in with `OpenTelemetry.withContextManager(_:_:)` for tests that only
+/// need "each worker thread sees its own context".
+public final class ThreadLocalContextManager: ImperativeContextManager, @unchecked Sendable {
+  private static let prefix = "io.opentelemetry.ThreadLocalContextManager."
+
+  public init() {}
+
+  private func storageKey(_ key: OpenTelemetryContextKeys) -> String {
+    Self.prefix + key.rawValue
+  }
+
+  public func getCurrentContextValue(forKey key: OpenTelemetryContextKeys) -> AnyObject? {
+    Thread.current.threadDictionary[storageKey(key)] as AnyObject?
+  }
+
+  public func setCurrentContextValue(forKey key: OpenTelemetryContextKeys, value: AnyObject) {
+    Thread.current.threadDictionary[storageKey(key)] = value
+  }
+
+  public func removeContextValue(forKey key: OpenTelemetryContextKeys, value: AnyObject) {
+    let dictionary = Thread.current.threadDictionary
+    if let current = dictionary[storageKey(key)] as AnyObject?, current === value {
+      dictionary.removeObject(forKey: storageKey(key))
+    }
+  }
+}

--- a/Tests/BridgesTests/OTelSwiftLog/OTelSwiftLogConcurrencyTests.swift
+++ b/Tests/BridgesTests/OTelSwiftLog/OTelSwiftLogConcurrencyTests.swift
@@ -1,0 +1,117 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// LoggerProviderSdk's witness tables are not linked into OTelSwiftLogTests on
+// watchOS (see LogHandlerCoverageTests), so keep these off watchOS too.
+#if !os(watchOS)
+
+  import Logging
+  @testable import OpenTelemetryApi
+  import OpenTelemetrySdk
+  @testable import OTelSwiftLog
+  import SharedTestUtils
+  import XCTest
+
+  /// Stress tests for the swift-log bridge. They only run under Thread
+  /// Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+  final class OTelSwiftLogConcurrencyTests: XCTestCase {
+    private final class CountingLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
+      private let lock = NSLock()
+      private var _records: [ReadableLogRecord] = []
+
+      var records: [ReadableLogRecord] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _records
+      }
+
+      func onEmit(logRecord: ReadableLogRecord) {
+        lock.lock()
+        _records.append(logRecord)
+        lock.unlock()
+      }
+
+      func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult { .success }
+      func shutdown(explicitTimeout: TimeInterval?) -> ExportResult { .success }
+    }
+
+    private var processor: CountingLogRecordProcessor!
+    private var handler: OTelLogHandler!
+
+    override func setUpWithError() throws {
+      try ConcurrencyTesting.skipUnlessEnabled()
+      processor = CountingLogRecordProcessor()
+      let provider = LoggerProviderBuilder()
+        .with(processors: [processor])
+        .build()
+      handler = OTelLogHandler(loggerProvider: provider, attributes: ["fixture": .string("stress")])
+    }
+
+    override func tearDown() {
+      processor = nil
+      handler = nil
+    }
+
+    func testLogThroughSharedLoggerFromManyThreads() {
+      let handler = self.handler!
+      let logger = Logger(label: "stress") { _ in handler }
+      let threads = ConcurrencyTesting.defaultThreads
+      let iterations = ConcurrencyTesting.defaultIterations
+
+      ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+        logger.info("message \(iteration)", metadata: ["thread": "\(thread)", "iteration": .stringConvertible(iteration)])
+      }
+
+      let records = processor.records
+      XCTAssertEqual(records.count, threads * iterations)
+      XCTAssertTrue(records.allSatisfy { $0.attributes["thread"] != nil && $0.attributes["iteration"] != nil })
+    }
+
+    func testPerThreadLoggerCopiesWithOwnMetadata() {
+      let handler = self.handler!
+      let base = Logger(label: "stress-copies") { _ in handler }
+      let threads = ConcurrencyTesting.defaultThreads
+      let iterations = ConcurrencyTesting.defaultIterations
+
+      ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+        var logger = base
+        logger[metadataKey: "thread"] = "\(thread)"
+        logger.logLevel = .debug
+        logger.debug("copy \(iteration)")
+        logger.error("copy error \(iteration)", metadata: ["iteration": "\(iteration)"])
+      }
+
+      let records = processor.records
+      XCTAssertEqual(records.count, 2 * threads * iterations)
+      let threadsSeen = Set(records.compactMap { record -> String? in
+        if case let .string(value)? = record.attributes["thread"] { return value }
+        return nil
+      })
+      XCTAssertEqual(threadsSeen.count, threads)
+    }
+
+    func testLoggingWhileActiveSpanChangesOnEachThread() {
+      let handler = self.handler!
+      let logger = Logger(label: "stress-spans") { _ in handler }
+      let tracer = UncheckedSendable(TracerProviderSdk().get(instrumentationName: "stress"))
+      let threads = ConcurrencyTesting.defaultThreads
+      let iterations = 50
+
+      OpenTelemetry.withContextManager(ThreadLocalContextManager()) {
+        ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, _ in
+          let span = tracer.value.spanBuilder(spanName: "thread-\(thread)").startSpan()
+          OpenTelemetry.instance.contextProvider.setActiveSpan(span)
+          logger.info("inside span")
+          OpenTelemetry.instance.contextProvider.removeContextForSpan(span)
+          span.end()
+        }
+      }
+
+      let records = processor.records
+      XCTAssertEqual(records.count, threads * iterations)
+    }
+  }
+
+#endif

--- a/Tests/BridgesTests/OTelSwiftTracing/OTelSwiftTracingConcurrencyTests.swift
+++ b/Tests/BridgesTests/OTelSwiftTracing/OTelSwiftTracingConcurrencyTests.swift
@@ -1,0 +1,135 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import InMemoryExporter
+import OpenTelemetryApi
+import OpenTelemetrySdk
+@testable import OTelSwiftTracing
+import SharedTestUtils
+import Tracing
+import XCTest
+
+/// Stress tests for the swift-distributed-tracing bridge. They only run under
+/// Thread Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class OTelSwiftTracingConcurrencyTests: XCTestCase {
+  private var exporter: InMemoryExporter!
+  private var processor: SimpleSpanProcessor!
+  private var tracer: OTelTracer!
+
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+    exporter = InMemoryExporter()
+    processor = SimpleSpanProcessor(spanExporter: exporter)
+    let provider = TracerProviderSdk(spanProcessors: [processor])
+    tracer = OTelTracer(tracerProvider: provider, propagator: W3CTraceContextPropagator())
+  }
+
+  override func tearDown() {
+    exporter?.shutdown()
+    exporter = nil
+    processor = nil
+    tracer = nil
+  }
+
+  func testStartAndEndSpansFromManyThreads() {
+    let tracer = self.tracer!
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      tracer.withSpan("span-\(thread)") { span in
+        span.attributes["thread"] = thread
+        span.attributes["iteration"] = iteration
+        span.addEvent(SpanEvent(name: "event"))
+        span.setStatus(SpanStatus(code: .ok))
+        _ = span.isRecording
+      }
+    }
+
+    _ = processor.forceFlush()
+    XCTAssertEqual(exporter.getFinishedSpanItems().count, threads * iterations)
+  }
+
+  func testMutateSharedSpanFromManyThreads() {
+    let span = tracer.startSpan("shared")
+    let threads = ConcurrencyTesting.defaultThreads
+
+    ConcurrencyTesting.stress(threads: threads) { thread, iteration in
+      span.attributes["thread-\(thread)"] = iteration
+      span.operationName = "renamed-\(thread)"
+      span.setStatus(SpanStatus(code: iteration.isMultiple(of: 2) ? .ok : .error))
+      span.addEvent(SpanEvent(name: "event-\(thread)"))
+      span.recordError(StressError.boom, attributes: ["thread": .int64(Int64(thread))])
+      _ = span.attributes
+      _ = span.operationName
+      _ = span.isRecording
+    }
+
+    span.end()
+    _ = processor.forceFlush()
+    let finished = exporter.getFinishedSpanItems()
+    XCTAssertEqual(finished.count, 1)
+    XCTAssertEqual(finished.first?.attributes.count, threads)
+  }
+
+  func testEndRacesAttributeWritesAndEvents() {
+    let span = tracer.startSpan("racing-end")
+
+    ConcurrencyTesting.concurrently([
+      { span.end() },
+      { span.attributes = ["after": "end"] },
+      { span.addEvent(SpanEvent(name: "late")) },
+      { span.setStatus(SpanStatus(code: .error)) },
+      { span.operationName = "renamed" },
+      { _ = span.attributes }
+    ])
+
+    _ = processor.forceFlush()
+    XCTAssertEqual(exporter.getFinishedSpanItems().count, 1)
+  }
+
+  func testInjectAndExtractFromManyThreads() {
+    let tracer = self.tracer!
+    let parent = tracer.startSpan("parent")
+    defer { parent.end() }
+    let parentContext = parent.context
+    let expectedTraceId = parentContext.otelSpanContext?.traceId
+    let mismatches = ConcurrentCounter()
+
+    ConcurrencyTesting.stress { _, _ in
+      var carrier: [String: String] = [:]
+      tracer.inject(parentContext, into: &carrier, using: DictionaryInjector())
+
+      var extracted = ServiceContext.topLevel
+      tracer.extract(carrier, into: &extracted, using: DictionaryExtractor())
+      if extracted.otelSpanContext?.traceId != expectedTraceId {
+        mismatches.increment()
+      }
+
+      // Children created from the extracted context on many threads.
+      tracer.withSpan("child", context: extracted) { child in
+        child.attributes["child"] = true
+      }
+    }
+
+    XCTAssertEqual(mismatches.value, 0)
+  }
+}
+
+private enum StressError: Error {
+  case boom
+}
+
+private struct DictionaryInjector: Injector {
+  func inject(_ value: String, forKey key: String, into carrier: inout [String: String]) {
+    carrier[key] = value
+  }
+}
+
+private struct DictionaryExtractor: Extractor {
+  func extract(key: String, from carrier: [String: String]) -> String? {
+    carrier[key]
+  }
+}

--- a/Tests/ContribTests/Processors/BaggagePropagationProcessorConcurrencyTests.swift
+++ b/Tests/ContribTests/Processors/BaggagePropagationProcessorConcurrencyTests.swift
@@ -1,0 +1,85 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import BaggagePropagationProcessor
+import InMemoryExporter
+@testable import OpenTelemetryApi
+import OpenTelemetrySdk
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for the baggage propagation span processor. They only run
+/// under Thread Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class BaggagePropagationProcessorConcurrencyTests: XCTestCase {
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+  }
+
+  private func makeBaggage(_ entries: [String: String]) throws -> Baggage {
+    var builder = DefaultBaggageManager.instance.baggageBuilder()
+    for (key, value) in entries {
+      let entryKey = try XCTUnwrap(EntryKey(name: key))
+      let entryValue = try XCTUnwrap(EntryValue(string: value))
+      builder = builder.put(key: entryKey, value: entryValue, metadata: nil)
+    }
+    return builder.build()
+  }
+
+  func testSpansStartedFromManyThreadsReceiveFilteredBaggage() throws {
+    let baggage = try makeBaggage(["keepme": "kept", "dropme": "dropped"])
+    var processor = BaggagePropagationProcessor(filter: { $0.key.name == "keepme" })
+    processor.activeBaggage = { baggage }
+    let exporter = InMemoryExporter()
+    let provider = TracerProviderBuilder()
+      .add(spanProcessor: processor)
+      .add(spanProcessor: SimpleSpanProcessor(spanExporter: exporter))
+      .build()
+    let tracer = UncheckedSendable(provider.get(instrumentationName: "stress"))
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      let span = tracer.value.spanBuilder(spanName: "span-\(thread)-\(iteration)").startSpan()
+      span.setAttribute(key: "thread", value: thread)
+      span.end()
+    }
+
+    let spans = exporter.getFinishedSpanItems()
+    XCTAssertEqual(spans.count, threads * iterations)
+    XCTAssertTrue(spans.allSatisfy { $0.attributes["keepme"] == .string("kept") })
+    XCTAssertTrue(spans.allSatisfy { $0.attributes["dropme"] == nil })
+  }
+
+  func testProcessorReadsPerThreadActiveBaggageThroughContextProvider() throws {
+    // Uses the processor's default `activeBaggage`, which reads the global
+    // context provider, so every thread installs its own baggage first.
+    let processor = BaggagePropagationProcessor(filter: { _ in true })
+    let exporter = InMemoryExporter()
+    let provider = TracerProviderBuilder()
+      .add(spanProcessor: processor)
+      .add(spanProcessor: SimpleSpanProcessor(spanExporter: exporter))
+      .build()
+    let tracer = UncheckedSendable(provider.get(instrumentationName: "stress"))
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+    let baggages = try UncheckedSendable((0 ..< threads).map { try makeBaggage(["thread": "\($0)"]) })
+
+    OpenTelemetry.withContextManager(ThreadLocalContextManager()) {
+      ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, _ in
+        let baggage = baggages.value[thread]
+        OpenTelemetry.instance.contextProvider.setActiveBaggage(baggage)
+        let span = tracer.value.spanBuilder(spanName: "span-\(thread)").startSpan()
+        span.setAttribute(key: "expected", value: "\(thread)")
+        span.end()
+        OpenTelemetry.instance.contextProvider.removeContextForBaggage(baggage)
+      }
+    }
+
+    let spans = exporter.getFinishedSpanItems()
+    XCTAssertEqual(spans.count, threads * iterations)
+    let mismatched = spans.filter { $0.attributes["thread"] != $0.attributes["expected"] }
+    XCTAssertTrue(mismatched.isEmpty, "\(mismatched.count) spans carried another thread's baggage")
+  }
+}

--- a/Tests/ContribTests/Processors/BaggagePropagationProcessorConcurrencyTests.swift
+++ b/Tests/ContribTests/Processors/BaggagePropagationProcessorConcurrencyTests.swift
@@ -46,6 +46,8 @@ final class BaggagePropagationProcessorConcurrencyTests: XCTestCase {
       span.end()
     }
 
+    // SimpleSpanProcessor exports asynchronously.
+    provider.forceFlush()
     let spans = exporter.getFinishedSpanItems()
     XCTAssertEqual(spans.count, threads * iterations)
     XCTAssertTrue(spans.allSatisfy { $0.attributes["keepme"] == .string("kept") })
@@ -77,6 +79,7 @@ final class BaggagePropagationProcessorConcurrencyTests: XCTestCase {
       }
     }
 
+    provider.forceFlush()
     let spans = exporter.getFinishedSpanItems()
     XCTAssertEqual(spans.count, threads * iterations)
     let mismatched = spans.filter { $0.attributes["thread"] != $0.attributes["expected"] }

--- a/Tests/ExportersTests/InMemory/InMemoryExporterConcurrencyTests.swift
+++ b/Tests/ExportersTests/InMemory/InMemoryExporterConcurrencyTests.swift
@@ -1,0 +1,75 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import InMemoryExporter
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for the in-memory span exporter. They only run under Thread
+/// Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class InMemoryExporterConcurrencyTests: XCTestCase {
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+  }
+
+  func testExportAndReadFromManyThreads() {
+    let exporter = InMemoryExporter()
+    let successes = ConcurrentCounter()
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, _ in
+      if thread == 0 {
+        _ = exporter.getFinishedSpanItems()
+        _ = exporter.flush()
+      } else if exporter.export(spans: [TelemetryFixtures.spanData(name: "thread-\(thread)")]) == .success {
+        successes.increment()
+      }
+    }
+
+    XCTAssertEqual(successes.value, (threads - 1) * iterations)
+    XCTAssertEqual(exporter.getFinishedSpanItems().count, successes.value)
+  }
+
+  func testResetRacesExport() {
+    let exporter = InMemoryExporter()
+
+    ConcurrencyTesting.stress { thread, _ in
+      if thread.isMultiple(of: 4) {
+        exporter.reset()
+      } else {
+        _ = exporter.export(spans: [TelemetryFixtures.spanData()])
+        _ = exporter.getFinishedSpanItems()
+      }
+    }
+
+    exporter.reset()
+    XCTAssertTrue(exporter.getFinishedSpanItems().isEmpty)
+  }
+
+  func testShutdownRacesExport() {
+    let exporter = InMemoryExporter()
+    let failuresAfterShutdown = ConcurrentCounter()
+
+    ConcurrencyTesting.concurrently([
+      { exporter.shutdown() },
+      { _ = exporter.export(spans: [TelemetryFixtures.spanData()]) },
+      { _ = exporter.export(spans: [TelemetryFixtures.spanData()]) },
+      { _ = exporter.flush() },
+      { _ = exporter.getFinishedSpanItems() }
+    ])
+
+    ConcurrencyTesting.stress(threads: 4, iterations: 20) { _, _ in
+      if exporter.export(spans: [TelemetryFixtures.spanData()]) == .failure {
+        failuresAfterShutdown.increment()
+      }
+    }
+
+    XCTAssertEqual(failuresAfterShutdown.value, 80)
+    XCTAssertTrue(exporter.getFinishedSpanItems().isEmpty)
+  }
+}

--- a/Tests/ExportersTests/Jaeger/JaegerExporterConcurrencyTests.swift
+++ b/Tests/ExportersTests/Jaeger/JaegerExporterConcurrencyTests.swift
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if !os(watchOS) && !os(visionOS)
+
+  import Foundation
+  @testable import JaegerExporter
+  import OpenTelemetryApi
+  import OpenTelemetrySdk
+  import SharedTestUtils
+  import XCTest
+
+  /// Stress tests for the Jaeger exporter. Batches go out over UDP to the
+  /// loopback address, which needs no listener. They only run under Thread
+  /// Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+  final class JaegerExporterConcurrencyTests: XCTestCase {
+    override func setUpWithError() throws {
+      try ConcurrencyTesting.skipUnlessEnabled()
+    }
+
+    func testAdapterConvertsSpansFromManyThreads() {
+      let converted = ConcurrentCounter()
+
+      ConcurrencyTesting.stress { thread, iteration in
+        let spans = [
+          TelemetryFixtures.spanData(name: "span-\(thread)-\(iteration)", kind: .client, attributes: ["thread": .int(thread)]),
+          TelemetryFixtures.spanData(name: "error", status: .error(description: "boom"))
+        ]
+        converted.increment(by: Adapter.toJaeger(spans: spans).count)
+      }
+
+      XCTAssertEqual(converted.value, 2 * ConcurrencyTesting.defaultThreads * ConcurrencyTesting.defaultIterations)
+    }
+
+    func testExportsThroughSharedExporterFromManyThreads() {
+      let exporter = JaegerSpanExporter(serviceName: "stress", collectorAddress: "127.0.0.1")
+      let attempts = ConcurrentCounter()
+
+      ConcurrencyTesting.stress(threads: ConcurrencyTesting.defaultThreads, iterations: 25) { thread, iteration in
+        _ = exporter.export(spans: [TelemetryFixtures.spanData(name: "span-\(thread)-\(iteration)")])
+        _ = exporter.flush()
+        attempts.increment()
+      }
+
+      exporter.shutdown()
+      XCTAssertEqual(attempts.value, ConcurrencyTesting.defaultThreads * 25)
+    }
+  }
+
+#endif

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersConcurrencyTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpExportersConcurrencyTests.swift
@@ -1,0 +1,271 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+import OpenTelemetryApi
+import OpenTelemetryProtocolExporterCommon
+@testable import OpenTelemetryProtocolExporterHttp
+@testable import OpenTelemetrySdk
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for the OTLP/HTTP exporters. The HTTP client is a stub that
+/// completes on a background queue, like `URLSession` does, so the exporters'
+/// completion handlers run on a different thread than the caller. They only
+/// run under Thread Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class OtlpHttpExportersConcurrencyTests: XCTestCase {
+  /// Completes every request asynchronously on a concurrent queue.
+  private final class BackgroundStubHTTPClient: HTTPClient, @unchecked Sendable {
+    enum Mode {
+      case succeed
+      case fail
+      /// Fails every other request so the exporters exercise their requeue paths.
+      case alternate
+    }
+
+    private let mode: Mode
+    private let lock = NSLock()
+    private var sent = 0
+    private var completed = 0
+    private let queue = DispatchQueue(label: "BackgroundStubHTTPClient", attributes: .concurrent)
+
+    init(mode: Mode) {
+      self.mode = mode
+    }
+
+    var sentCount: Int {
+      lock.lock()
+      defer { lock.unlock() }
+      return sent
+    }
+
+    private func nextOutcome(for request: URLRequest) -> Result<HTTPURLResponse, Error> {
+      lock.lock()
+      sent += 1
+      let sequence = sent
+      lock.unlock()
+
+      let shouldFail: Bool
+      switch mode {
+      case .succeed: shouldFail = false
+      case .fail: shouldFail = true
+      case .alternate: shouldFail = sequence.isMultiple(of: 2)
+      }
+      if shouldFail {
+        return .failure(StubError.transient)
+      }
+      let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!
+      return .success(response)
+    }
+
+    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+      let outcome = nextOutcome(for: request)
+      nonisolated(unsafe) let completion = completion
+      queue.async {
+        completion(outcome)
+        self.markCompleted()
+      }
+    }
+
+    private func markCompleted() {
+      lock.lock()
+      completed += 1
+      lock.unlock()
+    }
+
+    func send(request: URLRequest) async throws -> HTTPURLResponse {
+      let outcome = nextOutcome(for: request)
+      markCompleted()
+      return try outcome.get()
+    }
+
+    /// Waits until every completion handler has run, so a test can inspect
+    /// exporter state without racing a late callback.
+    func waitForAllCompletions(timeout: TimeInterval = 10) -> Bool {
+      let deadline = Date(timeIntervalSinceNow: timeout)
+      while Date() < deadline {
+        lock.lock()
+        let done = completed == sent
+        lock.unlock()
+        if done { return true }
+        Thread.sleep(forTimeInterval: 0.01)
+      }
+      return false
+    }
+  }
+
+  private enum StubError: Error {
+    case transient
+  }
+
+  private let endpoint = URL(string: "http://localhost:4318/v1/stress")!
+
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+  }
+
+  // MARK: - Traces
+
+  func testSpanExportsFromManyThreads() {
+    let client = BackgroundStubHTTPClient(mode: .succeed)
+    let exporter = OtlpHttpTraceExporter(endpoint: endpoint, config: OtlpConfiguration(), httpClient: client, envVarHeaders: nil)
+    let successes = ConcurrentCounter()
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      let spans = [TelemetryFixtures.spanData(name: "span-\(thread)-\(iteration)")]
+      if exporter.export(spans: spans) == .success {
+        successes.increment()
+      }
+    }
+
+    XCTAssertTrue(client.waitForAllCompletions())
+    XCTAssertEqual(successes.value, threads * iterations)
+    XCTAssertEqual(client.sentCount, threads * iterations)
+    XCTAssertTrue(exporter.pendingSpans.isEmpty)
+  }
+
+  func testSpanExportRacesFlushWithRequeuedFailures() {
+    let client = BackgroundStubHTTPClient(mode: .alternate)
+    let exporter = OtlpHttpTraceExporter(endpoint: endpoint, config: OtlpConfiguration(), httpClient: client, envVarHeaders: nil)
+
+    ConcurrencyTesting.stress(threads: ConcurrencyTesting.defaultThreads, iterations: 50) { thread, _ in
+      switch thread {
+      case 0:
+        _ = exporter.flush()
+      case 1:
+        exporter.shutdown()
+      default:
+        _ = exporter.export(spans: [TelemetryFixtures.spanData()])
+      }
+    }
+
+    XCTAssertTrue(client.waitForAllCompletions())
+    _ = exporter.flush()
+    XCTAssertTrue(client.waitForAllCompletions())
+  }
+
+  // MARK: - Logs
+
+  func testLogExportsFromManyThreadsRaceFlush() {
+    let client = BackgroundStubHTTPClient(mode: .alternate)
+    let exporter = OtlpHttpLogExporter(endpoint: endpoint, config: OtlpConfiguration(), httpClient: client, envVarHeaders: nil)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      if thread == 0 {
+        _ = exporter.forceFlush()
+      } else {
+        _ = exporter.export(logRecords: [TelemetryFixtures.logRecord(body: "log-\(thread)-\(iteration)")])
+      }
+    }
+
+    XCTAssertTrue(client.waitForAllCompletions())
+    XCTAssertGreaterThanOrEqual(client.sentCount, (threads - 1) * iterations)
+  }
+
+  // MARK: - Metrics
+
+  func testMetricExportsFromManyThreadsRaceFlush() {
+    let client = BackgroundStubHTTPClient(mode: .alternate)
+    let exporter = OtlpHttpMetricExporter(endpoint: endpoint, config: OtlpConfiguration(), httpClient: client, envVarHeaders: nil)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      switch thread {
+      case 0:
+        _ = exporter.flush()
+      case 1:
+        _ = exporter.getAggregationTemporality(for: .counter)
+        _ = exporter.getDefaultAggregation(for: .histogram)
+      default:
+        _ = exporter.export(metrics: [TelemetryFixtures.metricData(name: "metric_\(thread)_\(iteration)")])
+      }
+    }
+
+    XCTAssertTrue(client.waitForAllCompletions())
+    XCTAssertGreaterThanOrEqual(client.sentCount, (threads - 2) * iterations)
+  }
+
+  // MARK: - Shared configuration
+
+  func testHeadersProviderIsReadFromManyExportThreadsWhileUpdated() {
+    let client = BackgroundStubHTTPClient(mode: .succeed)
+    let provider = MutableHeadersProvider([("Authorization", "Bearer initial")])
+    let config = OtlpConfiguration(headersProvider: { provider.currentHeaders() })
+    let exporter = OtlpHttpTraceExporter(endpoint: endpoint, config: config, httpClient: client, envVarHeaders: nil)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      if thread == 0 {
+        provider.update([("Authorization", "Bearer rotated-\(iteration)")])
+      } else {
+        _ = exporter.export(spans: [TelemetryFixtures.spanData()])
+      }
+    }
+
+    XCTAssertTrue(client.waitForAllCompletions())
+    XCTAssertEqual(provider.callCount, (threads - 1) * iterations)
+  }
+
+  func testExporterMetricsAreRecordedFromCallerAndCallbackThreads() throws {
+    let client = BackgroundStubHTTPClient(mode: .alternate)
+    let collector = CollectingMetricExporter()
+    let reader = PeriodicMetricReaderSdk(exporter: collector, exportInterval: 3600)
+    let meterProvider = MeterProviderSdk.builder()
+      .registerView(selector: InstrumentSelector.builder().setInstrument(name: ".*").build(),
+                    view: View.builder().build())
+      .registerMetricReader(reader: reader)
+      .build()
+    defer { _ = reader.shutdown() }
+    let exporter = OtlpHttpTraceExporter(endpoint: endpoint,
+                                         config: OtlpConfiguration(),
+                                         meterProvider: meterProvider,
+                                         httpClient: client,
+                                         envVarHeaders: nil)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { _, _ in
+      _ = exporter.export(spans: [TelemetryFixtures.spanData(), TelemetryFixtures.spanData()])
+    }
+
+    XCTAssertTrue(client.waitForAllCompletions())
+    _ = reader.forceFlush()
+    let seen = try XCTUnwrap(collector.exported.first { $0.name == "otlp.exporter.seen" })
+    let seenPoint = try XCTUnwrap(seen.data.points.last as? LongPointData)
+    // Failed sends are requeued and counted again on the next attempt.
+    XCTAssertGreaterThanOrEqual(seenPoint.value, 2 * threads * iterations)
+  }
+
+  private final class CollectingMetricExporter: MetricExporter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var latest: [MetricData] = []
+
+    var exported: [MetricData] {
+      lock.lock()
+      defer { lock.unlock() }
+      return latest
+    }
+
+    func export(metrics: [MetricData]) -> ExportResult {
+      lock.lock()
+      latest = metrics
+      lock.unlock()
+      return .success
+    }
+
+    func flush() -> ExportResult { .success }
+    func shutdown() -> ExportResult { .success }
+    func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality { .cumulative }
+  }
+}

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceJsonExporterConcurrencyTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpTraceJsonExporterConcurrencyTests.swift
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import OpenTelemetryApi
+@testable import OpenTelemetryProtocolExporterGrpc
+import OpenTelemetrySdk
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for the JSON trace exporter. They only run under Thread
+/// Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class OtlpTraceJsonExporterConcurrencyTests: XCTestCase {
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+  }
+
+  func testExportAndReadFromManyThreads() {
+    let exporter = OtlpTraceJsonExporter()
+    let successes = ConcurrentCounter()
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, _ in
+      if thread == 0 {
+        _ = exporter.getExportedSpans()
+        _ = exporter.flush()
+      } else if exporter.export(spans: [TelemetryFixtures.spanData(name: "thread-\(thread)")]) == .success {
+        successes.increment()
+      }
+    }
+
+    XCTAssertEqual(successes.value, (threads - 1) * iterations)
+    XCTAssertEqual(exporter.getExportedSpans().count, successes.value)
+  }
+
+  func testResetAndShutdownRaceExport() {
+    let exporter = OtlpTraceJsonExporter()
+
+    ConcurrencyTesting.stress(threads: 8, iterations: 30) { thread, iteration in
+      switch thread {
+      case 0:
+        exporter.reset()
+      case 1 where iteration == 29:
+        exporter.shutdown()
+      default:
+        _ = exporter.export(spans: [TelemetryFixtures.spanData()])
+        _ = exporter.getExportedSpans()
+      }
+    }
+
+    XCTAssertEqual(exporter.flush(), .failure)
+    XCTAssertEqual(exporter.export(spans: [TelemetryFixtures.spanData()]), .failure)
+    XCTAssertTrue(exporter.getExportedSpans().isEmpty)
+  }
+}

--- a/Tests/ExportersTests/PersistenceExporter/PersistenceExporterConcurrencyTests.swift
+++ b/Tests/ExportersTests/PersistenceExporter/PersistenceExporterConcurrencyTests.swift
@@ -1,0 +1,169 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import InMemoryExporter
+import OpenTelemetryApi
+import OpenTelemetrySdk
+@testable import PersistenceExporter
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for the persistence exporter and its file storage. They only
+/// run under Thread Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class PersistenceExporterConcurrencyTests: XCTestCase {
+  @UniqueTemporaryDirectory private var temporaryDirectory: Directory
+
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+    temporaryDirectory.create()
+  }
+
+  override func tearDown() {
+    if ConcurrencyTesting.isEnabled {
+      temporaryDirectory.delete()
+    }
+  }
+
+  private func waitUntil(timeout: TimeInterval = 15, _ condition: () -> Bool) -> Bool {
+    let deadline = Date(timeIntervalSinceNow: timeout)
+    while Date() < deadline {
+      if condition() { return true }
+      Thread.sleep(forTimeInterval: 0.02)
+    }
+    return condition()
+  }
+
+  /// Files stop accepting writes well before they become readable, mirroring
+  /// the production presets, so the worker never drains a file that is still
+  /// being appended to.
+  private static func storage(maxObjectsInFile: Int) -> StoragePerformanceMock {
+    StoragePerformanceMock(maxFileSize: .max,
+                           maxDirectorySize: .max,
+                           maxFileAgeForWrite: 0.05,
+                           minFileAgeForRead: 0.2,
+                           maxFileAgeForRead: .distantFuture,
+                           maxObjectsInFile: maxObjectsInFile,
+                           maxObjectSize: .max)
+  }
+
+  private func drain(_ exporter: PersistenceSpanExporterDecorator, into sink: InMemoryExporter, expecting count: Int) {
+    // Let the last file age past `minFileAgeForRead`, then flush and wait.
+    Thread.sleep(forTimeInterval: 0.3)
+    _ = exporter.flush(explicitTimeout: nil)
+    let drained = waitUntil { sink.getFinishedSpanItems().count >= count }
+    XCTAssertTrue(drained, "sink received \(sink.getFinishedSpanItems().count) of \(count) spans")
+    XCTAssertEqual(sink.getFinishedSpanItems().count, count)
+    exporter.shutdown(explicitTimeout: nil)
+  }
+
+  // MARK: - Decorator
+
+  func testSpanExportsFromManyThreadsWhileWorkerDrainsStorage() {
+    let sink = InMemoryExporter()
+    let preset = PersistencePerformancePreset.mockWith(storagePerformance: Self.storage(maxObjectsInFile: .max),
+                                                       synchronousWrite: false,
+                                                       exportPerformance: ExportPerformanceMock.veryQuick)
+    let exporter = PersistenceSpanExporterDecorator(spanExporter: sink,
+                                                    storageURL: temporaryDirectory.url,
+                                                    exportCondition: { true },
+                                                    performancePreset: preset)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      _ = exporter.export(spans: [TelemetryFixtures.spanData(name: "span-\(thread)-\(iteration)")], explicitTimeout: nil)
+    }
+
+    drain(exporter, into: sink, expecting: threads * iterations)
+  }
+
+  func testSynchronousWritesFromManyThreads() {
+    let sink = InMemoryExporter()
+    let preset = PersistencePerformancePreset.mockWith(storagePerformance: Self.storage(maxObjectsInFile: .max),
+                                                       synchronousWrite: true,
+                                                       exportPerformance: ExportPerformanceMock.veryQuick)
+    let exporter = PersistenceSpanExporterDecorator(spanExporter: sink,
+                                                    storageURL: temporaryDirectory.url,
+                                                    exportCondition: { true },
+                                                    performancePreset: preset)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 25
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      _ = exporter.export(spans: [TelemetryFixtures.spanData(name: "span-\(thread)-\(iteration)")], explicitTimeout: nil)
+    }
+
+    drain(exporter, into: sink, expecting: threads * iterations)
+  }
+
+  // MARK: - Storage
+
+  func testOrchestratorServesOneWriterAndManyReaders() throws {
+    // Production has a single writer (the writer queue) racing a single
+    // reader that deletes what it has read (the worker queue), plus whoever
+    // lists the directory; that is the shape exercised here.
+    let orchestrator = FilesOrchestrator(directory: temporaryDirectory,
+                                         performance: Self.storage(maxObjectsInFile: .max),
+                                         dateProvider: SystemDateProvider())
+    let writeFailures = ConcurrentCounter()
+    let readFailures = ConcurrentCounter()
+    let readErrors = ConcurrentCollector<String>()
+    let filesRead = ConcurrentCounter()
+    let payload = Data(repeating: 0x41, count: 16)
+
+    ConcurrencyTesting.stress(threads: ConcurrencyTesting.defaultThreads, iterations: 100) { thread, _ in
+      if thread == 0 {
+        do {
+          let file = try orchestrator.getWritableFile(writeSize: UInt64(payload.count))
+          try file.append(data: payload, synchronized: false)
+        } catch {
+          writeFailures.increment()
+        }
+        Thread.sleep(forTimeInterval: 0.002)
+      } else if thread == 1 {
+        if let readable = orchestrator.getReadableFile(excludingFilesNamed: []) {
+          do {
+            _ = try readable.read()
+            orchestrator.delete(readableFile: readable)
+            filesRead.increment()
+          } catch {
+            readFailures.increment()
+            readErrors.append("\(readable.name): \(error)")
+          }
+        }
+      } else {
+        _ = orchestrator.getAllFiles(excludingFilesNamed: [])
+        _ = orchestrator.getReadableFile(excludingFilesNamed: [])
+      }
+    }
+
+    XCTAssertEqual(writeFailures.value, 0)
+    XCTAssertEqual(readFailures.value, 0, readErrors.values.joined(separator: " | "))
+  }
+
+  func testFileWriterMixesAsyncAndSyncWritesFromManyThreads() throws {
+    let orchestrator = FilesOrchestrator(directory: temporaryDirectory,
+                                         performance: StoragePerformanceMock.writeAllObjectsToTheSameFile,
+                                         dateProvider: RelativeDateProvider())
+    let writer = OrchestratedFileWriter(orchestrator: orchestrator)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+    let payload = Data(repeating: 0x42, count: 8)
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      switch thread % 3 {
+      case 0: writer.write(data: payload)
+      case 1: writer.writeSync(data: payload)
+      default:
+        writer.write(data: payload)
+        if iteration.isMultiple(of: 10) { writer.flush() }
+      }
+    }
+
+    writer.flush()
+    let totalBytes = try temporaryDirectory.files().reduce(UInt64(0)) { try $0 + $1.size() }
+    XCTAssertEqual(totalBytes, UInt64(threads * iterations * payload.count))
+  }
+}

--- a/Tests/ExportersTests/Prometheus/PrometheusExporterConcurrencyTests.swift
+++ b/Tests/ExportersTests/Prometheus/PrometheusExporterConcurrencyTests.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import OpenTelemetryApi
+import OpenTelemetrySdk
+@testable import PrometheusExporter
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for the Prometheus exporter. The HTTP server is not started;
+/// scrapes are simulated by calling the same collection writer the handler
+/// uses. They only run under Thread Sanitizer (or `OTEL_CONCURRENCY_TESTS=1`).
+final class PrometheusExporterConcurrencyTests: XCTestCase {
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+  }
+
+  private func makeExporter() -> UncheckedSendable<PrometheusExporter> {
+    UncheckedSendable(PrometheusExporter(options: PrometheusExporterOptions(url: "http://localhost:9184/metrics/")))
+  }
+
+  func testExportRacesScrapes() {
+    let exporter = makeExporter()
+    let tornReads = ConcurrentCounter()
+    let scrapes = ConcurrentCounter()
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 100
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, _ in
+      if thread.isMultiple(of: 2) {
+        // Each exporting thread publishes a batch whose size identifies it.
+        let batch = (0 ... thread).map { TelemetryFixtures.metricData(name: "metric_\(thread)_\($0)", value: Double($0)) }
+        _ = exporter.value.export(metrics: batch)
+      } else {
+        let snapshot = exporter.value.getMetrics()
+        // A snapshot must be a whole batch: empty, or sized like one exporter's batch.
+        if !snapshot.isEmpty, !(1 ... threads).contains(snapshot.count) {
+          tornReads.increment()
+        }
+        let output = PrometheusExporterExtensions.writeMetricsCollection(exporter: exporter.value)
+        if !output.isEmpty {
+          scrapes.increment()
+        }
+      }
+    }
+
+    XCTAssertEqual(tornReads.value, 0)
+    XCTAssertGreaterThan(scrapes.value, 0)
+  }
+
+  func testFlushAndShutdownRaceExport() {
+    let exporter = makeExporter()
+
+    ConcurrencyTesting.concurrently([
+      { _ = exporter.value.export(metrics: [TelemetryFixtures.metricData()]) },
+      { _ = exporter.value.flush() },
+      { _ = exporter.value.shutdown() },
+      { _ = exporter.value.getMetrics() },
+      { _ = exporter.value.getAggregationTemporality(for: .counter) }
+    ])
+  }
+}

--- a/Tests/ExportersTests/Zipkin/ZipkinExporterConcurrencyTests.swift
+++ b/Tests/ExportersTests/Zipkin/ZipkinExporterConcurrencyTests.swift
@@ -1,0 +1,76 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import SharedTestUtils
+import XCTest
+@testable import ZipkinExporter
+
+/// Stress tests for the Zipkin span conversion, whose endpoint caches are
+/// process-global. `export` is not exercised because it always hits the
+/// network. They only run under Thread Sanitizer (or `OTEL_CONCURRENCY_TESTS=1`).
+final class ZipkinExporterConcurrencyTests: XCTestCase {
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+    ZipkinConversionExtension._resetCachesForTesting()
+  }
+
+  override func tearDown() {
+    ZipkinConversionExtension._resetCachesForTesting()
+  }
+
+  private static func span(service: String, peer: String? = nil) -> SpanData {
+    var attributes: [String: AttributeValue] = [:]
+    if let peer {
+      attributes["peer.service"] = .string(peer)
+    }
+    return TelemetryFixtures.spanData(name: "span",
+                                      kind: peer == nil ? .server : .client,
+                                      resource: Resource(attributes: ["service.name": .string(service)]),
+                                      attributes: attributes)
+  }
+
+  func testConversionSharesEndpointCachesAcrossThreads() {
+    let defaultEndpoint = ZipkinEndpoint(serviceName: "default")
+    let wrongLocal = ConcurrentCounter()
+    let wrongRemote = ConcurrentCounter()
+    let threads = ConcurrencyTesting.defaultThreads
+
+    ConcurrencyTesting.stress(threads: threads) { thread, iteration in
+      // Half the threads collide on one service name, the rest use their own.
+      let service = thread.isMultiple(of: 2) ? "shared-service" : "service-\(thread)"
+      let peer = iteration.isMultiple(of: 2) ? "peer-\(thread)" : "shared-peer"
+      let converted = ZipkinConversionExtension.toZipkinSpan(otelSpan: Self.span(service: service, peer: peer),
+                                                             defaultLocalEndpoint: defaultEndpoint)
+      if converted.localEndpoint?.serviceName != service {
+        wrongLocal.increment()
+      }
+      if converted.remoteEndpoint?.serviceName != peer {
+        wrongRemote.increment()
+      }
+    }
+
+    XCTAssertEqual(wrongLocal.value, 0)
+    XCTAssertEqual(wrongRemote.value, 0)
+    let localCacheCount = ZipkinConversionExtension.localEndpointCacheLock.withLock {
+      ZipkinConversionExtension.localEndpointCache.count
+    }
+    XCTAssertEqual(localCacheCount, 1 + threads / 2)
+  }
+
+  func testEncodeSpansFromManyThreadsThroughSharedExporter() {
+    let exporter = UncheckedSendable(ZipkinTraceExporter(options: ZipkinTraceExporterOptions(endpoint: "http://localhost:9411/api/v2/spans")))
+    let encoded = ConcurrentCounter()
+
+    ConcurrencyTesting.stress { thread, _ in
+      let spans = [Self.span(service: "service-\(thread)"), Self.span(service: "shared", peer: "peer")]
+      encoded.increment(by: exporter.value.encodeSpans(spans: spans).count)
+      _ = exporter.value.flush()
+    }
+
+    XCTAssertEqual(encoded.value, 2 * ConcurrencyTesting.defaultThreads * ConcurrencyTesting.defaultIterations)
+  }
+}

--- a/Tests/ImportersTests/OpenTracingShim/OpenTracingShimConcurrencyTests.swift
+++ b/Tests/ImportersTests/OpenTracingShim/OpenTracingShimConcurrencyTests.swift
@@ -1,0 +1,152 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@testable import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+@testable import OpenTracingShim
+import Opentracing
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for the OpenTracing shim. They only run under Thread
+/// Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class OpenTracingShimConcurrencyTests: XCTestCase {
+  private var tracerProvider: TracerProviderSdk!
+  private var tracer: Tracer!
+  private var telemetryInfo: TelemetryInfo!
+  private var tracerShim: TracerShim!
+
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+    tracerProvider = TracerProviderSdk()
+    tracer = tracerProvider.get(instrumentationName: "OpenTracingShimConcurrencyTests")
+    telemetryInfo = TelemetryInfo(tracer: tracer,
+                                  baggageManager: OpenTelemetry.instance.baggageManager,
+                                  propagators: OpenTelemetry.instance.propagators)
+    tracerShim = TracerShim(telemetryInfo: telemetryInfo)
+  }
+
+  override func tearDown() {
+    tracerShim = nil
+    telemetryInfo = nil
+    tracer = nil
+    tracerProvider = nil
+  }
+
+  func testContextForSharedSpanResolvesToOneShimFromManyThreads() {
+    let span = tracer.spanBuilder(spanName: "shared").startSpan()
+    defer { span.end() }
+    let spanShim = UncheckedSendable(SpanShim(telemetryInfo: telemetryInfo, span: span))
+    let contexts = ConcurrentCollector<ObjectIdentifier>()
+
+    ConcurrencyTesting.stress { _, _ in
+      let context = spanShim.value.context() as AnyObject
+      contexts.append(ObjectIdentifier(context))
+    }
+
+    XCTAssertEqual(Set(contexts.values).count, 1)
+  }
+
+  func testBaggageOnSharedSpanFromManyThreads() {
+    let span = tracer.spanBuilder(spanName: "baggage").startSpan()
+    defer { span.end() }
+    let spanShim = UncheckedSendable(SpanShim(telemetryInfo: telemetryInfo, span: span))
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+    let missing = ConcurrentCounter()
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      _ = spanShim.value.setBaggageItem("thread-\(thread)", value: "\(iteration)")
+      if spanShim.value.getBaggageItem("thread-\(thread)") == nil {
+        missing.increment()
+      }
+      _ = spanShim.value.context()
+    }
+
+    XCTAssertEqual(missing.value, 0)
+    for thread in 0 ..< threads {
+      XCTAssertEqual(spanShim.value.getBaggageItem("thread-\(thread)"), "\(iterations - 1)")
+    }
+  }
+
+  func testStartTagLogFinishSpansFromManyThreads() {
+    let tracerShim = UncheckedSendable(self.tracerShim!)
+    let parent = tracerShim.value.startSpan("parent")
+    defer { parent.finish() }
+    let parentContext = UncheckedSendable(parent.context())
+
+    ConcurrencyTesting.stress { thread, iteration in
+      let span = tracerShim.value.startSpan("child-\(thread)",
+                                            childOf: parentContext.value,
+                                            tags: ["thread": thread])
+      span.setTag("iteration", numberValue: NSNumber(value: iteration))
+      span.setTag("flag", boolValue: iteration.isMultiple(of: 2))
+      span.log(["event": "progress" as NSString])
+      span.logEvent("named")
+      _ = span.setBaggageItem("key", value: "value")
+      _ = span.getBaggageItem("key")
+      span.setOperationName("renamed-\(thread)")
+      span.finish()
+    }
+  }
+
+  func testInjectAndExtractFromManyThreads() {
+    let tracerShim = UncheckedSendable(self.tracerShim!)
+    let parent = tracerShim.value.startSpan("parent")
+    defer { parent.finish() }
+    let parentContext = UncheckedSendable(parent.context())
+    let expectedTraceId = (parent.context() as? SpanContextShim)?.context.traceId
+    let missingBaggage = ConcurrentCounter()
+    let nilExtracts = ConcurrentCounter()
+    let wrongTraces = ConcurrentCounter()
+
+    // `extract` refuses to build a context unless the calling thread has
+    // active baggage, so each worker installs its own. A thread-local
+    // manager keeps that deterministic on plain threads.
+    OpenTelemetry.withContextManager(ThreadLocalContextManager()) {
+      ConcurrencyTesting.stress { _, _ in
+      let baggage = OpenTelemetry.instance.baggageManager.baggageBuilder().build()
+      OpenTelemetry.instance.contextProvider.setActiveBaggage(baggage)
+      defer { OpenTelemetry.instance.contextProvider.removeContextForBaggage(baggage) }
+
+      if OpenTelemetry.instance.contextProvider.activeBaggage == nil {
+        missingBaggage.increment()
+      }
+
+      let carrier = NSMutableDictionary()
+      _ = tracerShim.value.inject(parentContext.value, format: OTFormatTextMap, carrier: carrier)
+      let headers = carrier as? [String: String] ?? [:]
+      guard let extracted = tracerShim.value.extract(withFormat: OTFormatTextMap, carrier: headers) as? SpanContextShim else {
+        nilExtracts.increment()
+        return
+      }
+      if extracted.context.traceId != expectedTraceId {
+        wrongTraces.increment()
+      }
+      }
+    }
+
+    XCTAssertEqual(missingBaggage.value, 0, "active baggage not visible on worker thread")
+    XCTAssertEqual(nilExtracts.value, 0, "extract returned nil")
+    XCTAssertEqual(wrongTraces.value, 0, "extract returned another trace")
+  }
+
+  func testReadWriteLockUnderContention() {
+    let lock = UncheckedSendable(OpenTracingShim.ReadWriteLock())
+    let writes = ConcurrentCounter()
+    nonisolated(unsafe) var guarded = 0
+
+    ConcurrencyTesting.stress { thread, _ in
+      if thread.isMultiple(of: 4) {
+        lock.value.withWriterLockVoid { guarded += 1 }
+        writes.increment()
+      } else {
+        _ = lock.value.withReaderLock { guarded }
+      }
+    }
+
+    XCTAssertEqual(guarded, writes.value)
+  }
+}

--- a/Tests/ImportersTests/SwiftMetricsShim/SwiftMetricsShimConcurrencyTests.swift
+++ b/Tests/ImportersTests/SwiftMetricsShim/SwiftMetricsShimConcurrencyTests.swift
@@ -1,0 +1,227 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@testable import CoreMetrics
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import SharedTestUtils
+@testable import SwiftMetricsShim
+import XCTest
+
+/// Stress tests for the swift-metrics shim. They only run under Thread
+/// Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`); see `ConcurrencyTesting`.
+final class SwiftMetricsShimConcurrencyTests: XCTestCase {
+  private final class CollectingExporter: MetricExporter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var latest: [MetricData] = []
+
+    var exported: [MetricData] {
+      lock.lock()
+      defer { lock.unlock() }
+      return latest
+    }
+
+    func export(metrics: [MetricData]) -> ExportResult {
+      lock.lock()
+      latest = metrics
+      lock.unlock()
+      return .success
+    }
+
+    func flush() -> ExportResult { .success }
+    func shutdown() -> ExportResult { .success }
+    func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality { .cumulative }
+  }
+
+  private var exporter: CollectingExporter!
+  private var reader: PeriodicMetricReaderSdk!
+  private var provider: MeterProviderSdk!
+  private var metrics: OpenTelemetrySwiftMetrics!
+
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+    exporter = CollectingExporter()
+    // A very long interval so only `forceFlush` drives collection.
+    reader = PeriodicMetricReaderSdk(exporter: exporter, exportInterval: 3600)
+    // Without a matching view the SDK allocates no storage for an
+    // instrument, so register a catch-all view like the existing tests do.
+    provider = MeterProviderSdk.builder()
+      .registerView(selector: InstrumentSelector.builder().setInstrument(name: ".*").build(),
+                    view: View.builder().build())
+      .registerMetricReader(reader: reader)
+      .build()
+    metrics = OpenTelemetrySwiftMetrics(meter: provider.meterBuilder(name: "concurrency").build())
+  }
+
+  override func tearDown() {
+    _ = reader?.shutdown()
+    reader = nil
+    provider = nil
+    metrics = nil
+    exporter = nil
+  }
+
+  private var registeredMetricCount: Int {
+    metrics.lock.withLock { metrics.metrics.count }
+  }
+
+  private func exportedMetric(named name: String) -> MetricData? {
+    _ = reader.forceFlush()
+    return exporter.exported.first { $0.name == name }
+  }
+
+  // MARK: - Factory
+
+  func testMakeCounterWithSameLabelFromManyThreadsReturnsOneInstance() {
+    let metrics = self.metrics!
+    let handlers = ConcurrentCollector<ObjectIdentifier>()
+
+    ConcurrencyTesting.stress { _, _ in
+      let handler = metrics.makeCounter(label: "shared_counter", dimensions: [("dim", "value")])
+      handlers.append(ObjectIdentifier(handler))
+    }
+
+    XCTAssertEqual(Set(handlers.values).count, 1)
+    XCTAssertEqual(registeredMetricCount, 1)
+  }
+
+  func testMakeEveryInstrumentTypeFromManyThreads() {
+    let metrics = self.metrics!
+    let threads = ConcurrencyTesting.defaultThreads
+
+    ConcurrencyTesting.stress(threads: threads) { thread, _ in
+      for label in ["shared", "thread_\(thread)"] {
+        _ = metrics.makeCounter(label: label, dimensions: [])
+        _ = metrics.makeRecorder(label: label, dimensions: [], aggregate: true)
+        _ = metrics.makeRecorder(label: label, dimensions: [], aggregate: false)
+        _ = metrics.makeTimer(label: label, dimensions: [])
+      }
+    }
+
+    // Per label: one counter, one histogram (the non-aggregating recorder
+    // resolves to the existing histogram), one timer.
+    XCTAssertEqual(registeredMetricCount, 3 * (threads + 1))
+  }
+
+  func testMakeRacingDestroyOnSameLabel() {
+    let metrics = self.metrics!
+
+    // Only the factory is exercised here. Recording through two handlers of
+    // the same instrument reaches shared storage in the core SDK whose
+    // exemplar reservoir is not synchronized; that belongs upstream.
+    ConcurrencyTesting.stress { thread, _ in
+      if thread.isMultiple(of: 2) {
+        _ = metrics.makeCounter(label: "churn", dimensions: [])
+        _ = metrics.makeTimer(label: "churn", dimensions: [])
+      } else {
+        metrics.destroyCounter(metrics.makeCounter(label: "churn", dimensions: []))
+        metrics.destroyTimer(metrics.makeTimer(label: "churn", dimensions: []))
+      }
+    }
+
+    XCTAssertLessThanOrEqual(registeredMetricCount, 2)
+  }
+
+  // MARK: - Recording
+
+  func testIncrementSharedCounterFromManyThreads() throws {
+    let counter = metrics.makeCounter(label: "hits", dimensions: [("dim", "value")])
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { _, _ in
+      counter.increment(by: 1)
+    }
+
+    let metric = try XCTUnwrap(exportedMetric(named: "hits"))
+    let point = try XCTUnwrap(metric.data.points.last as? LongPointData)
+    XCTAssertEqual(metric.type, .LongSum)
+    XCTAssertEqual(point.value, threads * iterations)
+  }
+
+  func testRecordOnSharedRecordersFromManyThreads() throws {
+    let gauge = metrics.makeRecorder(label: "gauge", dimensions: [], aggregate: false)
+    let histogram = metrics.makeRecorder(label: "histogram", dimensions: [], aggregate: true)
+    let timer = metrics.makeTimer(label: "timer", dimensions: [])
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      gauge.record(Double(thread))
+      histogram.record(Int64(iteration))
+      timer.recordNanoseconds(1)
+    }
+
+    XCTAssertNotNil(exportedMetric(named: "gauge"))
+    let histogramData = try XCTUnwrap(exportedMetric(named: "histogram"))
+    let histogramPoint = try XCTUnwrap(histogramData.data.points.last as? HistogramPointData)
+    XCTAssertEqual(histogramPoint.count, UInt64(threads * iterations))
+    let timerData = try XCTUnwrap(exportedMetric(named: "timer"))
+    let timerPoint = try XCTUnwrap(timerData.data.points.last as? DoublePointData)
+    XCTAssertEqual(timerPoint.value, Double(threads * iterations))
+  }
+
+  // MARK: - swift-metrics front door
+
+  func testMetricsSystemInstrumentsFromManyThreads() throws {
+    // `MetricsSystem` is process-global; the existing tests bootstrap it the
+    // same way, and re-bootstrapping replaces the factory for this test.
+    MetricsSystem.bootstrapInternal(metrics)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, _ in
+      Counter(label: "system_counter").increment()
+      Recorder(label: "system_recorder").record(Double(thread))
+      Gauge(label: "system_gauge").record(thread)
+      Timer(label: "system_timer").recordNanoseconds(1)
+    }
+
+    let counter = try XCTUnwrap(exportedMetric(named: "system_counter"))
+    let point = try XCTUnwrap(counter.data.points.last as? LongPointData)
+    XCTAssertEqual(point.value, threads * iterations)
+    XCTAssertNotNil(exportedMetric(named: "system_recorder"))
+    XCTAssertNotNil(exportedMetric(named: "system_gauge"))
+    XCTAssertNotNil(exportedMetric(named: "system_timer"))
+  }
+
+  // MARK: - Locks
+
+  func testLockedValueUnderContention() {
+    let value = SwiftMetricsShim.Locked(initialValue: 0)
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, _ in
+      if thread.isMultiple(of: 2) {
+        value.protectedValue += 1
+      } else {
+        value.locking { $0 += 1 }
+      }
+      _ = value.protectedValue
+    }
+
+    XCTAssertEqual(value.protectedValue, threads * iterations)
+  }
+
+  func testReadWriteLockUnderContention() {
+    let lock = UncheckedSendable(SwiftMetricsShim.ReadWriteLock())
+    let counter = ConcurrentCounter()
+    nonisolated(unsafe) var guarded = 0
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, _ in
+      if thread.isMultiple(of: 4) {
+        lock.value.withWriterLockVoid { guarded += 1 }
+        counter.increment()
+      } else {
+        _ = lock.value.withReaderLock { guarded }
+      }
+    }
+
+    XCTAssertEqual(guarded, counter.value)
+  }
+}

--- a/Tests/InstrumentationTests/SDKResourceExtensionTests/ResourceExtensionConcurrencyTests.swift
+++ b/Tests/InstrumentationTests/SDKResourceExtensionTests/ResourceExtensionConcurrencyTests.swift
@@ -1,0 +1,73 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+@testable import ResourceExtension
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for resource detection. Some data sources hop to the main
+/// queue when called from another thread, so the workers run off the main
+/// thread while the test pumps the main run loop. They only run under Thread
+/// Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class ResourceExtensionConcurrencyTests: XCTestCase {
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+  }
+
+  private func runOffMainThread(timeout: TimeInterval = 120, _ body: @escaping @Sendable () -> Void) {
+    let finished = expectation(description: "workers finished")
+    Thread.detachNewThread {
+      body()
+      finished.fulfill()
+    }
+    wait(for: [finished], timeout: timeout)
+  }
+
+  func testDefaultResourcesFromManyBackgroundThreads() {
+    let resources = UncheckedSendable(DefaultResources())
+    let expected = UncheckedSendable(resources.value.get())
+    let mismatches = ConcurrentCounter()
+
+    runOffMainThread {
+      ConcurrencyTesting.stress(threads: ConcurrencyTesting.defaultThreads, iterations: 20) { _, _ in
+        let resource = resources.value.get()
+        if resource.attributes != expected.value.attributes {
+          mismatches.increment()
+        }
+      }
+    }
+
+    XCTAssertEqual(mismatches.value, 0)
+  }
+
+  func testDataSourcesFromManyBackgroundThreads() {
+    let reads = ConcurrentCounter()
+
+    runOffMainThread {
+      ConcurrencyTesting.stress(threads: ConcurrencyTesting.defaultThreads, iterations: 20) { _, _ in
+        let device = DeviceDataSource()
+        _ = device.model
+        _ = device.identifier
+        let os = OperatingSystemDataSource()
+        _ = os.name
+        _ = os.version
+        _ = os.description
+        _ = os.type
+        let application = ApplicationDataSource()
+        _ = application.name
+        _ = application.identifier
+        _ = application.version
+        _ = application.build
+        _ = TelemetryDataSource().version
+        reads.increment()
+      }
+    }
+
+    XCTAssertEqual(reads.value, ConcurrencyTesting.defaultThreads * 20)
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionsConcurrencyTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionsConcurrencyTests.swift
@@ -1,0 +1,196 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+@testable import Sessions
+import SharedTestUtils
+import XCTest
+
+/// Stress tests for session management. They only run under Thread Sanitizer
+/// (or with `OTEL_CONCURRENCY_TESTS=1`).
+final class SessionsConcurrencyTests: XCTestCase {
+  private let sessionIdKey = SemanticConventions.Session.id.rawValue
+
+  override func setUpWithError() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+    SessionStore.teardown()
+  }
+
+  override func tearDown() {
+    guard ConcurrencyTesting.isEnabled else { return }
+    SessionStore.teardown()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: DefaultLoggerProvider.instance)
+  }
+
+  private func makeManager(sessionTimeout: TimeInterval = 3600) -> SessionManager {
+    SessionManager(configuration: SessionConfig(sessionTimeout: sessionTimeout, restorePersistedSession: false))
+  }
+
+  // MARK: - SessionManager
+
+  func testGetAndPeekFromManyThreadsShareOneSession() {
+    let manager = makeManager()
+    let ids = ConcurrentCollector<String>()
+
+    ConcurrencyTesting.stress { thread, _ in
+      if thread == 0 {
+        if let session = manager.peekSession() {
+          ids.append(session.id)
+        }
+      } else {
+        ids.append(manager.getSession().id)
+      }
+    }
+
+    XCTAssertEqual(Set(ids.values).count, 1)
+  }
+
+  func testSessionRotatesOnEveryCallUnderContention() {
+    // A zero timeout expires the session immediately, so every call takes the
+    // "start new session" path: event queueing, notifications and store saves.
+    let manager = makeManager(sessionTimeout: 0)
+    let ids = ConcurrentCollector<String>()
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { _, _ in
+      ids.append(manager.getSession().id)
+      _ = manager.peekSession()
+    }
+
+    XCTAssertEqual(ids.count, threads * iterations)
+    XCTAssertEqual(Set(ids.values).count, threads * iterations)
+  }
+
+  // MARK: - SessionStore
+
+  func testStoreSaveAndLoadFromManyThreads() {
+    ConcurrencyTesting.stress(threads: ConcurrencyTesting.defaultThreads, iterations: 50) { thread, iteration in
+      let session = Session(id: "\(thread)-\(iteration)",
+                            expireTime: Date(timeIntervalSinceNow: 60),
+                            previousId: iteration == 0 ? nil : "\(thread)-\(iteration - 1)",
+                            startTime: Date())
+      if thread.isMultiple(of: 2) {
+        SessionStore.saveImmediately(session: session)
+      } else {
+        SessionStore.scheduleSave(session: session)
+      }
+      _ = SessionStore.load()
+    }
+
+    XCTAssertNotNil(SessionStore.load())
+  }
+
+  // MARK: - Processors
+
+  func testSharedSpanProcessorFromManyThreads() {
+    let manager = makeManager()
+    let processor = UncheckedSendable(SessionSpanProcessor(sessionManager: manager))
+    let expectedId = manager.getSession().id
+    let mismatches = ConcurrentCounter()
+    let sessionIdKey = self.sessionIdKey
+
+    ConcurrencyTesting.stress { _, _ in
+      let span = MockReadableSpan()
+      processor.value.onStart(parentContext: nil, span: span)
+      processor.value.onEnd(span: span)
+      if span.capturedAttributes[sessionIdKey] != .string(expectedId) {
+        mismatches.increment()
+      }
+    }
+
+    XCTAssertEqual(mismatches.value, 0)
+  }
+
+  func testSpanProcessorInsideTracerProviderFromManyThreads() {
+    let manager = makeManager()
+    let provider = TracerProviderSdk(spanProcessors: [SessionSpanProcessor(sessionManager: manager)])
+    let tracer = UncheckedSendable(provider.get(instrumentationName: "stress"))
+    let expectedId = manager.getSession().id
+    let mismatches = ConcurrentCounter()
+    let sessionIdKey = self.sessionIdKey
+
+    ConcurrencyTesting.stress { thread, _ in
+      let span = tracer.value.spanBuilder(spanName: "span-\(thread)").startSpan()
+      if let readable = span as? ReadableSpan, readable.toSpanData().attributes[sessionIdKey] != .string(expectedId) {
+        mismatches.increment()
+      }
+      span.end()
+    }
+
+    XCTAssertEqual(mismatches.value, 0)
+  }
+
+  func testSharedLogRecordProcessorFromManyThreads() {
+    let manager = makeManager()
+    let next = MockLogRecordProcessor()
+    let processor = UncheckedSendable(SessionLogRecordProcessor(nextProcessor: next, sessionManager: manager))
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = ConcurrencyTesting.defaultIterations
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      processor.value.onEmit(logRecord: TelemetryFixtures.logRecord(body: "log-\(thread)-\(iteration)"))
+      if iteration == 0 {
+        _ = processor.value.forceFlush(explicitTimeout: nil)
+      }
+    }
+
+    let records = next.receivedLogRecords
+    XCTAssertEqual(records.count, threads * iterations)
+    XCTAssertTrue(records.allSatisfy { $0.attributes[sessionIdKey] != nil })
+  }
+
+  // MARK: - Session events
+
+  func testInstallRacesQueuedSessionEvents() {
+    let exporter = InMemoryLogRecordExporter()
+    let loggerProvider = LoggerProviderBuilder()
+      .with(processors: [SimpleLogRecordProcessor(logRecordExporter: exporter)])
+      .build()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+    SessionEventInstrumentation.queue.removeAll()
+    SessionEventInstrumentation.isApplied = false
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 50
+
+    ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+      if thread == 0, iteration == 10 {
+        SessionEventInstrumentation.install()
+      }
+      let session = Session(id: "\(thread)-\(iteration)",
+                            expireTime: Date(timeIntervalSinceNow: 60),
+                            previousId: nil,
+                            startTime: Date(timeIntervalSinceNow: -1))
+      SessionEventInstrumentation.addSession(session: session, eventType: iteration.isMultiple(of: 2) ? .start : .end)
+    }
+
+    XCTAssertTrue(SessionEventInstrumentation.isApplied)
+    XCTAssertTrue(SessionEventInstrumentation.queue.isEmpty)
+    XCTAssertGreaterThan(exporter.getFinishedLogRecords().count, 0)
+  }
+
+  // MARK: - Provider
+
+  func testRegisterRacesGetInstance() {
+    let managers = UncheckedSendable((0 ..< 4).map { _ in makeManager() })
+    let initial = ObjectIdentifier(SessionManagerProvider.getInstance())
+    let seen = ConcurrentCollector<ObjectIdentifier>()
+
+    ConcurrencyTesting.stress(threads: ConcurrencyTesting.defaultThreads, iterations: 50) { thread, iteration in
+      if thread < 4, iteration.isMultiple(of: 10) {
+        SessionManagerProvider.register(sessionManager: managers.value[thread])
+      }
+      seen.append(ObjectIdentifier(SessionManagerProvider.getInstance()))
+    }
+
+    // Every observed instance is either the one present before the test or
+    // one of the managers registered during it.
+    let allowed = Set(managers.value.map { ObjectIdentifier($0) }).union([initial])
+    XCTAssertTrue(Set(seen.values).isSubset(of: allowed))
+    SessionManagerProvider.register(sessionManager: SessionManager())
+  }
+}

--- a/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationConcurrencyTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/URLSessionInstrumentationConcurrencyTests.swift
@@ -1,0 +1,108 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import SharedTestUtils
+@testable import URLSessionInstrumentation
+import XCTest
+
+/// Stress tests for URLSession instrumentation. The swizzling is installed
+/// once per process by `URLSessionInstrumentationTests`, and only the first
+/// instance's configuration is applied, so these live on that class and swap
+/// its configuration for the duration of each test. They only run under
+/// Thread Sanitizer (or with `OTEL_CONCURRENCY_TESTS=1`).
+extension URLSessionInstrumentationTests {
+  private final class Counters: @unchecked Sendable {
+    let created = ConcurrentCounter()
+    let responses = ConcurrentCounter()
+    let errors = ConcurrentCounter()
+    let named = ConcurrentCounter()
+  }
+
+  private static func toggleSemanticConvention(on instrumentation: URLSessionInstrumentation, iteration: Int) {
+    var updated = instrumentation.configuration
+    updated.semanticConvention = iteration.isMultiple(of: 2) ? .old : .stable
+    instrumentation.configuration = updated
+    _ = instrumentation.configuration.shouldInstrument
+  }
+
+  private func withStressConfiguration(_ counters: Counters, _ body: (URLSessionInstrumentation) -> Void) {
+    let instrumentation = URLSessionInstrumentationTests.instrumentation!
+    let original = instrumentation.configuration
+    instrumentation.configuration = URLSessionInstrumentationConfiguration(
+      shouldInstrument: { _ in true },
+      nameSpan: { request in
+        counters.named.increment()
+        return "stress \(request.url?.path ?? "")"
+      },
+      shouldInjectTracingHeaders: { _ in true },
+      createdRequest: { _, _ in counters.created.increment() },
+      receivedResponse: { _, _, _ in counters.responses.increment() },
+      receivedError: { _, _, _, _ in counters.errors.increment() }
+    )
+    defer { instrumentation.configuration = original }
+    body(instrumentation)
+  }
+
+  func testConcurrentDataTasksThroughSharedInstrumentation() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+    let counters = Counters()
+    let threads = ConcurrencyTesting.defaultThreads
+    let iterations = 15
+
+    withStressConfiguration(counters) { instrumentation in
+      let inFlight = DispatchGroup()
+
+      ConcurrencyTesting.stress(threads: threads, iterations: iterations) { thread, iteration in
+        inFlight.enter()
+        var request = URLRequest(url: URL(string: "http://localhost:33333/success?thread=\(thread)&iteration=\(iteration)")!)
+        request.timeoutInterval = 30
+        let task = URLSession.shared.dataTask(with: request) { _, _, _ in
+          inFlight.leave()
+        }
+        task.resume()
+        _ = instrumentation.startedRequestSpans
+      }
+
+      XCTAssertEqual(inFlight.wait(timeout: .now() + 120), .success)
+      wait(timeout: 10) { instrumentation.startedRequestSpans.isEmpty }
+    }
+
+    XCTAssertEqual(counters.created.value, threads * iterations)
+    XCTAssertEqual(counters.named.value, threads * iterations)
+    XCTAssertEqual(counters.responses.value + counters.errors.value, threads * iterations)
+    XCTAssertTrue(URLSessionInstrumentationTests.instrumentation.startedRequestSpans.isEmpty)
+  }
+
+  func testConfigurationUpdatesRaceInFlightRequests() throws {
+    try ConcurrencyTesting.skipUnlessEnabled()
+    let counters = Counters()
+
+    withStressConfiguration(counters) { instrumentation in
+      let inFlight = DispatchGroup()
+
+      ConcurrencyTesting.stress(threads: ConcurrencyTesting.defaultThreads, iterations: 10) { thread, iteration in
+        if thread == 0 {
+          // Reader and writer of the configuration on different threads.
+          Self.toggleSemanticConvention(on: instrumentation, iteration: iteration)
+        } else {
+          inFlight.enter()
+          let url = URL(string: "http://localhost:33333/success?config=\(thread)-\(iteration)")!
+          let task = URLSession.shared.dataTask(with: url) { _, _, _ in
+            inFlight.leave()
+          }
+          task.resume()
+        }
+      }
+
+      XCTAssertEqual(inFlight.wait(timeout: .now() + 120), .success)
+      wait(timeout: 10) { instrumentation.startedRequestSpans.isEmpty }
+    }
+
+    XCTAssertEqual(counters.created.value, (ConcurrencyTesting.defaultThreads - 1) * 10)
+  }
+}

--- a/Tests/SharedTestUtilsTests/ConcurrencyTestingTests.swift
+++ b/Tests/SharedTestUtilsTests/ConcurrencyTestingTests.swift
@@ -1,0 +1,70 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SharedTestUtils
+import XCTest
+
+final class ConcurrencyTestingTests: XCTestCase {
+  func testGateMatchesEnvironmentOrSanitizer() {
+    let env = ProcessInfo.processInfo.environment[ConcurrencyTesting.environmentVariable]
+    if let env, !env.isEmpty {
+      let forcedOff = ["0", "false", "no", "off"].contains(env.lowercased())
+      XCTAssertEqual(ConcurrencyTesting.isEnabled, !forcedOff)
+    } else {
+      XCTAssertEqual(ConcurrencyTesting.isEnabled, ConcurrencyTesting.isThreadSanitizerActive)
+    }
+  }
+
+  func testStressRunsEveryIterationOnEveryThread() {
+    let lock = NSLock()
+    nonisolated(unsafe) var seen = Set<String>()
+
+    ConcurrencyTesting.stress(threads: 4, iterations: 25) { thread, iteration in
+      lock.lock()
+      seen.insert("\(thread)-\(iteration)")
+      lock.unlock()
+    }
+
+    XCTAssertEqual(seen.count, 4 * 25)
+  }
+
+  func testConcurrentlyRunsEachOperationOnce() {
+    let lock = NSLock()
+    nonisolated(unsafe) var order: [Int] = []
+
+    ConcurrencyTesting.concurrently([
+      { lock.lock(); order.append(1); lock.unlock() },
+      { lock.lock(); order.append(2); lock.unlock() },
+      { lock.lock(); order.append(3); lock.unlock() }
+    ])
+
+    XCTAssertEqual(order.sorted(), [1, 2, 3])
+  }
+
+  func testAsyncStressRunsEveryIteration() async {
+    actor Counter {
+      var value = 0
+      func bump() { value += 1 }
+    }
+    let counter = Counter()
+
+    await ConcurrencyTesting.stress(tasks: 4, iterations: 25) { _, _ in
+      await counter.bump()
+    }
+
+    let value = await counter.value
+    XCTAssertEqual(value, 100)
+  }
+
+  func testSkipUnlessEnabledSkipsWhenDisabled() throws {
+    if ConcurrencyTesting.isEnabled {
+      XCTAssertNoThrow(try ConcurrencyTesting.skipUnlessEnabled())
+    } else {
+      XCTAssertThrowsError(try ConcurrencyTesting.skipUnlessEnabled()) { error in
+        XCTAssertTrue(error is XCTSkip)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Contributing this for parity with https://github.com/open-telemetry/opentelemetry-swift-core/pull/70 . I've also noticed in the past from my work on session management that our approval workflows are not great at catching crashes, so hopefully this will help some.

Adds thread sanitizer approval gate running against concurrency test suites to catch data races and regressions. 

The results are pretty positive. I only found some small issues in MetricHandlers, FileOrchestrator, OtlpTraceJsonExporter and ExporterMetrics which I resolved with locks. 

## Testing

See approval flows

Full transparency, I just had AI create a bunch of concurrency tests so that the thread sanitizer actually has some context to work with. They only run when `OTEL_CONCURRENCY_TESTS` is set to a truthy value, so they don't run unless explicitly intended. 