### PR TITLE
Add HTTP error-only response payload recording

### DIFF
--- a/Sources/Instrumentation/URLSession/README.md
+++ b/Sources/Instrumentation/URLSession/README.md
@@ -12,7 +12,9 @@ This behaviour can be modified or augmented by using the optional callbacks defi
 
 `shouldInstrument: ((URLRequest) -> (Bool)?)?` :  Filter which requests you want to instrument, all by default
 
-`shouldRecordPayload: ((URLSession) -> (Bool)?)?`: Implement if you want the session to record payload data, false by default.
+`shouldRecordPayload: ((URLSession) -> (Bool)?)?`: Return true to enable response payload recording for the session, false by default. Use `responsePayloadRecordingMode` to select which response payloads are recorded.
+
+`responsePayloadRecordingMode: ResponsePayloadRecordingMode`: Record all response payloads (`.all`, the default) or only HTTP `400...599` response payloads (`.httpErrorsOnly`).
 
 `shouldInjectTracingHeaders: ((URLRequest) -> (Bool)?)?`: Allows filtering which requests you want to inject headers to follow the trace, true by default. You must also return true if you want to inject custom headers.
 
@@ -29,4 +31,3 @@ This behaviour can be modified or augmented by using the optional callbacks defi
 `receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)?` -  Called after an error is received,  it allows to add extra information to the Span
 
 `baggageProvider: ((inout URLRequest, Span) -> (Baggage)?)?`: Provides baggage instance for instrumented requests that is merged with active baggage. The callback receives URLRequest and Span parameters to create dynamic baggage based on request context. The resulting baggage is injected into request headers using the configured propagator.
-

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -707,7 +707,7 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
 
   // URLSessionTask methods
   private func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-    guard configuration.shouldRecordPayload?(session) ?? false else { return }
+    guard shouldRecordPayload(for: session, response: dataTask.response) else { return }
     guard let taskId = objc_getAssociatedObject(dataTask, &idKey) as? String
     else {
       return
@@ -727,7 +727,7 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
   private func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
                           didReceive response: URLResponse,
                           completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-    guard configuration.shouldRecordPayload?(session) ?? false else { return }
+    guard shouldRecordPayload(for: session, response: response) else { return }
     guard let taskId = objc_getAssociatedObject(dataTask, &idKey) as? String
     else {
       return
@@ -937,6 +937,12 @@ public final class URLSessionInstrumentation: @unchecked Sendable {
       state = NetworkRequestState()
       requestMap[id] = state
     }
+  }
+
+  private func shouldRecordPayload(for session: URLSession, response: URLResponse?) -> Bool {
+    let configuration = configuration
+    guard configuration.shouldRecordPayload?(session) ?? false else { return false }
+    return configuration.responsePayloadRecordingMode.shouldRecordPayload(for: response)
   }
 }
 

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -23,8 +23,28 @@ public enum HTTPSemanticConvention {
   case httpDup  // Emit both old and stable (migration period)
 }
 
+/// Controls which response payloads are retained by URLSession instrumentation.
+public enum ResponsePayloadRecordingMode {
+  /// Records payloads for every response.
+  case all
+
+  /// Records payloads only for HTTP responses with a status code from 400 through 599.
+  case httpErrorsOnly
+
+  func shouldRecordPayload(for response: URLResponse?) -> Bool {
+    switch self {
+    case .all:
+      return true
+    case .httpErrorsOnly:
+      guard let response = response as? HTTPURLResponse else { return false }
+      return (400 ... 599).contains(response.statusCode)
+    }
+  }
+}
+
 public struct URLSessionInstrumentationConfiguration {
   public init(shouldRecordPayload: ((URLSession) -> (Bool)?)? = nil,
+              responsePayloadRecordingMode: ResponsePayloadRecordingMode = .all,
               shouldInstrument: ((URLRequest) -> (Bool)?)? = nil,
               nameSpan: ((URLRequest) -> (String)?)? = nil,
               spanCustomization: ((URLRequest, SpanBuilder) -> Void)? = nil,
@@ -39,6 +59,7 @@ public struct URLSessionInstrumentationConfiguration {
               ignoredClassPrefixes: [String]? = nil,
               semanticConvention: HTTPSemanticConvention = .old) {
     self.shouldRecordPayload = shouldRecordPayload
+    self.responsePayloadRecordingMode = responsePayloadRecordingMode
     self.shouldInstrument = shouldInstrument
     self.shouldInjectTracingHeaders = shouldInjectTracingHeaders
     self.injectCustomHeaders = injectCustomHeaders
@@ -65,6 +86,9 @@ public struct URLSessionInstrumentationConfiguration {
   /// Implement this callback if you want the session to record payload data, false by default.
   /// This callback is only necessary when using session delegate
   public var shouldRecordPayload: ((URLSession) -> (Bool)?)?
+
+  /// Controls whether all response payloads or only HTTP error payloads are recorded.
+  public var responsePayloadRecordingMode: ResponsePayloadRecordingMode
 
   /// Implement this callback to filter which requests you want to inject headers to follow the trace,
   /// also must implement it if you want to inject custom headers

--- a/Tests/InstrumentationTests/URLSessionTests/ResponsePayloadRecordingModeTests.swift
+++ b/Tests/InstrumentationTests/URLSessionTests/ResponsePayloadRecordingModeTests.swift
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@testable import URLSessionInstrumentation
+import XCTest
+
+final class ResponsePayloadRecordingModeTests: XCTestCase {
+  func testDefaultModeRecordsSuccessfulHTTPResponse() {
+    let configuration = URLSessionInstrumentationConfiguration()
+    let response = makeHTTPResponse(statusCode: 200)
+
+    XCTAssertTrue(configuration.responsePayloadRecordingMode.shouldRecordPayload(for: response))
+  }
+
+  func testHTTPErrorOnlyRecordsErrorResponses() {
+    for statusCode in [400, 500, 599] {
+      let response = makeHTTPResponse(statusCode: statusCode)
+
+      XCTAssertTrue(ResponsePayloadRecordingMode.httpErrorsOnly.shouldRecordPayload(for: response))
+    }
+  }
+
+  func testHTTPErrorOnlyDoesNotRecordNonErrorResponses() {
+    for statusCode in [200, 399, 600] {
+      let response = makeHTTPResponse(statusCode: statusCode)
+
+      XCTAssertFalse(ResponsePayloadRecordingMode.httpErrorsOnly.shouldRecordPayload(for: response))
+    }
+  }
+
+  func testHTTPErrorOnlyDoesNotRecordNonHTTPResponse() {
+    let response = URLResponse(url: URL(string: "file:///payload")!,
+                               mimeType: nil,
+                               expectedContentLength: 0,
+                               textEncodingName: nil)
+
+    XCTAssertFalse(ResponsePayloadRecordingMode.httpErrorsOnly.shouldRecordPayload(for: response))
+  }
+
+  private func makeHTTPResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: URL(string: "https://example.com")!,
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: nil)!
+  }
+}


### PR DESCRIPTION
## Summary

- Add response payload recording modes for all responses or HTTP errors only.
- Preserve existing behavior by keeping all-response recording as the default.
- Avoid allocating and appending successful response payloads when HTTP-error-only recording is selected.
- Document the new configuration and cover its behavior with tests.

## Testing

- swift test (620 tests passed)

Fixes open-telemetry/opentelemetry-swift#1191