### PR TITLE
fix(otlp-http): return upload failures from metric exporter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,10 @@ let package = Package(
     .executable(name: "StableMetricSample", targets: ["StableMetricSample"])
   ],
   dependencies: [
-    .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.5.1"),
+    .package(
+      url: "https://github.com/yasuradodo/opentelemetry-swift-core.git",
+      branch: "tech/periodic-metric-reader-background-export"
+    ),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.101.3"),
     .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.27.6"),
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.38.1"),

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/metric/OtlpHttpMetricExporter.swift
@@ -92,6 +92,7 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
   // MARK: - StableMetricsExporter
 
   public func export(metrics: [MetricData]) -> ExportResult {
+    var resultValue: ExportResult = .success
     var sendingMetrics: [MetricData] = []
     exporterLock.withLockVoid {
       pendingMetrics.append(contentsOf: metrics)
@@ -104,8 +105,10 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
           metricData: sendingMetrics)
       }
     exporterMetrics?.addSeen(value: sendingMetrics.count)
+    let timeout = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+    let semaphore = DispatchSemaphore(value: 0)
     var request = createRequest(body: body, endpoint: endpoint)
-    request.timeoutInterval = min(TimeInterval.greatestFiniteMagnitude, config.timeout)
+    request.timeoutInterval = timeout
     httpClient.send(request: request) { [weak self] result in
       switch result {
       case .success:
@@ -118,10 +121,17 @@ public class OtlpHttpMetricExporter: OtlpHttpExporterBase, MetricExporter, @unch
           }
         }
         OpenTelemetry.instance.feedbackHandler?("\(error)")
+        resultValue = .failure
       }
+      semaphore.signal()
     }
 
