### PR TITLE
feat(sessions): add explicit session end

### DIFF
--- a/Sources/Instrumentation/Sessions/README.md
+++ b/Sources/Instrumentation/Sessions/README.md
@@ -4,7 +4,7 @@ Automatic session tracking for OpenTelemetry Swift applications. Creates unique 
 
 ## Features
 
-- **Session Management** - Creates and manages session lifecycles with configurable timeouts and explicit reset
+- **Session Management** - Creates and manages session lifecycles with configurable timeouts, explicit reset, and explicit end
 - **Session Events** - Emits OpenTelemetry log records for session start/end events
 - **Span Attribution** - Automatically adds session IDs to all spans via span processor
 - **Persistence** - Sessions persist across app restarts using UserDefaults
@@ -60,8 +60,11 @@ SessionManagerProvider.register(sessionManager: sessionManager)
 let session = SessionManagerProvider.getInstance().getSession()
 print("Session ID: \(session.id)")
 
-// End the current session after sign-out and start a linked replacement
+// End the current session and immediately start a linked replacement
 SessionManagerProvider.getInstance().resetSession()
+
+// End the session on sign-out without immediately starting another
+SessionManagerProvider.getInstance().endSession()
 
 // Peek at session without extending it
 if let session = SessionManagerProvider.getInstance().peekSession() {
@@ -73,7 +76,7 @@ if let session = SessionManagerProvider.getInstance().peekSession() {
 
 ### SessionManager
 
-Manages session lifecycle with automatic expiration and explicit reset. Session access, including
+Manages session lifecycle with automatic expiration, explicit reset, and explicit end. Session access, including
 automatic span and log attribution, extends the inactivity deadline.
 
 ```swift
@@ -81,7 +84,14 @@ let manager = SessionManager(configuration: SessionConfig(sessionTimeout: 1800))
 let session = manager.getSession() // Creates or retrieves and extends the session
 manager.resetSession() // Starts a linked replacement
 let current = manager.peekSession() // Peek without creating or extending
+manager.endSession() // Ends the session without creating a replacement
 ```
+
+`endSession()` clears the current and persisted session, including pending saves, and
+emits one `session.end` event when a current or pending previous session exists.
+Calling it again without a session has no effect. It does not pause telemetry:
+a later `getSession()`, span, or log requiring session attribution starts a fresh,
+unlinked session. Existing spans keep the session attributes assigned when they started.
 
 ### SessionManagerProvider
 
@@ -197,7 +207,7 @@ The session's start time is carried on the log record's `timestamp` field, not a
 
 ### Session End
 
-A `session.end` log record is created when a session expires.
+A `session.end` log record is created when a session expires, is reset, or is explicitly ended.
 
 **Example session.end Event**:
 
@@ -247,6 +257,7 @@ Sessions are automatically persisted to UserDefaults and can be resumed on app r
 - Set `restorePersistedSession` to `false` to start a new session on clean start while linking and ending the persisted session
 - Expired sessions create new sessions with proper `previous_id` linking
 - Session starts and resets are saved immediately
+- `endSession()` clears the saved session so it is not restored or linked on restart
 - Access updates are coalesced and saved on a 30-second timer to minimize disk I/O
 
 ## Thread Safety

--- a/Sources/Instrumentation/Sessions/SessionManager.swift
+++ b/Sources/Instrumentation/Sessions/SessionManager.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Sessions are extended on access and persisted to UserDefaults.
 public class SessionManager: @unchecked Sendable {
   private struct SessionTransition {
-    let session: Session
+    let session: Session?
     let previousSessionToEnd: Session?
   }
 
@@ -72,6 +72,28 @@ public class SessionManager: @unchecked Sendable {
       drainClaimedTransition()
     }
     return access.session
+  }
+
+  /// Ends the current or pending previous session without starting a replacement.
+  /// Clears persisted session state and discards pending saves. Repeated calls without
+  /// a session do nothing. Later `getSession()` calls, including automatic span and log
+  /// attribution, start a fresh session without a previous-session link.
+  /// This does not pause telemetry collection.
+  public func endSession() {
+    let shouldDrainEffects = lock.withLock {
+      guard let previousSession = session ?? persistedPreviousSession else { return false }
+      let endedSession = previousSession.isExpired()
+        ? previousSession
+        : locked_endSession(previousSession, at: Date())
+      session = nil
+      persistedPreviousSession = nil
+      SessionStore.teardown()
+      return enqueueTransition(SessionTransition(session: nil, previousSessionToEnd: endedSession))
+    }
+
+    if shouldDrainEffects {
+      drainClaimedTransition()
+    }
   }
 
   /// Gets the current session without extending its inactivity deadline
@@ -230,8 +252,10 @@ public class SessionManager: @unchecked Sendable {
     if let previousSessionToEnd = transition.previousSessionToEnd {
       SessionEventInstrumentation.addSession(session: previousSessionToEnd, eventType: .end)
     }
-    SessionEventInstrumentation.addSession(session: transition.session, eventType: .start)
-    NotificationCenter.default.post(name: SessionEventNotification, object: transition.session)
+    if let session = transition.session {
+      SessionEventInstrumentation.addSession(session: session, eventType: .start)
+      NotificationCenter.default.post(name: SessionEventNotification, object: session)
+    }
   }
 
   /// Loads a saved session from UserDefaults according to the configured restore behavior

--- a/Sources/Instrumentation/Sessions/SessionStore.swift
+++ b/Sources/Instrumentation/Sessions/SessionStore.swift
@@ -26,7 +26,7 @@ enum SessionStore {
 
   /// Guards all static mutable state below; every access goes through this lock so
   /// callers from different threads (`SessionManager.getSession()` callers, the
-  /// repeating `saveTimer` callback, and test `teardown`) do not race.
+  /// repeating `saveTimer` callback, and `teardown`) do not race.
   private static let lock = NSLock()
   /// The most recent session to be saved to disk
   private nonisolated(unsafe) static var pendingSession: Session?

--- a/Tests/InstrumentationTests/SessionTests/SessionEndTests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionEndTests.swift
@@ -1,0 +1,417 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import XCTest
+import OpenTelemetryApi
+@testable import Sessions
+@testable import OpenTelemetrySdk
+
+final class SessionEndTests: XCTestCase {
+  private var previousQueuedEvents: [SessionEvent] = []
+  private var previousInstrumentationState = false
+
+  override func setUp() {
+    super.setUp()
+    previousQueuedEvents = SessionEventInstrumentation.queue
+    previousInstrumentationState = SessionEventInstrumentation.isApplied
+    SessionEventInstrumentation.queue = []
+    SessionEventInstrumentation.isApplied = false
+    SessionStore.teardown()
+  }
+
+  override func tearDown() {
+    SessionStore.teardown()
+    SessionEventInstrumentation.queue = previousQueuedEvents
+    SessionEventInstrumentation.isApplied = previousInstrumentationState
+    OpenTelemetry.registerLoggerProvider(loggerProvider: DefaultLoggerProvider.instance)
+    super.tearDown()
+  }
+
+  func testEndBeforeFirstAccessDoesNotCreateSessionOrEvents() {
+    let manager = SessionManager()
+    manager.endSession()
+    manager.endSession()
+
+    XCTAssertNil(manager.peekSession())
+    XCTAssertNil(SessionStore.load())
+    XCTAssertTrue(SessionEventInstrumentation.queue.isEmpty)
+  }
+
+  func testEndClearsStateAndEmitsOnlyEndWithOriginalContext() throws {
+    let manager = SessionManager()
+    let first = manager.getSession()
+    let current = manager.resetSession()
+    SessionEventInstrumentation.queue = []
+    let observer = NotificationCenter.default.addObserver(
+      forName: SessionEventNotification, object: nil, queue: nil
+    ) { _ in
+      XCTFail("Ending a session must not post a session-start notification")
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+    let before = Date()
+
+    manager.endSession()
+    manager.endSession()
+
+    let after = Date()
+    XCTAssertNil(manager.peekSession())
+    XCTAssertNil(SessionStore.load())
+    let events = SessionEventInstrumentation.queue
+    XCTAssertEqual(events.count, 1)
+    let end = try XCTUnwrap(events.first)
+    XCTAssertEqual(end.eventType, .end)
+    XCTAssertEqual(end.session.id, current.id)
+    XCTAssertEqual(end.session.previousId, first.id)
+    XCTAssertEqual(end.session.startTime, current.startTime)
+    let endTime = try XCTUnwrap(end.session.endTime)
+    XCTAssertGreaterThanOrEqual(endTime, before)
+    XCTAssertLessThanOrEqual(endTime, after)
+  }
+
+  func testGetAfterEndStartsUnlinkedSessionWithoutDuplicateEnd() {
+    let manager = SessionManager()
+    let original = manager.getSession()
+    manager.endSession()
+
+    let next = manager.getSession()
+
+    XCTAssertNotEqual(next.id, original.id)
+    XCTAssertNil(next.previousId)
+    XCTAssertEqual(SessionStore.load(), next)
+    XCTAssertEqual(SessionEventInstrumentation.queue.map(\.eventType), [.start, .end, .start])
+  }
+
+  func testResetAfterEndStartsUnlinkedSession() {
+    let manager = SessionManager()
+    let original = manager.getSession()
+    manager.endSession()
+
+    let next = manager.resetSession()
+
+    XCTAssertNotEqual(next.id, original.id)
+    XCTAssertNil(next.previousId)
+    XCTAssertEqual(SessionEventInstrumentation.queue.map(\.eventType), [.start, .end, .start])
+  }
+
+  func testEndKeepsInactivityAndMaxLifetimeEndTimes() throws {
+    let now = Date()
+    for maxLifetime: TimeInterval? in [nil, 15] {
+      let saved = Session(
+        id: UUID().uuidString,
+        expireTime: now.addingTimeInterval(-30),
+        startTime: now.addingTimeInterval(-120),
+        sessionTimeout: 60,
+        maxLifetime: maxLifetime
+      )
+      SessionStore.saveImmediately(session: saved)
+      let manager = SessionManager()
+      SessionEventInstrumentation.queue = []
+
+      manager.endSession()
+
+      let end = try XCTUnwrap(SessionEventInstrumentation.queue.first)
+      XCTAssertEqual(end.eventType, .end)
+      XCTAssertEqual(end.session.endTime, saved.endTime)
+      XCTAssertNil(SessionStore.load())
+    }
+  }
+
+  func testEndClearsRestoredAndPendingPreviousSessions() throws {
+    for restore in [true, false] {
+      let lastActivity = Date(timeIntervalSinceNow: -60)
+      let saved = Session(
+        id: UUID().uuidString,
+        expireTime: lastActivity.addingTimeInterval(1800),
+        startTime: lastActivity.addingTimeInterval(-60),
+        sessionTimeout: 1800
+      )
+      SessionStore.saveImmediately(session: saved)
+      let manager = SessionManager(configuration: SessionConfig(restorePersistedSession: restore))
+      SessionEventInstrumentation.queue = []
+
+      manager.endSession()
+      manager.endSession()
+
+      XCTAssertNil(manager.peekSession())
+      XCTAssertEqual(SessionEventInstrumentation.queue.count, 1)
+      let end = try XCTUnwrap(SessionEventInstrumentation.queue.first)
+      XCTAssertEqual(end.eventType, .end)
+      XCTAssertEqual(end.session.id, saved.id)
+      if !restore {
+        XCTAssertEqual(end.session.endTime, lastActivity)
+      }
+      XCTAssertNil(manager.getSession().previousId)
+      manager.endSession()
+    }
+  }
+
+  func testEndedSessionIsNotRestoredOrLinkedByNewManager() {
+    for restore in [true, false] {
+      let manager = SessionManager()
+      let original = manager.getSession()
+      manager.endSession()
+      let relaunched = SessionManager(configuration: SessionConfig(restorePersistedSession: restore))
+
+      XCTAssertNil(relaunched.peekSession())
+      let next = relaunched.getSession()
+      XCTAssertNotEqual(next.id, original.id)
+      XCTAssertNil(next.previousId)
+      relaunched.endSession()
+    }
+  }
+
+  func testPendingSaveCannotRestoreEndedSessionAfterTimerDeadline() {
+    let manager = SessionManager()
+    manager.getSession()
+    manager.getSession()
+    manager.getSession()
+    manager.endSession()
+
+    // Exercise the real 30-second save timer without load(), which clears pending saves.
+    let timerDeadline = expectation(description: "Passed the old save deadline")
+    DispatchQueue.main.asyncAfter(deadline: .now() + 31) { timerDeadline.fulfill() }
+    wait(for: [timerDeadline], timeout: 35)
+
+    XCTAssertNil(manager.peekSession())
+    for key in [SessionStore.idKey, SessionStore.previousIdKey, SessionStore.startTimeKey,
+                SessionStore.expireTimeKey, SessionStore.sessionTimeoutKey, SessionStore.maxLifetimeKey] {
+      XCTAssertNil(UserDefaults.standard.object(forKey: key), key)
+    }
+    let next = manager.getSession()
+    let refreshed = manager.getSession()
+    XCTAssertEqual(SessionStore.load(), refreshed)
+    XCTAssertEqual(next.id, refreshed.id)
+    XCTAssertNil(next.previousId)
+  }
+
+  func testLifecycleLogDoesNotStartReplacementButLaterApplicationLogDoes() throws {
+    let manager = SessionManager()
+    let recorder = EndSessionLogRecordProcessor()
+    let provider = install(recorder, manager: manager)
+    let original = manager.getSession()
+
+    manager.endSession()
+
+    XCTAssertNil(manager.peekSession())
+    XCTAssertEqual(recorder.records.map(\.eventName), [SessionConstants.sessionStartEvent, SessionConstants.sessionEndEvent])
+    XCTAssertEqual(recorder.records.last?.attributes[SemanticConventions.Session.id.rawValue], .string(original.id))
+    provider.get(instrumentationScopeName: "session-end-test").logRecordBuilder().setBody(.string("after end")).emit()
+
+    let next = try XCTUnwrap(manager.peekSession())
+    XCTAssertNotEqual(next.id, original.id)
+    XCTAssertNil(next.previousId)
+    let records = recorder.records
+    XCTAssertEqual(records.count, 4)
+    guard records.count == 4 else { return }
+    XCTAssertEqual(records[2].eventName, SessionConstants.sessionStartEvent)
+    XCTAssertEqual(records[3].attributes[SemanticConventions.Session.id.rawValue], .string(next.id))
+    XCTAssertNil(records[3].attributes[SemanticConventions.Session.previousId.rawValue])
+  }
+
+  func testLaterSpanStartsFreshSessionAndExistingSpanKeepsItsSession() throws {
+    let manager = SessionManager()
+    let provider = TracerProviderBuilder().add(spanProcessor: SessionSpanProcessor(sessionManager: manager)).build()
+    let tracer = provider.get(instrumentationName: "session-end-test")
+    let before = tracer.spanBuilder(spanName: "before end").startSpan()
+    let original = try XCTUnwrap(manager.peekSession())
+
+    manager.endSession()
+    before.end()
+    XCTAssertNil(manager.peekSession())
+    let after = tracer.spanBuilder(spanName: "after end").startSpan()
+    after.end()
+
+    let next = try XCTUnwrap(manager.peekSession())
+    XCTAssertNotEqual(next.id, original.id)
+    XCTAssertNil(next.previousId)
+    XCTAssertEqual((before as? ReadableSpan)?.getAttributes()[SemanticConventions.Session.id.rawValue], .string(original.id))
+    XCTAssertEqual((after as? ReadableSpan)?.getAttributes()[SemanticConventions.Session.id.rawValue], .string(next.id))
+    XCTAssertNil((after as? ReadableSpan)?.getAttributes()[SemanticConventions.Session.previousId.rawValue])
+    XCTAssertEqual(SessionEventInstrumentation.queue.map(\.eventType), [.start, .end, .start])
+  }
+
+  func testConcurrentEndEmitsOnce() {
+    let manager = SessionManager()
+    let recorder = EndSessionLogRecordProcessor()
+    install(recorder, manager: manager)
+    let original = manager.getSession()
+
+    DispatchQueue.concurrentPerform(iterations: 50) { _ in manager.endSession() }
+
+    XCTAssertNil(manager.peekSession())
+    XCTAssertNil(SessionStore.load())
+    XCTAssertEqual(recorder.records.map(\.eventName), [SessionConstants.sessionStartEvent, SessionConstants.sessionEndEvent])
+    XCTAssertEqual(recorder.records.last?.attributes[SemanticConventions.Session.id.rawValue], .string(original.id))
+  }
+
+  func testEndFromStartCallbackDrainsOnceWithoutDeadlock() {
+    let manager = SessionManager()
+    let ended = expectation(description: "Reentrant end published")
+    let recorder = EndSessionLogRecordProcessor { record in
+      if record.eventName == SessionConstants.sessionStartEvent {
+        manager.endSession()
+      } else {
+        manager.endSession()
+        XCTAssertNil(manager.peekSession())
+        XCTAssertNil(SessionStore.load())
+        ended.fulfill()
+      }
+    }
+    install(recorder, manager: manager)
+    let returned = expectation(description: "Initial call returned")
+    DispatchQueue.global().async {
+      manager.getSession()
+      returned.fulfill()
+    }
+    wait(for: [returned, ended], timeout: 3)
+
+    XCTAssertEqual(recorder.records.map(\.eventName), [SessionConstants.sessionStartEvent, SessionConstants.sessionEndEvent])
+    XCTAssertNil(manager.peekSession())
+  }
+
+  func testConcurrentAccessResetAndEndKeepBalancedOrderedEvents() throws {
+    let manager = SessionManager()
+    let recorder = EndSessionLogRecordProcessor()
+    install(recorder, manager: manager)
+
+    DispatchQueue.concurrentPerform(iterations: 100) { index in
+      switch index % 3 {
+      case 0: manager.getSession()
+      case 1: manager.resetSession()
+      default: manager.endSession()
+      }
+    }
+    let finalSession = manager.resetSession()
+    manager.endSession()
+    let drained = XCTNSPredicateExpectation(predicate: NSPredicate { _, _ in
+      let last = recorder.records.last
+      return last?.eventName == SessionConstants.sessionEndEvent &&
+        last?.attributes[SemanticConventions.Session.id.rawValue] == .string(finalSession.id)
+    }, object: nil)
+    wait(for: [drained], timeout: 3)
+
+    var activeId: AttributeValue?
+    var startedIds = Set<String>()
+    for record in recorder.records {
+      let id = try XCTUnwrap(record.attributes[SemanticConventions.Session.id.rawValue])
+      if record.eventName == SessionConstants.sessionStartEvent {
+        XCTAssertNil(activeId)
+        XCTAssertTrue(startedIds.insert(id.description).inserted)
+        activeId = id
+      } else {
+        XCTAssertEqual(record.eventName, SessionConstants.sessionEndEvent)
+        XCTAssertEqual(id, activeId)
+        activeId = nil
+      }
+    }
+    XCTAssertNil(activeId)
+    XCTAssertNil(manager.peekSession())
+    XCTAssertNil(SessionStore.load())
+  }
+
+  func testGetFromEndCallbackStartsUnlinkedSessionInOrder() throws {
+    let manager = SessionManager()
+    let restarted = expectation(description: "Callback's new session published")
+    let recorder = EndSessionLogRecordProcessor { record in
+      if record.eventName == SessionConstants.sessionEndEvent {
+        XCTAssertNil(manager.peekSession())
+        XCTAssertNil(SessionStore.load())
+        XCTAssertNil(manager.getSession().previousId)
+      }
+    }
+    install(recorder, manager: manager)
+    let original = manager.getSession()
+    let observer = NotificationCenter.default.addObserver(
+      forName: SessionEventNotification, object: nil, queue: nil
+    ) { _ in restarted.fulfill() }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    manager.endSession()
+    wait(for: [restarted], timeout: 3)
+
+    XCTAssertNotEqual(try XCTUnwrap(manager.peekSession()).id, original.id)
+    XCTAssertEqual(recorder.records.map(\.eventName), [SessionConstants.sessionStartEvent, SessionConstants.sessionEndEvent, SessionConstants.sessionStartEvent])
+  }
+
+  func testSlowExporterDoesNotBlockEndAndQueuedTransitionsStayOrdered() {
+    let manager = SessionManager()
+    let entered = DispatchSemaphore(value: 0)
+    let release = DispatchSemaphore(value: 0)
+    let finalEnd = expectation(description: "Queued replacement ended")
+    let recorder = EndSessionLogRecordProcessor { record in
+      if record.eventName == SessionConstants.sessionStartEvent,
+         record.attributes[SemanticConventions.Session.previousId.rawValue] == nil {
+        entered.signal()
+        XCTAssertEqual(release.wait(timeout: .now() + 5), .success)
+      }
+      if record.eventName == SessionConstants.sessionEndEvent,
+         record.attributes[SemanticConventions.Session.previousId.rawValue] != nil {
+        finalEnd.fulfill()
+      }
+    }
+    install(recorder, manager: manager)
+    let returned = expectation(description: "Initial call returned")
+    DispatchQueue.global().async {
+      manager.getSession()
+      returned.fulfill()
+    }
+    XCTAssertEqual(entered.wait(timeout: .now() + 2), .success)
+    let ended = expectation(description: "End returned while exporter blocked")
+    DispatchQueue.global().async {
+      manager.resetSession()
+      manager.endSession()
+      ended.fulfill()
+    }
+    wait(for: [ended], timeout: 2)
+    XCTAssertNil(manager.peekSession())
+    XCTAssertNil(SessionStore.load())
+    release.signal()
+    wait(for: [returned, finalEnd], timeout: 3)
+
+    let records = recorder.records
+    XCTAssertEqual(records.map(\.eventName), [SessionConstants.sessionStartEvent, SessionConstants.sessionEndEvent,
+                                              SessionConstants.sessionStartEvent, SessionConstants.sessionEndEvent])
+    guard records.count == 4 else { return }
+    XCTAssertEqual(records[0].attributes[SemanticConventions.Session.id.rawValue], records[1].attributes[SemanticConventions.Session.id.rawValue])
+    XCTAssertEqual(records[2].attributes[SemanticConventions.Session.id.rawValue], records[3].attributes[SemanticConventions.Session.id.rawValue])
+  }
+
+  @discardableResult
+  private func install(_ recorder: EndSessionLogRecordProcessor, manager: SessionManager) -> LoggerProviderSdk {
+    let provider = LoggerProviderBuilder().with(processors: [
+      SessionLogRecordProcessor(nextProcessor: recorder, sessionManager: manager)
+    ]).build()
+    OpenTelemetry.registerLoggerProvider(loggerProvider: provider)
+    SessionEventInstrumentation.install()
+    return provider
+  }
+}
+
+private final class EndSessionLogRecordProcessor: LogRecordProcessor, @unchecked Sendable {
+  private let lock = NSLock()
+  private var receivedRecords: [ReadableLogRecord] = []
+  private let callback: @Sendable (ReadableLogRecord) -> Void
+
+  init(callback: @escaping @Sendable (ReadableLogRecord) -> Void = { _ in }) {
+    self.callback = callback
+  }
+
+  var records: [ReadableLogRecord] {
+    return lock.withLock { receivedRecords }
+  }
+
+  func onEmit(logRecord: ReadableLogRecord) {
+    lock.withLock { receivedRecords.append(logRecord) }
+    callback(logRecord)
+  }
+
+  func shutdown(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+
+  func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
+    return .success
+  }
+}

--- a/Tests/InstrumentationTests/SessionTests/SessionPublicAPITests.swift
+++ b/Tests/InstrumentationTests/SessionTests/SessionPublicAPITests.swift
@@ -6,4 +6,9 @@ final class SessionPublicAPITests: XCTestCase {
     let reset: (SessionManager) -> () -> Session = SessionManager.resetSession
     XCTAssertNotNil(reset)
   }
+
+  func testEndSessionIsPublic() {
+    let end: (SessionManager) -> () -> Void = SessionManager.endSession
+    XCTAssertNotNil(end)
+  }
 }


### PR DESCRIPTION
Closes #1199. Follow-up to [Will's suggestion on #1183](https://github.com/open-telemetry/opentelemetry-swift/pull/1183#discussion_r3981096869).

Adds `SessionManager.endSession()` to end a session without immediately starting another. It emits `session.end`, clears saved state and pending writes, and preserves the existing lifecycle event ordering.

For review: later session-aware telemetry or `getSession()` starts a fresh, unlinked session. This is not a telemetry pause. `resetSession()` stays unchanged; persistence and sampling changes remain in #1184 and #1185.
