### PR TITLE
feat(signpost): allow a custom OSLog

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -398,6 +398,15 @@ extension Package {
           path: "Sources/Instrumentation/SignPostIntegration",
           exclude: ["README.md"]
         ),
+        .testTarget(
+          name: "SignPostIntegrationTests",
+          dependencies: [
+            "SignPostIntegration",
+            "InMemoryExporter",
+            .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
+          ],
+          path: "Tests/InstrumentationTests/SignPostIntegrationTests"
+        ),
         .target(
           name: "ResourceExtension",
           dependencies: [

--- a/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
+++ b/Sources/Instrumentation/SignPostIntegration/OSSignposterIntegration.swift
@@ -8,17 +8,23 @@ import os
 import OpenTelemetryApi
 import OpenTelemetrySdk
 
-/// A span processor that decorates spans with the origin attribute
+/// A span processor that emits signpost intervals for spans.
 @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
 public class OSSignposterIntegration: SpanProcessor {
-
   public let isStartRequired = true
   public let isEndRequired = true
-  public let osSignposter = OSSignposter(subsystem: "OpenTelemetry", category: .pointsOfInterest)
+  public let osSignposter: OSSignposter
   public let ossignposterQueue = DispatchQueue(label: "org.opentelemetry.ossignposterIntegration")
   private var spanIdToStateMap: [String: OSSignpostIntervalState] = [:]
 
-  public init() {}
+  public init() {
+    osSignposter = OSSignposter(subsystem: "OpenTelemetry", category: .pointsOfInterest)
+  }
+
+  /// Creates a processor that emits signposts to the supplied log.
+  public init(log: OSLog) {
+    osSignposter = OSSignposter(logHandle: log)
+  }
 
   public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
     let state = osSignposter.beginInterval("Span", id: .exclusive, "\(span.name, privacy: .public)")
@@ -38,5 +44,4 @@ public class OSSignposterIntegration: SpanProcessor {
 
   public func forceFlush(timeout: TimeInterval? = nil) {}
   public func shutdown(explicitTimeout: TimeInterval?) {}
-
 }

--- a/Sources/Instrumentation/SignPostIntegration/README.md
+++ b/Sources/Instrumentation/SignPostIntegration/README.md
@@ -5,10 +5,12 @@ instrumented with opentelemetry to show their spans in a profiling app like `Ins
 
 ## Version Notice
 
-- **iOS 15+, macOS 12+, tvOS 15+, watchOS 8+**:  
+- **iOS 15+, macOS 12+, tvOS 15+, watchOS 8+, visionOS 1+**:
   Use **`OSSignposterIntegration`**, which utilizes the modern `OSSignposter` API for improved efficiency and compatibility.
-- **Older systems**:  
+- **iOS 13-14, tvOS 13-14**:
   Use **`SignPostIntegration`**, which relies on the traditional `os_signpost` API.
+
+The legacy processor is not available on watchOS or visionOS.
 
 ## Usage 
 
@@ -18,7 +20,7 @@ Add the appropriate span processor to your `TracerProviderSdk`, based on your de
 let tracerProvider = TracerProviderSdk()
 ```
 
-### For iOS 15+, macOS 12+, tvOS 15+, watchOS 8+:
+### For iOS 15+, macOS 12+, tvOS 15+, watchOS 8+, visionOS 1+:
 
 ```swift
 tracerProvider.addSpanProcessor(OSSignposterIntegration())
@@ -36,7 +38,9 @@ tracerProvider.addSpanProcessor(SignPostIntegration())
 if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
     tracerProvider.addSpanProcessor(OSSignposterIntegration())
 } else {
+    #if !os(watchOS) && !os(visionOS)
     tracerProvider.addSpanProcessor(SignPostIntegration())
+    #endif
 }
 ```
 
@@ -47,27 +51,39 @@ Then register the provider with `OpenTelemetry.registerTracerProvider(tracerProv
 Both processors accept an `OSLog` through `init(log:)`. The zero-argument initializers still use
 the `OpenTelemetry` subsystem and `.pointsOfInterest` category. Passing `OSLog.disabled`
 disables signpost output without disabling span export.
+The supplied log replaces the default destination; signposts are not also sent to `.pointsOfInterest`.
 
-On iOS, you can pass a log created by
-[`MXMetricManager.makeLogHandle(category:)`](https://developer.apple.com/documentation/metrickit/mxmetricmanager/makeloghandle(category:)):
+On iOS 13+, Mac Catalyst 13.1+, macOS 12+, and visionOS 1+, you can pass a log created by
+[`MXMetricManager.makeLogHandle(category:)`](https://developer.apple.com/documentation/metrickit/mxmetricmanager/makeloghandle(category:)).
+MetricKit is not available on tvOS or watchOS.
+
+Apple limits how many MetricKit signposts it processes. Use this log only for critical sections,
+not every span from app-wide instrumentation. This example keeps the processor on a separate
+provider rather than registering it globally. Only use `criticalTracer` for those operations;
+MetricKit does not guarantee complete telemetry.
 
 ```swift
 import MetricKit
-import OpenTelemetryApi
 import OpenTelemetrySdk
 import SignPostIntegration
 
-let tracerProvider = TracerProviderSdk()
+let criticalSpanProvider = TracerProviderSdk()
 let log = MXMetricManager.makeLogHandle(category: "OpenTelemetrySpans")
-if #available(iOS 15, *) {
-    tracerProvider.addSpanProcessor(OSSignposterIntegration(log: log))
+if #available(iOS 15, macOS 12, *) {
+    criticalSpanProvider.addSpanProcessor(OSSignposterIntegration(log: log))
 } else {
-    tracerProvider.addSpanProcessor(SignPostIntegration(log: log))
+    #if !os(visionOS)
+    criticalSpanProvider.addSpanProcessor(SignPostIntegration(log: log))
+    #endif
 }
-OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
+let criticalTracer = criticalSpanProvider.get(instrumentationName: "CriticalOperations")
 ```
 
 This sends span intervals to the supplied log; it does not subscribe to MetricKit payloads.
+Both processors use the signpost name `Span`; the OpenTelemetry span name is included in the
+public message, not the signpost name. MetricKit groups signpost metrics by name and category,
+so this does not create separate metrics for each OpenTelemetry span name.
+
 MetricKit resource measurements such as CPU time, memory usage, and logical writes require
-[`mxSignpost`](https://developer.apple.com/documentation/metrickit/monitoring-app-performance-with-metrickit),
-which these processors do not call. Passing a MetricKit log alone does not populate those measurements.
+`mxSignpost`, which these processors do not call. Passing a MetricKit log alone does not populate
+those measurements. See [Apple's MetricKit signpost guidance](https://developer.apple.com/documentation/metrickit/monitoring-app-performance-with-metrickit).

--- a/Sources/Instrumentation/SignPostIntegration/README.md
+++ b/Sources/Instrumentation/SignPostIntegration/README.md
@@ -12,26 +12,62 @@ instrumented with opentelemetry to show their spans in a profiling app like `Ins
 
 ## Usage 
 
-Add the appropriate span processor based on your deployment target:
+Add the appropriate span processor to your `TracerProviderSdk`, based on your deployment target:
+
+```swift
+let tracerProvider = TracerProviderSdk()
+```
 
 ### For iOS 15+, macOS 12+, tvOS 15+, watchOS 8+:
 
 ```swift
-OpenTelemetry.instance.tracerProvider.addSpanProcessor(OSSignposterIntegration())
+tracerProvider.addSpanProcessor(OSSignposterIntegration())
 ```
 
 ### For older systems
 
 ```swift
-OpenTelemetry.instance.tracerProvider.addSpanProcessor(SignPostIntegration())
+tracerProvider.addSpanProcessor(SignPostIntegration())
 ```
 
 ### Or, to select automatically at runtime:
 
 ```swift
 if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
-    OpenTelemetry.instance.tracerProvider.addSpanProcessor(OSSignposterIntegration())
+    tracerProvider.addSpanProcessor(OSSignposterIntegration())
 } else {
-    OpenTelemetry.instance.tracerProvider.addSpanProcessor(SignPostIntegration())
+    tracerProvider.addSpanProcessor(SignPostIntegration())
 }
 ```
+
+Then register the provider with `OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)`.
+
+### Custom logs and MetricKit
+
+Both processors accept an `OSLog` through `init(log:)`. The zero-argument initializers still use
+the `OpenTelemetry` subsystem and `.pointsOfInterest` category. Passing `OSLog.disabled`
+disables signpost output without disabling span export.
+
+On iOS, you can pass a log created by
+[`MXMetricManager.makeLogHandle(category:)`](https://developer.apple.com/documentation/metrickit/mxmetricmanager/makeloghandle(category:)):
+
+```swift
+import MetricKit
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import SignPostIntegration
+
+let tracerProvider = TracerProviderSdk()
+let log = MXMetricManager.makeLogHandle(category: "OpenTelemetrySpans")
+if #available(iOS 15, *) {
+    tracerProvider.addSpanProcessor(OSSignposterIntegration(log: log))
+} else {
+    tracerProvider.addSpanProcessor(SignPostIntegration(log: log))
+}
+OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
+```
+
+This sends span intervals to the supplied log; it does not subscribe to MetricKit payloads.
+MetricKit resource measurements such as CPU time, memory usage, and logical writes require
+[`mxSignpost`](https://developer.apple.com/documentation/metrickit/monitoring-app-performance-with-metrickit),
+which these processors do not call. Passing a MetricKit log alone does not populate those measurements.

--- a/Sources/Instrumentation/SignPostIntegration/README.md
+++ b/Sources/Instrumentation/SignPostIntegration/README.md
@@ -10,6 +10,9 @@ instrumented with opentelemetry to show their spans in a profiling app like `Ins
 - **iOS 13-14, tvOS 13-14**:
   Use **`SignPostIntegration`**, which relies on the traditional `os_signpost` API.
 
+These ranges follow the deployment targets in [`Package.swift`](../../../Package.swift).
+The legacy class is annotated for iOS/tvOS 12, but this package requires iOS/tvOS 13 or later.
+
 The legacy processor is not available on watchOS or visionOS.
 
 ## Usage 

--- a/Sources/Instrumentation/SignPostIntegration/SignPostIntegration.swift
+++ b/Sources/Instrumentation/SignPostIntegration/SignPostIntegration.swift
@@ -10,14 +10,21 @@
   import OpenTelemetryApi
   import OpenTelemetrySdk
 
-  /// A span processor that decorates spans with the origin attribute
+  /// A span processor that emits signpost intervals for spans.
   @available(macOS 10.14, iOS 12.0, tvOS 12.0, *)
   public class SignPostIntegration: SpanProcessor {
     public let isStartRequired = true
     public let isEndRequired = true
-    public let osLog = OSLog(subsystem: "OpenTelemetry", category: .pointsOfInterest)
+    public let osLog: OSLog
 
-    public init() {}
+    public init() {
+      osLog = OSLog(subsystem: "OpenTelemetry", category: .pointsOfInterest)
+    }
+
+    /// Creates a processor that emits signposts to the supplied log.
+    public init(log: OSLog) {
+      osLog = log
+    }
 
     public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
       let signpostID = OSSignpostID(log: osLog, object: self)

--- a/Tests/InstrumentationTests/SignPostIntegrationTests/SignPostIntegrationTests.swift
+++ b/Tests/InstrumentationTests/SignPostIntegrationTests/SignPostIntegrationTests.swift
@@ -1,0 +1,107 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os
+import OpenTelemetrySdk
+import InMemoryExporter
+import SignPostIntegration
+import XCTest
+
+#if os(iOS) || os(macOS)
+  import MetricKit
+#endif
+
+@available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+final class SignPostIntegrationTests: XCTestCase {
+  private let customLog = OSLog(subsystem: "io.opentelemetry.signpost.tests", category: "CustomSpans")
+
+  func testSignposterDefaultLog() {
+    let processor = OSSignposterIntegration()
+    let defaultLog = OSLog(subsystem: "OpenTelemetry", category: .pointsOfInterest)
+
+    XCTAssertEqual(processor.osSignposter.isEnabled, defaultLog.signpostsEnabled)
+    assertSpanExport(processor, name: "signpost.default.modern")
+  }
+
+  func testSignposterCustomLog() {
+    let processor = OSSignposterIntegration(log: customLog)
+
+    XCTAssertEqual(processor.osSignposter.isEnabled, customLog.signpostsEnabled)
+    assertSpanExport(processor, name: "signpost.custom.modern")
+  }
+
+  func testSignposterDisabledLog() {
+    let processor = OSSignposterIntegration(log: .disabled)
+
+    XCTAssertFalse(processor.osSignposter.isEnabled)
+    assertSpanExport(processor, name: "signpost.disabled.modern")
+  }
+
+  #if !os(watchOS) && !os(visionOS)
+    func testLegacyDefaultLog() {
+      let processor = SignPostIntegration()
+      let defaultLog = OSLog(subsystem: "OpenTelemetry", category: .pointsOfInterest)
+
+      XCTAssertEqual(processor.osLog.signpostsEnabled, defaultLog.signpostsEnabled)
+      assertSpanExport(processor, name: "signpost.default.legacy")
+    }
+
+    func testLegacyCustomLog() {
+      let processor = SignPostIntegration(log: customLog)
+
+      XCTAssertTrue(processor.osLog === customLog)
+      assertSpanExport(processor, name: "signpost.custom.legacy")
+    }
+
+    func testLegacyDisabledLog() {
+      let processor = SignPostIntegration(log: .disabled)
+
+      XCTAssertTrue(processor.osLog === OSLog.disabled)
+      XCTAssertFalse(processor.osLog.signpostsEnabled)
+      assertSpanExport(processor, name: "signpost.disabled.legacy")
+    }
+  #endif
+
+  #if os(iOS) || os(macOS)
+    func testSignposterMetricKitLog() {
+      let log = MXMetricManager.makeLogHandle(category: "OpenTelemetrySpans")
+      let processor = OSSignposterIntegration(log: log)
+
+      XCTAssertEqual(processor.osSignposter.isEnabled, log.signpostsEnabled)
+      assertSpanExport(processor, name: "signpost.metrickit.modern")
+    }
+
+    func testLegacyMetricKitLog() {
+      let log = MXMetricManager.makeLogHandle(category: "OpenTelemetrySpans")
+      let processor = SignPostIntegration(log: log)
+
+      XCTAssertTrue(processor.osLog === log)
+      assertSpanExport(processor, name: "signpost.metrickit.legacy")
+    }
+  #endif
+
+  private func assertSpanExport(_ processor: SpanProcessor, name: String,
+                                file: StaticString = #filePath, line: UInt = #line) {
+    XCTAssertTrue(processor.isStartRequired, file: file, line: line)
+    XCTAssertTrue(processor.isEndRequired, file: file, line: line)
+
+    let exporter = InMemoryExporter()
+    let provider = TracerProviderSdk()
+    provider.addSpanProcessor(processor)
+    provider.addSpanProcessor(SimpleSpanProcessor(spanExporter: exporter))
+    defer { provider.shutdown() }
+
+    let span = provider.get(instrumentationName: "SignPostIntegrationTests")
+      .spanBuilder(spanName: name).startSpan()
+    XCTAssertTrue(exporter.getFinishedSpanItems().isEmpty, file: file, line: line)
+    span.end()
+    provider.forceFlush()
+
+    let exportedSpans = exporter.getFinishedSpanItems()
+    XCTAssertEqual(exportedSpans.count, 1, file: file, line: line)
+    XCTAssertEqual(exportedSpans.first?.name, name, file: file, line: line)
+    XCTAssertEqual(exportedSpans.first?.spanId, span.context.spanId, file: file, line: line)
+  }
+}

--- a/Tests/InstrumentationTests/SignPostIntegrationTests/SignPostIntegrationTests.swift
+++ b/Tests/InstrumentationTests/SignPostIntegrationTests/SignPostIntegrationTests.swift
@@ -9,7 +9,7 @@ import InMemoryExporter
 import SignPostIntegration
 import XCTest
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
   import MetricKit
 #endif
 
@@ -44,6 +44,7 @@ final class SignPostIntegrationTests: XCTestCase {
       let processor = SignPostIntegration()
       let defaultLog = OSLog(subsystem: "OpenTelemetry", category: .pointsOfInterest)
 
+      XCTAssertTrue(processor.osLog === defaultLog)
       XCTAssertEqual(processor.osLog.signpostsEnabled, defaultLog.signpostsEnabled)
       assertSpanExport(processor, name: "signpost.default.legacy")
     }
@@ -64,7 +65,7 @@ final class SignPostIntegrationTests: XCTestCase {
     }
   #endif
 
-  #if os(iOS) || os(macOS)
+  #if os(iOS) || os(macOS) || os(visionOS)
     func testSignposterMetricKitLog() {
       let log = MXMetricManager.makeLogHandle(category: "OpenTelemetrySpans")
       let processor = OSSignposterIntegration(log: log)
@@ -73,13 +74,15 @@ final class SignPostIntegrationTests: XCTestCase {
       assertSpanExport(processor, name: "signpost.metrickit.modern")
     }
 
-    func testLegacyMetricKitLog() {
-      let log = MXMetricManager.makeLogHandle(category: "OpenTelemetrySpans")
-      let processor = SignPostIntegration(log: log)
+    #if !os(visionOS)
+      func testLegacyMetricKitLog() {
+        let log = MXMetricManager.makeLogHandle(category: "OpenTelemetrySpans")
+        let processor = SignPostIntegration(log: log)
 
-      XCTAssertTrue(processor.osLog === log)
-      assertSpanExport(processor, name: "signpost.metrickit.legacy")
-    }
+        XCTAssertTrue(processor.osLog === log)
+        assertSpanExport(processor, name: "signpost.metrickit.legacy")
+      }
+    #endif
   #endif
 
   private func assertSpanExport(_ processor: SpanProcessor, name: String,


### PR DESCRIPTION
Adds `init(log:)` to both signpost processors so apps can use their own `OSLog`, including one created by MetricKit. Existing defaults stay the same.

Includes tests and a MetricKit example. Tested on macOS and an iPhone 17 simulator running iOS 26.5, with begin/end signposts confirmed in the selected logs. Disabled logs still allow spans to export.

This does not add MetricKit CPU or memory measurements, which require `mxSignpost`, or verify delivery of a device's MetricKit payloads.

Related to #583.