-    return .success
+    let waitResult = semaphore.wait(timeout: .now() + timeout)
+    if waitResult == .timedOut {
+      exporterMetrics?.addFailed(value: sendingMetrics.count)
+      return .failure
+    }
+    return resultValue
   }
 
   public func flush() -> ExportResult {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/OtlpHttpMetricExporterCoverageTests.swift
@@ -50,6 +50,43 @@ private final class StubHTTPClient: HTTPClient {
 
 private struct FakeError: Error {}
 
+private final class HangingHTTPClient: HTTPClient {
+  private(set) var sentRequests: [URLRequest] = []
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sentRequests.append(request)
+  }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sentRequests.append(request)
+    return await withCheckedContinuation { (_: CheckedContinuation<HTTPURLResponse, Never>) in }
+  }
+}
+
+private final class DelayedFailureHTTPClient: HTTPClient {
+  private let delay: TimeInterval
+  private(set) var sentRequests: [URLRequest] = []
+
+  init(delay: TimeInterval) {
+    self.delay = delay
+  }
+
+  func send(request: URLRequest,
+            completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    sentRequests.append(request)
+    nonisolated(unsafe) let completion = completion
+    DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+      completion(.failure(FakeError()))
+    }
+  }
+
+  func send(request: URLRequest) async throws -> HTTPURLResponse {
+    sentRequests.append(request)
+    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    throw FakeError()
+  }
+}
+
 final class OtlpHttpMetricExporterCoverageTests: XCTestCase {
   private let endpoint = URL(string: "http://localhost:4318/v1/metrics")!
 
@@ -64,8 +101,47 @@ final class OtlpHttpMetricExporterCoverageTests: XCTestCase {
   func testExportFailurePutsMetricsBackInPending() {
     let client = StubHTTPClient(outcomes: [.failure(FakeError())])
     let exporter = OtlpHttpMetricExporter(endpoint: endpoint, httpClient: client)
-    _ = exporter.export(metrics: [.empty])
+    let result = exporter.export(metrics: [.empty])
+    XCTAssertEqual(result, .failure)
     XCTAssertEqual(exporter.pendingMetrics.count, 1)
+  }
+
+  func testExportWaitsForDelayedFailureBeforeReturning() {
+    let delay: TimeInterval = 0.05
+    let client = DelayedFailureHTTPClient(delay: delay)
+    let exporter = OtlpHttpMetricExporter(endpoint: endpoint, httpClient: client)
+
+    let start = Date()
+    let result = exporter.export(metrics: [.empty])
+
+    XCTAssertEqual(result, .failure)
+    XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), delay)
+    XCTAssertEqual(exporter.pendingMetrics.count, 1)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testExportTimesOutWhenResponseNeverArrives() {
+    let timeout: TimeInterval = 0.05
+    let client = HangingHTTPClient()
+    let exporter = OtlpHttpMetricExporter(endpoint: endpoint,
+                                          config: OtlpConfiguration(timeout: timeout),
+                                          httpClient: client)
+
+    let start = Date()
+    XCTAssertEqual(exporter.export(metrics: [.empty]), .failure)
+    XCTAssertLessThan(Date().timeIntervalSince(start), timeout * 4)
+    XCTAssertEqual(client.sentRequests.count, 1)
+  }
+
+  func testExportFailureWithRequeueDisabledLeavesPendingEmpty() {
+    let client = StubHTTPClient(outcomes: [.failure(FakeError())])
+    let exporter = OtlpHttpMetricExporter(endpoint: endpoint,
+                                          httpClient: client,
+                                          requeueOnFailure: false)
+    let result = exporter.export(metrics: [.empty])
+    XCTAssertEqual(result, .failure)
+    XCTAssertEqual(exporter.pendingMetrics.count, 0)
+    XCTAssertEqual(client.sentRequests.count, 1)
   }
 
   func testFlushWithPendingReturnsSuccessAfterRetry() {

--- a/Tests/ExportersTests/OpenTelemetryProtocol/PeriodicMetricReaderIntegrationTests.swift
+++ b/Tests/ExportersTests/OpenTelemetryProtocol/PeriodicMetricReaderIntegrationTests.swift
@@ -1,0 +1,175 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetryProtocolExporterHttp
+@testable import OpenTelemetrySdk
+import SharedTestUtils
+import XCTest
+
+final class PeriodicMetricReaderIntegrationTests: XCTestCase {
+  private let exportInterval: TimeInterval = 0.05
+  private let metricsPath = "/v1/metrics"
+  private var meterProvider: MeterProviderSdk!
+  private var testServer: HttpTestServer!
+
+  override func setUp() {
+    super.setUp()
+    testServer = HttpTestServer()
+    XCTAssertNoThrow(try testServer.start())
+  }
+
+  override func tearDown() {
+    _ = meterProvider?.shutdown()
+    meterProvider = nil
+    testServer.stop()
+    testServer = nil
+    super.tearDown()
+  }
+
+  func testTimerKeepsEnqueueingWhileExportIsBlocked() {
+    let exporter = CountingBlockingMetricExporter(aggregationTemporality: .delta)
+    let reader = PeriodicMetricReaderBuilder(exporter: exporter)
+      .setInterval(timeInterval: exportInterval)
+      .build()
+    meterProvider = MeterProviderSdk.builder()
+      .registerMetricReader(reader: reader)
+      .registerView(
+        selector: InstrumentSelector.builder().setInstrument(name: ".*").build(),
+        view: View.builder().build()
+      )
+      .build()
+    let observableGauge = meterProvider
+      .meterBuilder(name: "periodic-reader-integration")
+      .build()
+      .gaugeBuilder(name: "gauge")
+      .buildWithCallback { measurement in
+        measurement.record(value: 1)
+      }
+
+    exporter.waitUntilIsBlocked()
+    XCTAssertEqual(exporter.exportCallCount, 1)
+
+    Thread.sleep(forTimeInterval: exportInterval * 30)
+
+    let blockedCallCount = exporter.exportCallCount
+    XCTAssertEqual(blockedCallCount, 1)
+
+    exporter.unblock()
+    let drainStart = Date()
+    let drainDeadline = drainStart.addingTimeInterval(0.3)
+    while exporter.exportCallCount <= 10, Date() < drainDeadline {
+      Thread.sleep(forTimeInterval: 0.01)
+    }
+
+    let elapsed = Date().timeIntervalSince(drainStart)
+    let drainedCallCount = exporter.exportCallCount
+    let capturedBatchCount = exporter.capturedBatches.count
+    print(
+      "PeriodicMetricReader calibration: blocked=\(blockedCallCount), "
+        + "drained=\(drainedCallCount), capturedBatches=\(capturedBatchCount), elapsed=\(elapsed)"
+    )
+    XCTAssertGreaterThan(drainedCallCount, 10)
+    XCTAssertLessThan(elapsed, 0.3)
+    XCTAssertGreaterThan(capturedBatchCount, 8)
+    withExtendedLifetime(observableGauge) {}
+  }
+
+  func testOtlpHttpExportWithPeriodicReader() {
+    let endpoint = URL(string: "http://localhost:\(testServer.serverPort)\(metricsPath)")!
+    let exporter = OtlpHttpMetricExporter(endpoint: endpoint)
+    let reader = PeriodicMetricReaderBuilder(exporter: exporter)
+      .setInterval(timeInterval: 60)
+      .build()
+    meterProvider = MeterProviderSdk.builder()
+      .registerMetricReader(reader: reader)
+      .registerView(
+        selector: InstrumentSelector.builder().setInstrument(name: ".*").build(),
+        view: View.builder().build()
+      )
+      .build()
+    let counter = meterProvider
+      .meterBuilder(name: "otlp-periodic-reader-integration")
+      .build()
+      .counterBuilder(name: "requests")
+      .build()
+
+    counter.add(value: 1)
+    XCTAssertEqual(meterProvider.forceFlush(), .success)
+
+    let request = testServer.waitForRequest()
+    XCTAssertNotNil(request)
+    XCTAssertEqual(request?.head.method, .POST)
+    XCTAssertEqual(request?.head.uri, metricsPath)
+    XCTAssertFalse(request?.body?.isEmpty ?? true)
+  }
+}
+
+private final class CountingBlockingMetricExporter: MetricExporter, @unchecked Sendable {
+  private enum State {
+    case waitingToBlock
+    case blocked
+    case unblocked
+  }
+
+  private let condition = NSCondition()
+  private let aggregationTemporality: AggregationTemporality
+  private var state = State.waitingToBlock
+  private var callCount = 0
+  private var batches = [[MetricData]]()
+
+  var exportCallCount: Int {
+    condition.withLock { callCount }
+  }
+
+  var capturedBatches: [[MetricData]] {
+    condition.withLock { batches }
+  }
+
+  init(aggregationTemporality: AggregationTemporality) {
+    self.aggregationTemporality = aggregationTemporality
+  }
+
+  func export(metrics: [MetricData]) -> ExportResult {
+    condition.lock()
+    callCount += 1
+    batches.append(metrics)
+    while state != .unblocked {
+      state = .blocked
+      condition.broadcast()
+      condition.wait()
+    }
+    condition.unlock()
+    return .success
+  }
+
+  func waitUntilIsBlocked() {
+    condition.lock()
+    while state != .blocked {
+      condition.wait()
+    }
+    condition.unlock()
+  }
+
+  func unblock() {
+    condition.lock()
+    state = .unblocked
+    condition.broadcast()
+    condition.unlock()
+  }
+
+  func flush() -> ExportResult {
+    .success
+  }
+
+  func shutdown() -> ExportResult {
+    .success
+  }
+
+  func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {
+    aggregationTemporality
+  }
+}


### PR DESCRIPTION
Fixes the metrics portion of #1146: `OtlpHttpMetricExporter.export()` always returned `.success` even when the HTTP upload failed.

This PR is independent of the log exporter fix in #1187.

## Summary

- Propagate upload failures from `OtlpHttpMetricExporter.export()` instead of always returning `.success`
- Add a `PeriodicMetricReader` background export integration test that exercises OTLP HTTP metric export failure handling
- Pin `opentelemetry-swift-core` to `yasuradodo/opentelemetry-swift-core` branch `tech/periodic-metric-reader-background-export` until [open-telemetry/opentelemetry-swift-core/pull/107](https://github.com/open-telemetry/opentelemetry-swift-core/pull/107) lands

## Dependencies

- Depends on core PR: https://github.com/open-telemetry/opentelemetry-swift-core/pull/107
- `Package.swift` pins `yasuradodo/opentelemetry-swift-core` at branch `tech/periodic-metric-reader-background-export`

## Test plan

- [x] `swift build --build-tests`
- [x] `swift test --filter OtlpHttpMetricExporter`
- [x] `swift test --filter PeriodicMetricReader`
- [x] Verify metric export failure surfaces as `.failure` (not `.success`) when the OTLP endpoint is unreachable
- [x] After core PR #107 merges, update `Package.swift` to point at the released core version and re-run the integration test

<details>
<summary>Commits</summary>

1. `fix(otlp-http): return upload failures from metric exporter`
2. `test(metrics): add PeriodicMetricReader background export integration test`
3. `build(deps): pin opentelemetry-swift-core to background-export branch`

</details>